### PR TITLE
Update imports to reference vendored packages

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/ably/ably-go",
-	"GoVersion": "go1.4",
+	"GoVersion": "go1.4.2",
 	"Packages": [
 		"./..."
 	],

--- a/Godeps/_workspace/src/github.com/flynn/flynn/pkg/random/random.go
+++ b/Godeps/_workspace/src/github.com/flynn/flynn/pkg/random/random.go
@@ -8,7 +8,7 @@ import (
 	mathrand "math/rand"
 	"strings"
 
-	"github.com/wadey/cryptorand"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/wadey/cryptorand"
 )
 
 var Math = mathrand.New(cryptorand.Source)

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/bootstrap_command.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/bootstrap_command.go
@@ -11,7 +11,7 @@ import (
 
 	"go/build"
 
-	"github.com/onsi/ginkgo/ginkgo/nodot"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/nodot"
 )
 
 func BuildBootstrapCommand() *Command {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/build_command.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/build_command.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/onsi/ginkgo/ginkgo/interrupthandler"
-	"github.com/onsi/ginkgo/ginkgo/testrunner"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/interrupthandler"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/testrunner"
 )
 
 func BuildBuildCommand() *Command {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/convert_command.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/convert_command.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/onsi/ginkgo/ginkgo/convert"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/convert"
 	"os"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/main.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/main.go
@@ -124,8 +124,8 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/ginkgo/testsuite"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/testsuite"
 )
 
 const greenColor = "\x1b[32m"

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/nodot/nodot_suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/nodot/nodot_suite_test.go
@@ -1,9 +1,8 @@
 package nodot_test
 
 import (
-	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
-
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"testing"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/nodot/nodot_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/nodot/nodot_test.go
@@ -1,7 +1,7 @@
 package nodot_test
 
 import (
-	. "github.com/onsi/ginkgo/ginkgo/nodot"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/nodot"
 	"strings"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/nodot_command.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/nodot_command.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bufio"
 	"flag"
-	"github.com/onsi/ginkgo/ginkgo/nodot"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/nodot"
 	"io/ioutil"
 	"os"
 	"path/filepath"

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/notifications.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/notifications.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/onsi/ginkgo/ginkgo/testsuite"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/testsuite"
 )
 
 type Notifier struct {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/run_command.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/run_command.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/ginkgo/interrupthandler"
-	"github.com/onsi/ginkgo/ginkgo/testrunner"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/interrupthandler"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/testrunner"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 )
 
 func BuildRunCommand() *Command {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/run_watch_and_build_command_flags.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/run_watch_and_build_command_flags.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"runtime"
 
-	"github.com/onsi/ginkgo/config"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
 )
 
 type RunWatchAndBuildCommandFlags struct {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/suite_runner.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/suite_runner.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/ginkgo/interrupthandler"
-	"github.com/onsi/ginkgo/ginkgo/testrunner"
-	"github.com/onsi/ginkgo/ginkgo/testsuite"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/interrupthandler"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/testrunner"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/testsuite"
 )
 
 type SuiteRunner struct {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/testrunner/test_runner.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/testrunner/test_runner.go
@@ -14,11 +14,11 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/ginkgo/testsuite"
-	"github.com/onsi/ginkgo/internal/remote"
-	"github.com/onsi/ginkgo/reporters/stenographer"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/testsuite"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/stenographer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 )
 
 type TestRunner struct {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/testsuite/testsuite_suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/testsuite/testsuite_suite_test.go
@@ -1,9 +1,8 @@
 package testsuite_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"testing"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/testsuite/testsuite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/testsuite/testsuite_test.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"path/filepath"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/ginkgo/testsuite"
-	. "github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/testsuite"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 )
 
 var _ = Describe("TestSuite", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/version_command.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/version_command.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/onsi/ginkgo/config"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
 )
 
 func BuildVersionCommand() *Command {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/watch/delta_tracker.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/watch/delta_tracker.go
@@ -3,7 +3,7 @@ package watch
 import (
 	"fmt"
 
-	"github.com/onsi/ginkgo/ginkgo/testsuite"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/testsuite"
 )
 
 type SuiteErrors map[testsuite.TestSuite]error

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/watch/suite.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/watch/suite.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"time"
 
-	"github.com/onsi/ginkgo/ginkgo/testsuite"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/testsuite"
 )
 
 type Suite struct {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/watch_command.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/watch_command.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/ginkgo/interrupthandler"
-	"github.com/onsi/ginkgo/ginkgo/testrunner"
-	"github.com/onsi/ginkgo/ginkgo/testsuite"
-	"github.com/onsi/ginkgo/ginkgo/watch"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/interrupthandler"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/testrunner"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/testsuite"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/watch"
 )
 
 func BuildWatchCommand() *Command {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo_dsl.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo_dsl.go
@@ -20,16 +20,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/internal/codelocation"
-	"github.com/onsi/ginkgo/internal/failer"
-	"github.com/onsi/ginkgo/internal/remote"
-	"github.com/onsi/ginkgo/internal/suite"
-	"github.com/onsi/ginkgo/internal/testingtproxy"
-	"github.com/onsi/ginkgo/internal/writer"
-	"github.com/onsi/ginkgo/reporters"
-	"github.com/onsi/ginkgo/reporters/stenographer"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/failer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/suite"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/testingtproxy"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/writer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/stenographer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 )
 
 const GINKGO_VERSION = config.VERSION

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/convert_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/convert_test.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 )
 
 var _ = Describe("ginkgo convert", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/coverage_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/coverage_test.go
@@ -1,9 +1,9 @@
 package integration_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gexec"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gexec"
 	"os"
 	"os/exec"
 )

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/fail_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/fail_test.go
@@ -1,9 +1,9 @@
 package integration_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gexec"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Failing Specs", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/flags_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/flags_test.go
@@ -5,10 +5,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	. "github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/types"
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gexec"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Flags Specs", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/integration_suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/integration_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gexec"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gexec"
 	"testing"
 	"time"
 )

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/interrupt_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/interrupt_test.go
@@ -3,10 +3,10 @@ package integration_test
 import (
 	"os/exec"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gbytes"
-	"github.com/onsi/gomega/gexec"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gbytes"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Interrupt", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/precompiled_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/precompiled_test.go
@@ -5,10 +5,10 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gbytes"
-	"github.com/onsi/gomega/gexec"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gbytes"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("ginkgo build", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/progress_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/progress_test.go
@@ -1,10 +1,10 @@
 package integration_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gbytes"
-	"github.com/onsi/gomega/gexec"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gbytes"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Emitting progress", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/run_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/run_test.go
@@ -4,11 +4,11 @@ import (
 	"runtime"
 	"strings"
 
-	. "github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/types"
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gbytes"
-	"github.com/onsi/gomega/gexec"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gbytes"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Running Specs", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/subcommand_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/subcommand_test.go
@@ -6,10 +6,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	. "github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/types"
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gexec"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Subcommand", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/suite_setup_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/suite_setup_test.go
@@ -1,9 +1,9 @@
 package integration_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gexec"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gexec"
 	"strings"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/tags_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/tags_test.go
@@ -1,9 +1,9 @@
 package integration_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gexec"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Tags", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/verbose_and_succinct_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/verbose_and_succinct_test.go
@@ -1,9 +1,9 @@
 package integration_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gexec"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Verbose And Succinct Mode", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/watch_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/integration/watch_test.go
@@ -6,10 +6,10 @@ import (
 	"path/filepath"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gbytes"
-	"github.com/onsi/gomega/gexec"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gbytes"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Watch", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation/code_location.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation/code_location.go
@@ -6,7 +6,7 @@ import (
 	"runtime/debug"
 	"strings"
 
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 )
 
 func New(skip int) types.CodeLocation {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation/code_location_suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation/code_location_suite_test.go
@@ -1,9 +1,8 @@
 package codelocation_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"testing"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation/code_location_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation/code_location_test.go
@@ -1,11 +1,11 @@
 package codelocation_test
 
 import (
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"runtime"
-	. "github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/internal/codelocation"
-	"github.com/onsi/ginkgo/types"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("CodeLocation", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/containernode/container_node.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/containernode/container_node.go
@@ -4,8 +4,8 @@ import (
 	"math/rand"
 	"sort"
 
-	"github.com/onsi/ginkgo/internal/leafnodes"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 )
 
 type subjectOrContainerNode struct {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/containernode/container_node_suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/containernode/container_node_suite_test.go
@@ -1,9 +1,8 @@
 package containernode_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"testing"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/containernode/container_node_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/containernode/container_node_test.go
@@ -1,15 +1,13 @@
 package containernode_test
 
 import (
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/containernode"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"math/rand"
-	"github.com/onsi/ginkgo/internal/leafnodes"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
-	"github.com/onsi/ginkgo/internal/codelocation"
-	. "github.com/onsi/ginkgo/internal/containernode"
-	"github.com/onsi/ginkgo/types"
 )
 
 var _ = Describe("Container Node", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/failer/failer.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/failer/failer.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 )
 
 type Failer struct {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/failer/failer_suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/failer/failer_suite_test.go
@@ -1,9 +1,8 @@
 package failer_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"testing"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/failer/failer_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/failer/failer_test.go
@@ -1,12 +1,11 @@
 package failer_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/internal/failer"
-	. "github.com/onsi/gomega"
-
-	"github.com/onsi/ginkgo/internal/codelocation"
-	"github.com/onsi/ginkgo/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/failer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 )
 
 var _ = Describe("Failer", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/benchmarker.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/benchmarker.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"time"
 
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 )
 
 type benchmarker struct {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/interfaces.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/interfaces.go
@@ -1,7 +1,7 @@
 package leafnodes
 
 import (
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 )
 
 type BasicNode interface {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/it_node.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/it_node.go
@@ -1,8 +1,8 @@
 package leafnodes
 
 import (
-	"github.com/onsi/ginkgo/internal/failer"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/failer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 	"time"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/it_node_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/it_node_test.go
@@ -1,12 +1,11 @@
 package leafnodes_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/internal/leafnodes"
-	. "github.com/onsi/gomega"
-
-	"github.com/onsi/ginkgo/internal/codelocation"
-	"github.com/onsi/ginkgo/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 )
 
 var _ = Describe("It Nodes", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/leaf_node_suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/leaf_node_suite_test.go
@@ -1,9 +1,8 @@
 package leafnodes_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"testing"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/measure_node.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/measure_node.go
@@ -1,8 +1,8 @@
 package leafnodes
 
 import (
-	"github.com/onsi/ginkgo/internal/failer"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/failer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 	"reflect"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/measure_node_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/measure_node_test.go
@@ -1,14 +1,13 @@
 package leafnodes_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/internal/leafnodes"
-	. "github.com/onsi/gomega"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation"
+	Failer "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/failer"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"time"
-	"github.com/onsi/ginkgo/internal/codelocation"
-	Failer "github.com/onsi/ginkgo/internal/failer"
-	"github.com/onsi/ginkgo/types"
 )
 
 var _ = Describe("Measure Nodes", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/runner.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/runner.go
@@ -2,9 +2,9 @@ package leafnodes
 
 import (
 	"fmt"
-	"github.com/onsi/ginkgo/internal/codelocation"
-	"github.com/onsi/ginkgo/internal/failer"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/failer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 	"reflect"
 	"time"
 )

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/setup_nodes.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/setup_nodes.go
@@ -1,8 +1,8 @@
 package leafnodes
 
 import (
-	"github.com/onsi/ginkgo/internal/failer"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/failer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 	"time"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/setup_nodes_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/setup_nodes_test.go
@@ -1,13 +1,11 @@
 package leafnodes_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/types"
-	. "github.com/onsi/gomega"
-
-	. "github.com/onsi/ginkgo/internal/leafnodes"
-
-	"github.com/onsi/ginkgo/internal/codelocation"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 )
 
 var _ = Describe("Setup Nodes", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/shared_runner_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/shared_runner_test.go
@@ -1,17 +1,16 @@
 package leafnodes_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/internal/leafnodes"
-	. "github.com/onsi/gomega"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"reflect"
 	"runtime"
 	"time"
 
-	"github.com/onsi/ginkgo/internal/codelocation"
-	Failer "github.com/onsi/ginkgo/internal/failer"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation"
+	Failer "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/failer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 )
 
 type runnable interface {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/suite_nodes.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/suite_nodes.go
@@ -1,8 +1,8 @@
 package leafnodes
 
 import (
-	"github.com/onsi/ginkgo/internal/failer"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/failer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 	"time"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/suite_nodes_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/suite_nodes_test.go
@@ -1,16 +1,14 @@
 package leafnodes_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
-	. "github.com/onsi/ginkgo/internal/leafnodes"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"time"
 
-	"github.com/onsi/ginkgo/internal/codelocation"
-	Failer "github.com/onsi/ginkgo/internal/failer"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation"
+	Failer "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/failer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 )
 
 var _ = Describe("SuiteNodes", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/synchronized_after_suite_node.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/synchronized_after_suite_node.go
@@ -2,8 +2,8 @@ package leafnodes
 
 import (
 	"encoding/json"
-	"github.com/onsi/ginkgo/internal/failer"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/failer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 	"io/ioutil"
 	"net/http"
 	"time"

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/synchronized_after_suite_node_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/synchronized_after_suite_node_test.go
@@ -1,17 +1,17 @@
 package leafnodes_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/internal/leafnodes"
-	"github.com/onsi/ginkgo/types"
-	. "github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"sync"
 
-	"github.com/onsi/gomega/ghttp"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/ghttp"
 	"net/http"
 
-	"github.com/onsi/ginkgo/internal/codelocation"
-	Failer "github.com/onsi/ginkgo/internal/failer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation"
+	Failer "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/failer"
 	"time"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/synchronized_before_suite_node.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/synchronized_before_suite_node.go
@@ -3,8 +3,8 @@ package leafnodes
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/onsi/ginkgo/internal/failer"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/failer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 	"io/ioutil"
 	"net/http"
 	"reflect"

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/synchronized_before_suite_node_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes/synchronized_before_suite_node_test.go
@@ -1,16 +1,15 @@
 package leafnodes_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/internal/leafnodes"
-	. "github.com/onsi/gomega"
-
-	"github.com/onsi/gomega/ghttp"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/ghttp"
 	"net/http"
 
-	"github.com/onsi/ginkgo/internal/codelocation"
-	Failer "github.com/onsi/ginkgo/internal/failer"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation"
+	Failer "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/failer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 	"time"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote/aggregator.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote/aggregator.go
@@ -12,9 +12,9 @@ package remote
 import (
 	"time"
 
-	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/reporters/stenographer"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/stenographer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 )
 
 type configAndSuite struct {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote/aggregator_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote/aggregator_test.go
@@ -1,14 +1,13 @@
 package remote_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote"
+	st "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/stenographer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"time"
-	"github.com/onsi/ginkgo/config"
-	. "github.com/onsi/ginkgo/internal/remote"
-	st "github.com/onsi/ginkgo/reporters/stenographer"
-	"github.com/onsi/ginkgo/types"
 )
 
 var _ = Describe("Aggregator", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote/forwarding_reporter.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote/forwarding_reporter.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 )
 
 //An interface to net/http's client to allow the injection of fakes under test

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote/forwarding_reporter_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote/forwarding_reporter_test.go
@@ -2,11 +2,11 @@ package remote_test
 
 import (
 	"encoding/json"
-	. "github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/config"
-	. "github.com/onsi/ginkgo/internal/remote"
-	"github.com/onsi/ginkgo/types"
-	. "github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 )
 
 var _ = Describe("ForwardingReporter", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote/output_interceptor_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote/output_interceptor_test.go
@@ -2,9 +2,9 @@ package remote_test
 
 import (
 	"fmt"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/internal/remote"
-	. "github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"os"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote/remote_suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote/remote_suite_test.go
@@ -1,9 +1,8 @@
 package remote_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"testing"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote/server.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote/server.go
@@ -9,9 +9,9 @@ package remote
 
 import (
 	"encoding/json"
-	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/reporters"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 	"io/ioutil"
 	"net"
 	"net/http"

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote/server_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote/server_test.go
@@ -1,16 +1,14 @@
 package remote_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/internal/remote"
-	. "github.com/onsi/gomega"
-
-	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/reporters"
-	"github.com/onsi/ginkgo/types"
-
 	"bytes"
 	"encoding/json"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"net/http"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/spec/index_computer_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/spec/index_computer_test.go
@@ -1,9 +1,9 @@
 package spec_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/internal/spec"
-	. "github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/spec"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 )
 
 var _ = Describe("ParallelizedIndexRange", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/spec/spec.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/spec/spec.go
@@ -5,9 +5,9 @@ import (
 	"io"
 	"time"
 
-	"github.com/onsi/ginkgo/internal/containernode"
-	"github.com/onsi/ginkgo/internal/leafnodes"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/containernode"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 )
 
 type Spec struct {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/spec/spec_suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/spec/spec_suite_test.go
@@ -1,9 +1,8 @@
 package spec_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"testing"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/spec/spec_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/spec/spec_test.go
@@ -3,17 +3,15 @@ package spec_test
 import (
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gbytes"
-
-	. "github.com/onsi/ginkgo/internal/spec"
-
-	"github.com/onsi/ginkgo/internal/codelocation"
-	"github.com/onsi/ginkgo/internal/containernode"
-	Failer "github.com/onsi/ginkgo/internal/failer"
-	"github.com/onsi/ginkgo/internal/leafnodes"
-	"github.com/onsi/ginkgo/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/containernode"
+	Failer "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/failer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/spec"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gbytes"
 )
 
 var noneFlag = types.FlagTypeNone

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/spec/specs_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/spec/specs_test.go
@@ -3,14 +3,13 @@ package spec_test
 import (
 	"math/rand"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/internal/spec"
-	. "github.com/onsi/gomega"
-
-	"github.com/onsi/ginkgo/internal/codelocation"
-	"github.com/onsi/ginkgo/internal/containernode"
-	"github.com/onsi/ginkgo/internal/leafnodes"
-	"github.com/onsi/ginkgo/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/containernode"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/spec"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 )
 
 var _ = Describe("Specs", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go
@@ -7,13 +7,12 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/internal/leafnodes"
-	"github.com/onsi/ginkgo/internal/spec"
-	Writer "github.com/onsi/ginkgo/internal/writer"
-	"github.com/onsi/ginkgo/reporters"
-	"github.com/onsi/ginkgo/types"
-
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/spec"
+	Writer "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/writer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 	"time"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/specrunner/spec_runner_suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/specrunner/spec_runner_suite_test.go
@@ -1,9 +1,8 @@
 package specrunner_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"testing"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/specrunner/spec_runner_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/specrunner/spec_runner_test.go
@@ -1,19 +1,18 @@
 package specrunner_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/internal/specrunner"
-	"github.com/onsi/ginkgo/types"
-	. "github.com/onsi/gomega"
-
-	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/internal/codelocation"
-	"github.com/onsi/ginkgo/internal/containernode"
-	Failer "github.com/onsi/ginkgo/internal/failer"
-	"github.com/onsi/ginkgo/internal/leafnodes"
-	"github.com/onsi/ginkgo/internal/spec"
-	Writer "github.com/onsi/ginkgo/internal/writer"
-	"github.com/onsi/ginkgo/reporters"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/containernode"
+	Failer "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/failer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/spec"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/specrunner"
+	Writer "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/writer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 )
 
 var noneFlag = types.FlagTypeNone

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/suite/suite.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/suite/suite.go
@@ -4,15 +4,15 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/internal/containernode"
-	"github.com/onsi/ginkgo/internal/failer"
-	"github.com/onsi/ginkgo/internal/leafnodes"
-	"github.com/onsi/ginkgo/internal/spec"
-	"github.com/onsi/ginkgo/internal/specrunner"
-	"github.com/onsi/ginkgo/internal/writer"
-	"github.com/onsi/ginkgo/reporters"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/containernode"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/failer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/leafnodes"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/spec"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/specrunner"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/writer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 )
 
 type ginkgoTestingT interface {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/suite/suite_suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/suite/suite_suite_test.go
@@ -1,9 +1,8 @@
 package suite_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"testing"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/suite/suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/suite/suite_test.go
@@ -3,19 +3,18 @@ package suite_test
 import (
 	"bytes"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/internal/suite"
-	. "github.com/onsi/gomega"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/suite"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"math/rand"
 	"time"
 
-	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/internal/codelocation"
-	Failer "github.com/onsi/ginkgo/internal/failer"
-	Writer "github.com/onsi/ginkgo/internal/writer"
-	"github.com/onsi/ginkgo/reporters"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation"
+	Failer "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/failer"
+	Writer "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/writer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 )
 
 var _ = Describe("Suite", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/writer/writer_suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/writer/writer_suite_test.go
@@ -1,9 +1,8 @@
 package writer_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"testing"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/writer/writer_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/writer/writer_test.go
@@ -1,11 +1,10 @@
 package writer_test
 
 import (
-	"github.com/onsi/gomega/gbytes"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/internal/writer"
-	. "github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/writer"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gbytes"
 )
 
 var _ = Describe("Writer", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/default_reporter.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/default_reporter.go
@@ -8,9 +8,9 @@ These are documented [here](http://onsi.github.io/ginkgo/#running_tests)
 package reporters
 
 import (
-	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/reporters/stenographer"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/stenographer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 )
 
 type DefaultReporter struct {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/default_reporter_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/default_reporter_test.go
@@ -3,12 +3,12 @@ package reporters_test
 import (
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/reporters"
-	st "github.com/onsi/ginkgo/reporters/stenographer"
-	"github.com/onsi/ginkgo/types"
-	. "github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters"
+	st "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/stenographer"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 )
 
 var _ = Describe("DefaultReporter", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/fake_reporter.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/fake_reporter.go
@@ -1,8 +1,8 @@
 package reporters
 
 import (
-	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 )
 
 //FakeReporter is useful for testing purposes

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/junit_reporter.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/junit_reporter.go
@@ -11,8 +11,8 @@ package reporters
 import (
 	"encoding/xml"
 	"fmt"
-	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 	"os"
 	"strings"
 )

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/junit_reporter_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/junit_reporter_test.go
@@ -6,12 +6,12 @@ import (
 	"os"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/internal/codelocation"
-	"github.com/onsi/ginkgo/reporters"
-	"github.com/onsi/ginkgo/types"
-	. "github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 )
 
 var _ = Describe("JUnit Reporter", func() {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/reporter.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/reporter.go
@@ -1,8 +1,8 @@
 package reporters
 
 import (
-	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 )
 
 type Reporter interface {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/reporters_suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/reporters_suite_test.go
@@ -1,9 +1,8 @@
 package reporters_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"testing"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/stenographer/fake_stenographer.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/stenographer/fake_stenographer.go
@@ -3,7 +3,7 @@ package stenographer
 import (
 	"sync"
 
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 )
 
 func NewFakeStenographerCall(method string, args ...interface{}) FakeStenographerCall {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/stenographer/stenographer.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/stenographer/stenographer.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 )
 
 const defaultStyle = "\x1b[0m"

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/teamcity_reporter.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/teamcity_reporter.go
@@ -10,8 +10,8 @@ package reporters
 
 import (
 	"fmt"
-	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
 	"io"
 	"strings"
 )

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/teamcity_reporter_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters/teamcity_reporter_test.go
@@ -3,12 +3,12 @@ package reporters_test
 import (
 	"bytes"
 	"fmt"
-	. "github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/internal/codelocation"
-	"github.com/onsi/ginkgo/reporters"
-	"github.com/onsi/ginkgo/types"
-	. "github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/config"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/codelocation"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/reporters"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"time"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/types/types_suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/types/types_suite_test.go
@@ -1,9 +1,8 @@
 package types_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"testing"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/types/types_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/types/types_test.go
@@ -1,10 +1,9 @@
 package types_test
 
 import (
-	. "github.com/onsi/ginkgo/types"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 )
 
 var specStates = []SpecState{

--- a/Godeps/_workspace/src/github.com/onsi/gomega/format/format_suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/format/format_suite_test.go
@@ -1,9 +1,8 @@
 package format_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"testing"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/gomega/format/format_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/format/format_test.go
@@ -2,11 +2,11 @@ package format_test
 
 import (
 	"fmt"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/types"
 	"strings"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/format"
-	"github.com/onsi/gomega/types"
 )
 
 //recursive struct

--- a/Godeps/_workspace/src/github.com/onsi/gomega/gbytes/buffer_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/gbytes/buffer_test.go
@@ -4,10 +4,9 @@ import (
 	"io"
 	"time"
 
-	. "github.com/onsi/gomega/gbytes"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gbytes"
 )
 
 var _ = Describe("Buffer", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/gbytes/gbuffer_suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/gbytes/gbuffer_suite_test.go
@@ -1,9 +1,8 @@
 package gbytes_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"testing"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/gomega/gbytes/say_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/gbytes/say_matcher.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 )
 
 //Objects satisfying the BufferProvider can be used with the Say matcher.

--- a/Godeps/_workspace/src/github.com/onsi/gomega/gbytes/say_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/gbytes/say_matcher_test.go
@@ -1,11 +1,10 @@
 package gbytes_test
 
 import (
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gbytes"
 	"time"
-	. "github.com/onsi/gomega/gbytes"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 type speaker struct {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/gexec/exit_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/gexec/exit_matcher.go
@@ -3,7 +3,7 @@ package gexec
 import (
 	"fmt"
 
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 )
 
 /*

--- a/Godeps/_workspace/src/github.com/onsi/gomega/gexec/exit_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/gexec/exit_matcher_test.go
@@ -1,12 +1,11 @@
 package gexec_test
 
 import (
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gexec"
 	"os/exec"
 	"time"
-	. "github.com/onsi/gomega/gexec"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 type NeverExits struct{}

--- a/Godeps/_workspace/src/github.com/onsi/gomega/gexec/gexec_suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/gexec/gexec_suite_test.go
@@ -1,10 +1,9 @@
 package gexec_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gexec"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gexec"
 	"testing"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/gomega/gexec/prefixed_writer_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/gexec/prefixed_writer_test.go
@@ -3,10 +3,9 @@ package gexec_test
 import (
 	"bytes"
 
-	. "github.com/onsi/gomega/gexec"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("PrefixedWriter", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/gexec/session.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/gexec/session.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 	"syscall"
 
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gbytes"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gbytes"
 )
 
 const INVALID_EXIT_CODE = 254

--- a/Godeps/_workspace/src/github.com/onsi/gomega/gexec/session_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/gexec/session_test.go
@@ -1,14 +1,13 @@
 package gexec_test
 
 import (
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gbytes"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gexec"
 	"os/exec"
 	"syscall"
 	"time"
-	. "github.com/onsi/gomega/gbytes"
-	. "github.com/onsi/gomega/gexec"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Session", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/ghttp/handlers.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/ghttp/handlers.go
@@ -7,8 +7,8 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/types"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/types"
 )
 
 //CombineHandler takes variadic list of handlers and produces one handler

--- a/Godeps/_workspace/src/github.com/onsi/gomega/ghttp/test_server.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/ghttp/test_server.go
@@ -113,7 +113,7 @@ import (
 	"regexp"
 	"sync"
 
-	. "github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 )
 
 func new() *Server {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/ghttp/test_server_suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/ghttp/test_server_suite_test.go
@@ -1,9 +1,8 @@
 package ghttp_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"testing"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/gomega/ghttp/test_server_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/ghttp/test_server_test.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"regexp"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/ghttp"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/ghttp"
 )
 
 var _ = Describe("TestServer", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/gomega_dsl.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/gomega_dsl.go
@@ -18,10 +18,10 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/onsi/gomega/internal/assertion"
-	"github.com/onsi/gomega/internal/asyncassertion"
-	"github.com/onsi/gomega/internal/testingtsupport"
-	"github.com/onsi/gomega/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/internal/assertion"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/internal/asyncassertion"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/internal/testingtsupport"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/types"
 )
 
 const GOMEGA_VERSION = "1.0"

--- a/Godeps/_workspace/src/github.com/onsi/gomega/internal/assertion/assertion.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/internal/assertion/assertion.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/onsi/gomega/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/types"
 )
 
 type Assertion struct {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/internal/assertion/assertion_suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/internal/assertion/assertion_suite_test.go
@@ -1,9 +1,8 @@
 package assertion_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"testing"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/gomega/internal/assertion/assertion_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/internal/assertion/assertion_test.go
@@ -3,10 +3,10 @@ package assertion_test
 import (
 	"errors"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/internal/assertion"
-	"github.com/onsi/gomega/internal/fakematcher"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/internal/assertion"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/internal/fakematcher"
 )
 
 var _ = Describe("Assertion", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/internal/asyncassertion/async_assertion.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/internal/asyncassertion/async_assertion.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/onsi/gomega/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/types"
 )
 
 type AsyncAssertionType uint

--- a/Godeps/_workspace/src/github.com/onsi/gomega/internal/asyncassertion/async_assertion_suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/internal/asyncassertion/async_assertion_suite_test.go
@@ -1,9 +1,8 @@
 package asyncassertion_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"testing"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/gomega/internal/asyncassertion/async_assertion_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/internal/asyncassertion/async_assertion_test.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/internal/asyncassertion"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/internal/asyncassertion"
 )
 
 var _ = Describe("Async Assertion", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/internal/testingtsupport/testing_t_support.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/internal/testingtsupport/testing_t_support.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 	"strings"
 
-	"github.com/onsi/gomega/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/types"
 )
 
 type gomegaTestingT interface {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/internal/testingtsupport/testing_t_support_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/internal/testingtsupport/testing_t_support_test.go
@@ -1,8 +1,7 @@
 package testingtsupport_test
 
 import (
-	. "github.com/onsi/gomega"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"testing"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers.go
@@ -3,8 +3,8 @@ package gomega
 import (
 	"time"
 
-	"github.com/onsi/gomega/matchers"
-	"github.com/onsi/gomega/types"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/types"
 )
 
 //Equal uses reflect.DeepEqual to compare actual with expected.  Equal is strict about

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/assignable_to_type_of_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/assignable_to_type_of_matcher.go
@@ -2,7 +2,7 @@ package matchers
 
 import (
 	"fmt"
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 	"reflect"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/assignable_to_type_of_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/assignable_to_type_of_matcher_test.go
@@ -1,9 +1,9 @@
 package matchers_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/matchers"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
 )
 
 var _ = Describe("AssignableToTypeOf", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_closed_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_closed_matcher.go
@@ -2,7 +2,7 @@ package matchers
 
 import (
 	"fmt"
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 	"reflect"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_closed_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_closed_matcher_test.go
@@ -1,9 +1,9 @@
 package matchers_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/matchers"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
 )
 
 var _ = Describe("BeClosedMatcher", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_empty_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_empty_matcher.go
@@ -2,7 +2,7 @@ package matchers
 
 import (
 	"fmt"
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 )
 
 type BeEmptyMatcher struct {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_empty_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_empty_matcher_test.go
@@ -1,9 +1,9 @@
 package matchers_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/matchers"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
 )
 
 var _ = Describe("BeEmpty", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_equivalent_to_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_equivalent_to_matcher.go
@@ -2,7 +2,7 @@ package matchers
 
 import (
 	"fmt"
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 	"reflect"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_equivalent_to_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_equivalent_to_matcher_test.go
@@ -1,9 +1,9 @@
 package matchers_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/matchers"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
 )
 
 var _ = Describe("BeEquivalentTo", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_false_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_false_matcher.go
@@ -2,7 +2,7 @@ package matchers
 
 import (
 	"fmt"
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 )
 
 type BeFalseMatcher struct {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_false_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_false_matcher_test.go
@@ -1,9 +1,9 @@
 package matchers_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/matchers"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
 )
 
 var _ = Describe("BeFalse", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_nil_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_nil_matcher.go
@@ -1,6 +1,6 @@
 package matchers
 
-import "github.com/onsi/gomega/format"
+import "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 
 type BeNilMatcher struct {
 }

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_nil_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_nil_matcher_test.go
@@ -1,8 +1,8 @@
 package matchers_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 )
 
 var _ = Describe("BeNil", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_numerically_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_numerically_matcher.go
@@ -2,7 +2,7 @@ package matchers
 
 import (
 	"fmt"
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 	"math"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_numerically_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_numerically_matcher_test.go
@@ -1,9 +1,9 @@
 package matchers_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/matchers"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
 )
 
 var _ = Describe("BeNumerically", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_sent_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_sent_matcher.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 )
 
 type BeSentMatcher struct {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_sent_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_sent_matcher_test.go
@@ -1,11 +1,10 @@
 package matchers_test
 
 import (
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
 	"time"
-	. "github.com/onsi/gomega/matchers"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("BeSent", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_temporally_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_temporally_matcher.go
@@ -2,7 +2,7 @@ package matchers
 
 import (
 	"fmt"
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 	"time"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_temporally_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_temporally_matcher_test.go
@@ -1,9 +1,9 @@
 package matchers_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/matchers"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
 	"time"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_true_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_true_matcher.go
@@ -2,7 +2,7 @@ package matchers
 
 import (
 	"fmt"
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 )
 
 type BeTrueMatcher struct {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_true_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_true_matcher_test.go
@@ -1,9 +1,9 @@
 package matchers_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/matchers"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
 )
 
 var _ = Describe("BeTrue", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_zero_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_zero_matcher.go
@@ -1,7 +1,7 @@
 package matchers
 
 import (
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 	"reflect"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_zero_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/be_zero_matcher_test.go
@@ -1,8 +1,8 @@
 package matchers_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 )
 
 var _ = Describe("BeZero", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/consist_of.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/consist_of.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/onsi/gomega/format"
-	"github.com/onsi/gomega/matchers/support/goraph/bipartitegraph"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers/support/goraph/bipartitegraph"
 )
 
 type ConsistOfMatcher struct {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/consist_of_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/consist_of_test.go
@@ -1,8 +1,8 @@
 package matchers_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 )
 
 var _ = Describe("ConsistOf", func() {
@@ -54,10 +54,10 @@ var _ = Describe("ConsistOf", func() {
 			Ω([]string{"foo", "bar", "baz"}).ShouldNot(ConsistOf("foo", MatchRegexp("^ba"), MatchRegexp("turducken")))
 		})
 
-        It("should not depend on the order of the matchers", func() {
+		It("should not depend on the order of the matchers", func() {
 			Ω([][]int{[]int{1, 2}, []int{2}}).Should(ConsistOf(ContainElement(1), ContainElement(2)))
 			Ω([][]int{[]int{1, 2}, []int{2}}).Should(ConsistOf(ContainElement(2), ContainElement(1)))
-        })
+		})
 
 		Context("when a matcher errors", func() {
 			It("should soldier on", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/contain_element_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/contain_element_matcher.go
@@ -2,7 +2,7 @@ package matchers
 
 import (
 	"fmt"
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 	"reflect"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/contain_element_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/contain_element_matcher_test.go
@@ -1,9 +1,9 @@
 package matchers_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/matchers"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
 )
 
 var _ = Describe("ContainElement", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/contain_substring_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/contain_substring_matcher.go
@@ -2,7 +2,7 @@ package matchers
 
 import (
 	"fmt"
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 	"strings"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/contain_substring_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/contain_substring_matcher_test.go
@@ -1,9 +1,9 @@
 package matchers_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/matchers"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
 )
 
 var _ = Describe("ContainSubstringMatcher", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/equal_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/equal_matcher.go
@@ -2,7 +2,7 @@ package matchers
 
 import (
 	"fmt"
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 	"reflect"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/equal_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/equal_matcher_test.go
@@ -2,9 +2,9 @@ package matchers_test
 
 import (
 	"errors"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/matchers"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
 )
 
 var _ = Describe("Equal", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/have_key_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/have_key_matcher.go
@@ -2,7 +2,7 @@ package matchers
 
 import (
 	"fmt"
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 	"reflect"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/have_key_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/have_key_matcher_test.go
@@ -1,9 +1,9 @@
 package matchers_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/matchers"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
 )
 
 var _ = Describe("HaveKey", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/have_key_with_value_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/have_key_with_value_matcher.go
@@ -2,7 +2,7 @@ package matchers
 
 import (
 	"fmt"
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 	"reflect"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/have_key_with_value_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/have_key_with_value_matcher_test.go
@@ -1,9 +1,9 @@
 package matchers_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/matchers"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
 )
 
 var _ = Describe("HaveKeyWithValue", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/have_len_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/have_len_matcher.go
@@ -2,7 +2,7 @@ package matchers
 
 import (
 	"fmt"
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 )
 
 type HaveLenMatcher struct {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/have_len_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/have_len_matcher_test.go
@@ -1,9 +1,9 @@
 package matchers_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/matchers"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
 )
 
 var _ = Describe("HaveLen", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/have_occurred_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/have_occurred_matcher.go
@@ -2,7 +2,7 @@ package matchers
 
 import (
 	"fmt"
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 )
 
 type HaveOccurredMatcher struct {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/have_occurred_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/have_occurred_matcher_test.go
@@ -2,9 +2,9 @@ package matchers_test
 
 import (
 	"errors"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/matchers"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
 )
 
 var _ = Describe("HaveOccurred", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/have_prefix_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/have_prefix_matcher.go
@@ -2,7 +2,7 @@ package matchers
 
 import (
 	"fmt"
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 )
 
 type HavePrefixMatcher struct {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/have_prefix_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/have_prefix_matcher_test.go
@@ -1,9 +1,9 @@
 package matchers_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/matchers"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
 )
 
 var _ = Describe("HavePrefixMatcher", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/have_suffix_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/have_suffix_matcher.go
@@ -2,7 +2,7 @@ package matchers
 
 import (
 	"fmt"
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 )
 
 type HaveSuffixMatcher struct {
@@ -16,7 +16,7 @@ func (matcher *HaveSuffixMatcher) Match(actual interface{}) (success bool, err e
 		return false, fmt.Errorf("HaveSuffix matcher requires a string or stringer.  Got:\n%s", format.Object(actual, 1))
 	}
 	suffix := matcher.suffix()
-	return len(actualString) >= len(suffix) && actualString[len(actualString) - len(suffix):] == suffix, nil
+	return len(actualString) >= len(suffix) && actualString[len(actualString)-len(suffix):] == suffix, nil
 }
 
 func (matcher *HaveSuffixMatcher) suffix() string {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/have_suffix_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/have_suffix_matcher_test.go
@@ -1,9 +1,9 @@
 package matchers_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/matchers"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
 )
 
 var _ = Describe("HaveSuffixMatcher", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/match_error_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/match_error_matcher.go
@@ -2,7 +2,7 @@ package matchers
 
 import (
 	"fmt"
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 	"reflect"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/match_error_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/match_error_matcher_test.go
@@ -3,9 +3,9 @@ package matchers_test
 import (
 	"errors"
 	"fmt"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/matchers"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
 )
 
 type CustomError struct {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/match_json_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/match_json_matcher.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 	"reflect"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/match_json_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/match_json_matcher_test.go
@@ -1,9 +1,9 @@
 package matchers_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/matchers"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
 )
 
 var _ = Describe("MatchJSONMatcher", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/match_regexp_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/match_regexp_matcher.go
@@ -2,7 +2,7 @@ package matchers
 
 import (
 	"fmt"
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 	"regexp"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/match_regexp_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/match_regexp_matcher_test.go
@@ -1,9 +1,9 @@
 package matchers_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/matchers"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
 )
 
 var _ = Describe("MatchRegexp", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/matcher_tests_suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/matcher_tests_suite_test.go
@@ -1,9 +1,9 @@
 package matchers_test
 
 import (
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"testing"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 type myStringer struct {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/panic_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/panic_matcher.go
@@ -2,7 +2,7 @@ package matchers
 
 import (
 	"fmt"
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 	"reflect"
 )
 

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/panic_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/panic_matcher_test.go
@@ -1,9 +1,9 @@
 package matchers_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/matchers"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
 )
 
 var _ = Describe("Panic", func() {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/receive_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/receive_matcher.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 )
 
 type ReceiveMatcher struct {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/receive_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/receive_matcher_test.go
@@ -3,9 +3,9 @@ package matchers_test
 import (
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/matchers"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
 )
 
 type kungFuActor interface {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/succeed_matcher.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/succeed_matcher.go
@@ -3,7 +3,7 @@ package matchers
 import (
 	"fmt"
 
-	"github.com/onsi/gomega/format"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/format"
 )
 
 type SucceedMatcher struct {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/succeed_matcher_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/succeed_matcher_test.go
@@ -3,9 +3,9 @@ package matchers_test
 import (
 	"errors"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/matchers"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers"
 )
 
 func Erroring() error {

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/support/goraph/bipartitegraph/bipartitegraph.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/support/goraph/bipartitegraph/bipartitegraph.go
@@ -3,8 +3,8 @@ package bipartitegraph
 import "errors"
 import "fmt"
 
-import . "github.com/onsi/gomega/matchers/support/goraph/node"
-import . "github.com/onsi/gomega/matchers/support/goraph/edge"
+import . "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers/support/goraph/node"
+import . "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers/support/goraph/edge"
 
 type BipartiteGraph struct {
 	Left  NodeOrderedSet

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/support/goraph/bipartitegraph/bipartitegraphmatching.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/support/goraph/bipartitegraph/bipartitegraphmatching.go
@@ -1,8 +1,8 @@
 package bipartitegraph
 
-import . "github.com/onsi/gomega/matchers/support/goraph/node"
-import . "github.com/onsi/gomega/matchers/support/goraph/edge"
-import "github.com/onsi/gomega/matchers/support/goraph/util"
+import . "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers/support/goraph/node"
+import . "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers/support/goraph/edge"
+import "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers/support/goraph/util"
 
 func (bg *BipartiteGraph) LargestMatching() (matching EdgeSet) {
 	paths := bg.maximalDisjointSLAPCollection(matching)

--- a/Godeps/_workspace/src/github.com/onsi/gomega/matchers/support/goraph/edge/edge.go
+++ b/Godeps/_workspace/src/github.com/onsi/gomega/matchers/support/goraph/edge/edge.go
@@ -1,6 +1,6 @@
 package edge
 
-import . "github.com/onsi/gomega/matchers/support/goraph/node"
+import . "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/matchers/support/goraph/node"
 
 type Edge struct {
 	Node1 Node

--- a/Godeps/_workspace/src/github.com/wadey/cryptorand/example_test.go
+++ b/Godeps/_workspace/src/github.com/wadey/cryptorand/example_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/wadey/cryptorand"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/wadey/cryptorand"
 )
 
 func Example() {

--- a/Godeps/_workspace/src/github.com/wadey/cryptorand/source_test.go
+++ b/Godeps/_workspace/src/github.com/wadey/cryptorand/source_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/wadey/cryptorand"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/wadey/cryptorand"
 )
 
 func TestSource(t *testing.T) {

--- a/ably_go_suite_test.go
+++ b/ably_go_suite_test.go
@@ -1,9 +1,8 @@
 package ably_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"testing"
 )
 

--- a/ably_test.go
+++ b/ably_test.go
@@ -5,8 +5,8 @@ import (
 	"github.com/ably/ably-go/realtime"
 	"github.com/ably/ably-go/rest"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 )
 
 var _ = Describe("ably package", func() {

--- a/client_options_test.go
+++ b/client_options_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/ably/ably-go"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gbytes"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega/gbytes"
 )
 
 var _ = Describe("ClientOptions", func() {

--- a/realtime/connection.go
+++ b/realtime/connection.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/ably/ably-go/protocol"
 
-	"code.google.com/p/go.net/websocket"
+	"github.com/ably/ably-go/Godeps/_workspace/src/code.google.com/p/go.net/websocket"
 )
 
 func Dial(w string) (*Conn, error) {

--- a/rest/auth.go
+++ b/rest/auth.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/flynn/flynn/pkg/random"
 	"github.com/ably/ably-go/config"
-	"github.com/flynn/flynn/pkg/random"
 )
 
 type Capability map[string][]string

--- a/rest/channel_test.go
+++ b/rest/channel_test.go
@@ -1,8 +1,8 @@
 package rest_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 )
 
 var _ = Describe("Channel", func() {

--- a/rest/client_test.go
+++ b/rest/client_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/ably/ably-go/rest"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 )
 
 var _ = Describe("Client", func() {

--- a/rest/rest_suite_test.go
+++ b/rest/rest_suite_test.go
@@ -5,9 +5,8 @@ import (
 	"github.com/ably/ably-go/rest"
 	"github.com/ably/ably-go/test/support"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"testing"
 )
 


### PR DESCRIPTION
The dependencies have already been vendored using godep (see 5d8ca38) but they were not being referenced.

This is the result of running `godep save -r ./...`.