### PR TITLE
Rest presence

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -16,6 +16,10 @@
 			"Rev": "736b4d597fe39e75c9777942245ee02a24bb0d26"
 		},
 		{
+			"ImportPath": "github.com/google/go-querystring/query",
+			"Rev": "d8840cbb2baa915f4836edda4750050a2c0b7aea"
+		},
+		{
 			"ImportPath": "github.com/onsi/ginkgo",
 			"Comment": "v1.1.0-33-g17ea479",
 			"Rev": "17ea479729ee427265ac1e913443018350946ddf"

--- a/Godeps/_workspace/src/github.com/google/go-querystring/query/encode.go
+++ b/Godeps/_workspace/src/github.com/google/go-querystring/query/encode.go
@@ -1,0 +1,274 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package query implements encoding of structs into URL query parameters.
+//
+// As a simple example:
+//
+// 	type Options struct {
+// 		Query   string `url:"q"`
+// 		ShowAll bool   `url:"all"`
+// 		Page    int    `url:"page"`
+// 	}
+//
+// 	opt := Options{ "foo", true, 2 }
+// 	v, _ := query.Values(opt)
+// 	fmt.Print(v.Encode()) // will output: "q=foo&all=true&page=2"
+//
+// The exact mapping between Go values and url.Values is described in the
+// documentation for the Values() function.
+package query
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var timeType = reflect.TypeOf(time.Time{})
+
+var encoderType = reflect.TypeOf(new(Encoder)).Elem()
+
+// Encoder is an interface implemented by any type that wishes to encode
+// itself into URL values in a non-standard way.
+type Encoder interface {
+	EncodeValues(key string, v *url.Values) error
+}
+
+// Values returns the url.Values encoding of v.
+//
+// Values expects to be passed a struct, and traverses it recursively using the
+// following encoding rules.
+//
+// Each exported struct field is encoded as a URL parameter unless
+//
+//	- the field's tag is "-", or
+//	- the field is empty and its tag specifies the "omitempty" option
+//
+// The empty values are false, 0, any nil pointer or interface value, any array
+// slice, map, or string of length zero, and any time.Time that returns true
+// for IsZero().
+//
+// The URL parameter name defaults to the struct field name but can be
+// specified in the struct field's tag value.  The "url" key in the struct
+// field's tag value is the key name, followed by an optional comma and
+// options.  For example:
+//
+// 	// Field is ignored by this package.
+// 	Field int `url:"-"`
+//
+// 	// Field appears as URL parameter "myName".
+// 	Field int `url:"myName"`
+//
+// 	// Field appears as URL parameter "myName" and the field is omitted if
+// 	// its value is empty
+// 	Field int `url:"myName,omitempty"`
+//
+// 	// Field appears as URL parameter "Field" (the default), but the field
+// 	// is skipped if empty.  Note the leading comma.
+// 	Field int `url:",omitempty"`
+//
+// For encoding individual field values, the following type-dependent rules
+// apply:
+//
+// Boolean values default to encoding as the strings "true" or "false".
+// Including the "int" option signals that the field should be encoded as the
+// strings "1" or "0".
+//
+// time.Time values default to encoding as RFC3339 timestamps.  Including the
+// "unix" option signals that the field should be encoded as a Unix time (see
+// time.Unix())
+//
+// Slice and Array values default to encoding as multiple URL values of the
+// same name.  Including the "comma" option signals that the field should be
+// encoded as a single comma-delimited value.  Including the "space" option
+// similarly encodes the value as a single space-delimited string.
+//
+// Anonymous struct fields are usually encoded as if their inner exported
+// fields were fields in the outer struct, subject to the standard Go
+// visibility rules.  An anonymous struct field with a name given in its URL
+// tag is treated as having that name, rather than being anonymous.
+//
+// Non-nil pointer values are encoded as the value pointed to.
+//
+// All other values are encoded using their default string representation.
+//
+// Multiple fields that encode to the same URL parameter name will be included
+// as multiple URL values of the same name.
+func Values(v interface{}) (url.Values, error) {
+	val := reflect.ValueOf(v)
+	for val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil, errors.New("query: Values() expects non-nil value")
+		}
+		val = val.Elem()
+	}
+
+	if val.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("query: Values() expects struct input. Got %v", val.Kind())
+	}
+
+	values := make(url.Values)
+	err := reflectValue(values, val)
+	return values, err
+}
+
+// reflectValue populates the values parameter from the struct fields in val.
+// Embedded structs are followed recursively (using the rules defined in the
+// Values function documentation) breadth-first.
+func reflectValue(values url.Values, val reflect.Value) error {
+	var embedded []reflect.Value
+
+	typ := val.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		sf := typ.Field(i)
+		if sf.PkgPath != "" { // unexported
+			continue
+		}
+
+		sv := val.Field(i)
+		tag := sf.Tag.Get("url")
+		if tag == "-" {
+			continue
+		}
+		name, opts := parseTag(tag)
+		if name == "" {
+			if sf.Anonymous && sv.Kind() == reflect.Struct {
+				// save embedded struct for later processing
+				embedded = append(embedded, sv)
+				continue
+			}
+
+			name = sf.Name
+		}
+
+		if opts.Contains("omitempty") && isEmptyValue(sv) {
+			continue
+		}
+
+		if sv.Type().Implements(encoderType) {
+			m := sv.Interface().(Encoder)
+			if err := m.EncodeValues(name, &values); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if sv.Kind() == reflect.Slice || sv.Kind() == reflect.Array {
+			var del byte
+			if opts.Contains("comma") {
+				del = ','
+			} else if opts.Contains("space") {
+				del = ' '
+			}
+
+			if del != 0 {
+				s := new(bytes.Buffer)
+				first := true
+				for i := 0; i < sv.Len(); i++ {
+					if first {
+						first = false
+					} else {
+						s.WriteByte(del)
+					}
+					s.WriteString(valueString(sv.Index(i), opts))
+				}
+				values.Add(name, s.String())
+			} else {
+				for i := 0; i < sv.Len(); i++ {
+					values.Add(name, valueString(sv.Index(i), opts))
+				}
+			}
+			continue
+		}
+
+		values.Add(name, valueString(sv, opts))
+	}
+
+	for _, f := range embedded {
+		if err := reflectValue(values, f); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// valueString returns the string representation of a value.
+func valueString(v reflect.Value, opts tagOptions) string {
+	for v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return ""
+		}
+		v = v.Elem()
+	}
+
+	if v.Kind() == reflect.Bool && opts.Contains("int") {
+		if v.Bool() {
+			return "1"
+		}
+		return "0"
+	}
+
+	if v.Type() == timeType {
+		t := v.Interface().(time.Time)
+		if opts.Contains("unix") {
+			return strconv.FormatInt(t.Unix(), 10)
+		}
+		return t.Format(time.RFC3339)
+	}
+
+	return fmt.Sprint(v.Interface())
+}
+
+// isEmptyValue checks if a value should be considered empty for the purposes
+// of omitting fields with the "omitempty" option.
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+
+	if v.Type() == timeType {
+		return v.Interface().(time.Time).IsZero()
+	}
+
+	return false
+}
+
+// tagOptions is the string following a comma in a struct field's "url" tag, or
+// the empty string. It does not include the leading comma.
+type tagOptions []string
+
+// parseTag splits a struct field's url tag into its name and comma-separated
+// options.
+func parseTag(tag string) (string, tagOptions) {
+	s := strings.Split(tag, ",")
+	return s[0], s[1:]
+}
+
+// Contains checks whether the tagOptions contains the specified option.
+func (o tagOptions) Contains(option string) bool {
+	for _, s := range o {
+		if s == option {
+			return true
+		}
+	}
+	return false
+}

--- a/Godeps/_workspace/src/github.com/google/go-querystring/query/encode_test.go
+++ b/Godeps/_workspace/src/github.com/google/go-querystring/query/encode_test.go
@@ -1,0 +1,238 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package query
+
+import (
+	"fmt"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestValues_types(t *testing.T) {
+	str := "string"
+	strPtr := &str
+
+	tests := []struct {
+		in   interface{}
+		want url.Values
+	}{
+		{
+			// basic primitives
+			struct {
+				A string
+				B int
+				C uint
+				D float32
+				E bool
+			}{},
+			url.Values{
+				"A": {""},
+				"B": {"0"},
+				"C": {"0"},
+				"D": {"0"},
+				"E": {"false"},
+			},
+		},
+		{
+			// pointers
+			struct {
+				A *string
+				B *int
+				C **string
+			}{A: strPtr, C: &strPtr},
+			url.Values{
+				"A": {str},
+				"B": {""},
+				"C": {str},
+			},
+		},
+		{
+			// slices and arrays
+			struct {
+				A []string
+				B []string `url:",comma"`
+				C []string `url:",space"`
+				D [2]string
+				E [2]string `url:",comma"`
+				F [2]string `url:",space"`
+				G []*string `url:",space"`
+				H []bool    `url:",int,space"`
+			}{
+				A: []string{"a", "b"},
+				B: []string{"a", "b"},
+				C: []string{"a", "b"},
+				D: [2]string{"a", "b"},
+				E: [2]string{"a", "b"},
+				F: [2]string{"a", "b"},
+				G: []*string{&str, &str},
+				H: []bool{true, false},
+			},
+			url.Values{
+				"A": {"a", "b"},
+				"B": {"a,b"},
+				"C": {"a b"},
+				"D": {"a", "b"},
+				"E": {"a,b"},
+				"F": {"a b"},
+				"G": {"string string"},
+				"H": {"1 0"},
+			},
+		},
+		{
+			// other types
+			struct {
+				A time.Time
+				B time.Time `url:",unix"`
+				C bool      `url:",int"`
+				D bool      `url:",int"`
+			}{
+				A: time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC),
+				B: time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC),
+				C: true,
+				D: false,
+			},
+			url.Values{
+				"A": {"2000-01-01T12:34:56Z"},
+				"B": {"946730096"},
+				"C": {"1"},
+				"D": {"0"},
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		v, err := Values(tt.in)
+		if err != nil {
+			t.Errorf("%d. Values(%q) returned error: %v", i, tt.in, err)
+		}
+
+		if !reflect.DeepEqual(tt.want, v) {
+			t.Errorf("%d. Values(%q) returned %v, want %v", i, tt.in, v, tt.want)
+		}
+	}
+}
+
+func TestValues_omitEmpty(t *testing.T) {
+	str := ""
+	s := struct {
+		a string
+		A string
+		B string  `url:",omitempty"`
+		C string  `url:"-"`
+		D string  `url:"omitempty"` // actually named omitempty, not an option
+		E *string `url:",omitempty"`
+	}{E: &str}
+
+	v, err := Values(s)
+	if err != nil {
+		t.Errorf("Values(%q) returned error: %v", s, err)
+	}
+
+	want := url.Values{
+		"A":         {""},
+		"omitempty": {""},
+		"E":         {""}, // E is included because the pointer is not empty, even though the string being pointed to is
+	}
+	if !reflect.DeepEqual(want, v) {
+		t.Errorf("Values(%q) returned %v, want %v", s, v, want)
+	}
+}
+
+type A struct {
+	B
+}
+
+type B struct {
+	C string
+}
+
+type D struct {
+	B
+	C string
+}
+
+func TestValues_embeddedStructs(t *testing.T) {
+	tests := []struct {
+		in   interface{}
+		want url.Values
+	}{
+		{
+			A{B{C: "foo"}},
+			url.Values{"C": {"foo"}},
+		},
+		{
+			D{B: B{C: "bar"}, C: "foo"},
+			url.Values{"C": {"foo", "bar"}},
+		},
+	}
+
+	for i, tt := range tests {
+		v, err := Values(tt.in)
+		if err != nil {
+			t.Errorf("%d. Values(%q) returned error: %v", i, tt.in, err)
+		}
+
+		if !reflect.DeepEqual(tt.want, v) {
+			t.Errorf("%d. Values(%q) returned %v, want %v", i, tt.in, v, tt.want)
+		}
+	}
+}
+
+func TestValues_invalidInput(t *testing.T) {
+	_, err := Values("")
+	if err == nil {
+		t.Errorf("expected Values() to return an error on invalid input")
+	}
+}
+
+type EncodedArgs []string
+
+func (m EncodedArgs) EncodeValues(key string, v *url.Values) error {
+	for i, arg := range m {
+		v.Set(fmt.Sprintf("%s.%d", key, i), arg)
+	}
+	return nil
+}
+
+func TestValues_Marshaler(t *testing.T) {
+	s := struct {
+		Args EncodedArgs `url:"arg"`
+	}{[]string{"a", "b", "c"}}
+	v, err := Values(s)
+	if err != nil {
+		t.Errorf("Values(%q) returned error: %v", s, err)
+	}
+
+	want := url.Values{
+		"arg.0": {"a"},
+		"arg.1": {"b"},
+		"arg.2": {"c"},
+	}
+	if !reflect.DeepEqual(want, v) {
+		t.Errorf("Values(%q) returned %v, want %v", s, v, want)
+	}
+}
+
+func TestTagParsing(t *testing.T) {
+	name, opts := parseTag("field,foobar,foo")
+	if name != "field" {
+		t.Fatalf("name = %q, want field", name)
+	}
+	for _, tt := range []struct {
+		opt  string
+		want bool
+	}{
+		{"foobar", true},
+		{"foo", true},
+		{"bar", false},
+		{"field", false},
+	} {
+		if opts.Contains(tt.opt) != tt.want {
+			t.Errorf("Contains(%q) = %v", tt.opt, !tt.want)
+		}
+	}
+}

--- a/README.md
+++ b/README.md
@@ -70,50 +70,67 @@ channel.Presence.Enter(message, listener)
 
 ## Using the REST API
 
+### Introduction
+
+Unlike the Realtime API, all calls are synchronous and are not run within an [EventMachine](https://github.com/eventmachine/eventmachine) [reactor](https://github.com/eventmachine/eventmachine/wiki/General-Introduction).
+
+All examples assume a client and/or channel has been created as follows:
+
+```ruby
+client = ably.NewRestClient(api_key: "xxxxx")
+channel = client.Channel('test')
+```
+
 ### Publishing a message to a channel
 
-```go
-client := ably.NewRestClient(ably.ClientOptions{ApiKey: "xxxx"})
-channel := client.Channel("test")
-channel.Publish("myEvent", "Hello!")
+```ruby
+channel.Publish("myEvent", "Hello!") #=> true
 ```
 
-### Fetching a channel's history
+### Querying the History
 
-```go
-client := ably.NewRestClient(ably.ClientOptions{ApiKey: "xxxx"})
-channel := client.Channel("test")
-channel.History() // =>  []Message
+```ruby
+channel.History()
 ```
 
-### Authentication with a token
+### Presence on a channel
 
-```go
-client := ably.NewRestClient(ably.ClientOptions{ApiKey: "xxxx"})
-client.Auth.Authorize() // creates a token and will use token authentication moving forwards
-client.Auth.CurrentToken() // => ably.Auth.Token
-channel := client.Channel("test")
-channel.Publish("myEvent", "Hello!") // => true, sent using token authentication
+```ruby
+channel.Presence.Get() # => PaginatedResource
+```
+
+### Querying the Presence History
+
+```ruby
+channel.Presence.History() # => PaginatedResource
+```
+
+### Generate Token and Token Request
+
+```ruby
+client.Auth.RequestToken()
+client.Auth.CreateTokenRequest()
 ```
 
 ### Fetching your application's stats
 
-```go
-client := ably.NewRestClient(ably.ClientOptions{ApiKey: "xxxx"})
-client.Stats() // => []Stat
+```ruby
+client.Stats() #=> PaginatedResource
 ```
 
-### Fetching the Ably service time
+## Support and feedback
 
-```go
-client := ably.NewRestClient(ably.ClientOptions{ApiKey: "xxxx"})
-client.Time() // => time.Time
-```
+Please visit https://support.ably.io/ for access to our knowledgebase and to ask for any assistance.
 
 ## Contributing
 
 1. Fork it
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Ensure you have added suitable tests and the test suite is passing(`bundle exec rspec`)
 4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
+5. Create a new Pull Request
+
+## License
+
+Copyright (c) 2015 Ably, Licensed under an MIT license.  Refer to [LICENSE.txt](LICENSE.txt) for the license terms.

--- a/README.md
+++ b/README.md
@@ -96,13 +96,13 @@ channel.History()
 ### Presence on a channel
 
 ```ruby
-channel.Presence.Get(nil) # => PaginatedResource
+channel.Presence.Get(nil) # => rest.PaginatedPresenceMessages
 ```
 
 ### Querying the Presence History
 
 ```ruby
-channel.Presence.History(nil) # => PaginatedResource
+channel.Presence.History(nil) # => rest.PaginatedPresenceMessages
 ```
 
 ### Generate Token and Token Request

--- a/README.md
+++ b/README.md
@@ -96,13 +96,13 @@ channel.History()
 ### Presence on a channel
 
 ```ruby
-channel.Presence.Get() # => PaginatedResource
+channel.Presence.Get(nil) # => PaginatedResource
 ```
 
 ### Querying the Presence History
 
 ```ruby
-channel.Presence.History() # => PaginatedResource
+channel.Presence.History(nil) # => PaginatedResource
 ```
 
 ### Generate Token and Token Request

--- a/config/config_suite_test.go
+++ b/config/config_suite_test.go
@@ -1,0 +1,12 @@
+package config_test
+
+import (
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	"testing"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Suite")
+}

--- a/config/paginate_params.go
+++ b/config/paginate_params.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"net/url"
 
 	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/google/go-querystring/query"
@@ -12,5 +13,19 @@ type PaginateParams struct {
 }
 
 func (p *PaginateParams) Values() (url.Values, error) {
+	if p.Limit < 1 {
+		p.Limit = 100
+	}
+
+	switch p.Direction {
+	case "":
+		p.Direction = "backwards"
+		break
+	case "backwards", "forwards":
+		break
+	default:
+		return url.Values{}, fmt.Errorf("Invalid value for direction: %s", p.Direction)
+	}
+
 	return query.Values(p)
 }

--- a/config/paginate_params.go
+++ b/config/paginate_params.go
@@ -10,6 +10,8 @@ import (
 type PaginateParams struct {
 	Limit     int    `url:"limit"`
 	Direction string `url:"direction"`
+
+	ScopeParams
 }
 
 func (p *PaginateParams) Values() (url.Values, error) {

--- a/config/paginate_params_test.go
+++ b/config/paginate_params_test.go
@@ -1,0 +1,55 @@
+package config_test
+
+import (
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	"github.com/ably/ably-go/config"
+)
+
+var _ = Describe("PaginationParams", func() {
+	var params config.PaginateParams
+
+	It("returns nil with no values", func() {
+		params = config.PaginateParams{}
+		values, err := params.Values()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(values).NotTo(BeNil())
+	})
+
+	Describe("Values", func() {
+		BeforeEach(func() {
+			params = config.PaginateParams{
+				Limit:     10,
+				Direction: "backwards",
+			}
+		})
+
+		It("does not return an error", func() {
+			_, err := params.Values()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("with invalid value for direction", func() {
+			BeforeEach(func() {
+				params.Direction = "unknown"
+			})
+
+			It("resets the value to the default", func() {
+				_, err := params.Values()
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("with invalid value for limit", func() {
+			BeforeEach(func() {
+				params.Limit = -1
+			})
+
+			It("resets the value to the default", func() {
+				values, err := params.Values()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(values.Get("limit")).To(Equal("100"))
+			})
+		})
+	})
+})

--- a/config/paginate_params_test.go
+++ b/config/paginate_params_test.go
@@ -29,6 +29,18 @@ var _ = Describe("PaginationParams", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
+		Context("with a value for ScopeParams", func() {
+			BeforeEach(func() {
+				params.Start = 123
+			})
+
+			It("creates a valid url", func() {
+				values, err := params.Values()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(values.Get("start")).To(Equal("123"))
+			})
+		})
+
 		Context("with invalid value for direction", func() {
 			BeforeEach(func() {
 				params.Direction = "unknown"

--- a/config/pagination_params.go
+++ b/config/pagination_params.go
@@ -1,0 +1,16 @@
+package config
+
+import (
+	"net/url"
+
+	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/google/go-querystring/query"
+)
+
+type PaginateParams struct {
+	Limit     int    `url:"limit"`
+	Direction string `url:"direction"`
+}
+
+func (p *PaginateParams) Values() (url.Values, error) {
+	return query.Values(p)
+}

--- a/config/scope_params.go
+++ b/config/scope_params.go
@@ -2,7 +2,23 @@ package config
 
 import "time"
 
+type TimestampMillisecond struct {
+	time.Time
+}
+
+func (t *TimestampMillisecond) ToInt() int64 {
+	return int64(time.Nanosecond * time.Duration(t.UnixNano()) / time.Millisecond)
+}
+
+// Get a timestamp in millisecond
+func NewTimestamp(t time.Time) int64 {
+	tm := TimestampMillisecond{Time: t}
+	return tm.ToInt()
+}
+
+// This needs to use a timestamp in millisecond
+// Use the previous function to generate them from a time.Time struct.
 type ScopeParams struct {
-	Start time.Time
-	End   time.Time
+	Start int64 `url:"start"`
+	End   int64 `url:"end"`
 }

--- a/config/scope_params.go
+++ b/config/scope_params.go
@@ -1,0 +1,8 @@
+package config
+
+import "time"
+
+type ScopeParams struct {
+	Start time.Time
+	End   time.Time
+}

--- a/protocol/paginated_resource.go
+++ b/protocol/paginated_resource.go
@@ -1,0 +1,74 @@
+package protocol
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+type PaginatedResource struct {
+	Response          *http.Response
+	Path              string
+	paginationHeaders map[string]string
+}
+
+const relLink = `<(?P<url>[^>]+)>; rel="(?P<rel>[^"]+)"`
+
+var relLinkRegexp = regexp.MustCompile(relLink)
+
+func (p *PaginatedResource) NextPage() (string, error) {
+	if p.GetPaginationHeaders()["next"] == "" {
+		return "", fmt.Errorf("No next page after %v", p.Path)
+	}
+
+	nextPage, err := p.BuildPath(p.Path, p.GetPaginationHeaders()["next"])
+	if err != nil {
+		return "", err
+	}
+
+	return nextPage, nil
+}
+
+func (p *PaginatedResource) BuildPath(path string, newRelativePath string) (string, error) {
+	oldURL, err := url.Parse("http://example.com" + path)
+	if err != nil {
+		return "", err
+	}
+
+	rootPath := strings.TrimRightFunc(oldURL.Path, func(r rune) bool {
+		return r != '/'
+	})
+
+	newPath := rootPath + strings.TrimLeft(newRelativePath, "./")
+
+	return newPath, nil
+}
+
+func (p *PaginatedResource) GetPaginationHeaders() map[string]string {
+	if len(p.paginationHeaders) > 0 {
+		return p.paginationHeaders
+	}
+
+	links := p.Response.Header["Link"]
+	p.paginationHeaders = map[string]string{}
+
+	for i := range links {
+		if result := relLinkRegexp.FindStringSubmatch(links[i]); result != nil {
+			p.addMatch(result)
+		}
+	}
+
+	return p.paginationHeaders
+}
+
+func (p *PaginatedResource) addMatch(matches []string) {
+	matchingNames := relLinkRegexp.SubexpNames()
+	matchMap := map[string]string{}
+	for i, value := range matches {
+		matchMap[matchingNames[i]] = value
+	}
+
+	p.paginationHeaders[matchMap["rel"]] = matchMap["url"]
+}

--- a/protocol/paginated_resource_test.go
+++ b/protocol/paginated_resource_test.go
@@ -1,0 +1,24 @@
+package protocol_test
+
+import (
+	"github.com/ably/ably-go/protocol"
+
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+)
+
+var _ = Describe("PaginatedResource", func() {
+	var paginatedResource protocol.PaginatedResource
+
+	Describe("BuildPath", func() {
+		BeforeEach(func() {
+			paginatedResource = protocol.PaginatedResource{}
+		})
+
+		It("returns a string pointing to the new path based on the given path", func() {
+			newPath, err := paginatedResource.BuildPath("/path/to/resource?hello", "./newresource?world")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(newPath).To(Equal("/path/to/newresource?world"))
+		})
+	})
+})

--- a/protocol/presence_message.go
+++ b/protocol/presence_message.go
@@ -9,11 +9,9 @@ const (
 )
 
 type PresenceMessage struct {
-	State           PresenceState `json:"state"`
-	ClientId        string        `json:"client_id"`
-	ClientData      *Data         `json:"clientData"`
-	MemberId        string        `json:"memberId"`
-	InheritMemberId string        `json:"inheritMemberId"`
-	ConnectionId    string        `json:"connectionId"`
-	InstanceId      string        `json:"instanceId"`
+	State        PresenceState `json:"action"`
+	ClientId     string        `json:"clientId"`
+	Data         string        `json:"data"`
+	ConnectionId string        `json:"connectionId"`
+	Timestamp    int64         `json:"timestamp"`
 }

--- a/protocol/presence_message.go
+++ b/protocol/presence_message.go
@@ -1,0 +1,19 @@
+package protocol
+
+type PresenceState int64
+
+const (
+	PresenceStateENTER PresenceState = iota
+	PresenceStateLEAVE
+	PresenceStateUPDATE
+)
+
+type PresenceMessage struct {
+	State           PresenceState `json:"state"`
+	ClientId        string        `json:"client_id"`
+	ClientData      *Data         `json:"clientData"`
+	MemberId        string        `json:"memberId"`
+	InheritMemberId string        `json:"inheritMemberId"`
+	ConnectionId    string        `json:"connectionId"`
+	InstanceId      string        `json:"instanceId"`
+}

--- a/protocol/protocol_suite_test.go
+++ b/protocol/protocol_suite_test.go
@@ -1,0 +1,12 @@
+package protocol_test
+
+import (
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+	"testing"
+)
+
+func TestProtocol(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Protocol Suite")
+}

--- a/protocol/types.go
+++ b/protocol/types.go
@@ -47,19 +47,19 @@ func (a Action) String() string {
 }
 
 type ProtocolMessage struct {
-	Action           Action      `json:"action"`
-	Flags            byte        `json:"flags,omitempty"`
-	Count            int         `json:"count,omitempty"`
-	Error            *Error      `json:"error,omitempty"`
-	ApplicationId    string      `json:"applicationId,omitempty"`
-	ConnectionId     string      `json:"connectionId,omitempty"`
-	ConnectionSerial int64       `json:"connectionSerial,omitempty"`
-	Channel          string      `json:"channel,omitempty"`
-	ChannelSerial    string      `json:"channelSerial,omitempty"`
-	MsgSerial        int64       `json:"msgSerial,omitempty"`
-	Timestamp        int64       `json:"timestamp,omitempty"`
-	Messages         []*Message  `json:"messages,omitempty"`
-	Presence         []*Presence `json:"presence,omitempty"`
+	Action           Action             `json:"action"`
+	Flags            byte               `json:"flags,omitempty"`
+	Count            int                `json:"count,omitempty"`
+	Error            *Error             `json:"error,omitempty"`
+	ApplicationId    string             `json:"applicationId,omitempty"`
+	ConnectionId     string             `json:"connectionId,omitempty"`
+	ConnectionSerial int64              `json:"connectionSerial,omitempty"`
+	Channel          string             `json:"channel,omitempty"`
+	ChannelSerial    string             `json:"channelSerial,omitempty"`
+	MsgSerial        int64              `json:"msgSerial,omitempty"`
+	Timestamp        int64              `json:"timestamp,omitempty"`
+	Messages         []*Message         `json:"messages,omitempty"`
+	Presence         []*PresenceMessage `json:"presence,omitempty"`
 }
 
 type Error struct {
@@ -102,21 +102,3 @@ type Data struct {
 	BinaryData []byte  `json:"binaryData"`
 	CipherData []byte  `json:"cipherData"`
 }
-
-type Presence struct {
-	State           PresenceState `json:"state"`
-	ClientId        string        `json:"client_id"`
-	ClientData      *Data         `json:"clientData"`
-	MemberId        string        `json:"memberId"`
-	InheritMemberId string        `json:"inheritMemberId"`
-	ConnectionId    string        `json:"connectionId"`
-	InstanceId      string        `json:"instanceId"`
-}
-
-type PresenceState int64
-
-const (
-	PresenceStateENTER PresenceState = iota
-	PresenceStateLEAVE
-	PresenceStateUPDATE
-)

--- a/rest/auth_test.go
+++ b/rest/auth_test.go
@@ -1,0 +1,23 @@
+package rest_test
+
+import (
+	"github.com/ably/ably-go/rest"
+
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+)
+
+var _ = Describe("Auth", func() {
+	Describe("RequestToken", func() {
+		It("gets a token from the API", func() {
+			ttl := 60 * 60
+			capability := &rest.Capability{"foo": []string{"publish"}}
+			token, err := client.Auth.RequestToken(ttl, capability)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(token.ID).To(ContainSubstring(testApp.Config.AppID))
+			Expect(token.Key).To(Equal(testApp.AppKeyId()))
+			Expect(token.Capability).To(Equal(capability))
+		})
+	})
+})

--- a/rest/channel.go
+++ b/rest/channel.go
@@ -3,9 +3,24 @@ package rest
 import "github.com/ably/ably-go/protocol"
 
 type Channel struct {
-	Name string
+	Name     string
+	Presence *Presence
 
 	client *Client
+}
+
+func newChannel(name string, client *Client) *Channel {
+	c := &Channel{
+		Name:   name,
+		client: client,
+	}
+
+	c.Presence = &Presence{
+		client:  client,
+		channel: c,
+	}
+
+	return c
 }
 
 func (c *Channel) Publish(name string, data interface{}) error {

--- a/rest/client.go
+++ b/rest/client.go
@@ -133,3 +133,21 @@ func (c *Client) Post(path string, in, out interface{}) (*http.Response, error) 
 func (c *Client) ok(status int) bool {
 	return status == http.StatusOK || status == http.StatusCreated
 }
+
+func (c *Client) buildPaginatedURL(url string, params *config.PaginateParams) (string, error) {
+	if params == nil {
+		return url, nil
+	}
+
+	values, err := params.Values()
+	if err != nil {
+		return "", err
+	}
+
+	queryString := values.Encode()
+	if len(queryString) > 0 {
+		url = url + "?" + queryString
+	}
+
+	return url, nil
+}

--- a/rest/client.go
+++ b/rest/client.go
@@ -56,7 +56,7 @@ func (c *Client) Channel(name string) *Channel {
 		return ch
 	}
 
-	ch := &Channel{Name: name, client: c}
+	ch := newChannel(name, c)
 	c.channels[name] = ch
 	return ch
 }

--- a/rest/client_test.go
+++ b/rest/client_test.go
@@ -71,19 +71,6 @@ var _ = Describe("Client", func() {
 		})
 	})
 
-	Describe("RequestToken", func() {
-		It("gets a token from the API", func() {
-			ttl := 60 * 60
-			capability := &rest.Capability{"foo": []string{"publish"}}
-			token, err := client.Auth.RequestToken(ttl, capability)
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(token.ID).To(ContainSubstring(testApp.Config.AppID))
-			Expect(token.Key).To(Equal(testApp.AppKeyId()))
-			Expect(token.Capability).To(Equal(capability))
-		})
-	})
-
 	Describe("Time", func() {
 		It("returns server time", func() {
 			t, err := client.Time()

--- a/rest/presence.go
+++ b/rest/presence.go
@@ -1,24 +1,32 @@
 package rest
 
-import "github.com/ably/ably-go/protocol"
+import (
+	"github.com/ably/ably-go/config"
+	"github.com/ably/ably-go/protocol"
+)
 
 type Presence struct {
 	client  *Client
 	channel *Channel
 }
 
-func (p *Presence) Get() ([]*protocol.PresenceMessage, error) {
+func (p *Presence) Get(params *config.PaginateParams) ([]*protocol.PresenceMessage, error) {
+	return p.clientGet("/channels/"+p.channel.Name+"/presence", params)
+}
+
+func (p *Presence) History(params *config.PaginateParams) ([]*protocol.PresenceMessage, error) {
+	return p.clientGet("/channels/"+p.channel.Name+"/presence/history", params)
+}
+
+func (p *Presence) clientGet(url string, params *config.PaginateParams) ([]*protocol.PresenceMessage, error) {
 	msgs := []*protocol.PresenceMessage{}
-	_, err := p.client.Get("/channels/"+p.channel.Name+"/presence", &msgs)
+
+	builtURL, err := p.client.buildPaginatedURL(url, params)
 	if err != nil {
 		return nil, err
 	}
-	return msgs, nil
-}
 
-func (p *Presence) History() ([]*protocol.PresenceMessage, error) {
-	msgs := []*protocol.PresenceMessage{}
-	_, err := p.client.Get("/channels/"+p.channel.Name+"/presence/history", &msgs)
+	_, err = p.client.Get(builtURL, &msgs)
 	if err != nil {
 		return nil, err
 	}

--- a/rest/presence.go
+++ b/rest/presence.go
@@ -12,8 +12,8 @@ type Presence struct {
 
 type PaginatedPresenceMessages struct {
 	paginatedResource *protocol.PaginatedResource
+	client            *Client
 
-	client  *Client
 	Current []*protocol.PresenceMessage
 }
 

--- a/rest/presence.go
+++ b/rest/presence.go
@@ -12,30 +12,18 @@ type Presence struct {
 
 type PaginatedPresenceMessages struct {
 	paginatedResource *protocol.PaginatedResource
-	client            *Client
+	presence          *Presence
 
 	Current []*protocol.PresenceMessage
 }
 
-func (pm *PaginatedPresenceMessages) NextPage() ([]*protocol.PresenceMessage, error) {
+func (pm *PaginatedPresenceMessages) NextPage() (*PaginatedPresenceMessages, error) {
 	path, err := pm.paginatedResource.NextPage()
 	if err != nil {
 		return nil, err
 	}
 
-	pm.Current = []*protocol.PresenceMessage{}
-
-	resp, err := pm.client.Get(path, &pm.Current)
-	if err != nil {
-		return nil, err
-	}
-
-	pm.paginatedResource = &protocol.PaginatedResource{
-		Response: resp,
-		Path:     path,
-	}
-
-	return pm.Current, nil
+	return pm.presence.clientGet(path, nil)
 }
 
 func (p *Presence) Get(params *config.PaginateParams) (*PaginatedPresenceMessages, error) {
@@ -64,8 +52,8 @@ func (p *Presence) clientGet(url string, params *config.PaginateParams) (*Pagina
 			Response: resp,
 			Path:     builtURL,
 		},
-		client:  p.client,
-		Current: msgs,
+		presence: p,
+		Current:  msgs,
 	}
 
 	return paginatedMessages, nil

--- a/rest/presence.go
+++ b/rest/presence.go
@@ -1,0 +1,26 @@
+package rest
+
+import "github.com/ably/ably-go/protocol"
+
+type Presence struct {
+	client  *Client
+	channel *Channel
+}
+
+func (p *Presence) Get() ([]*protocol.PresenceMessage, error) {
+	msgs := []*protocol.PresenceMessage{}
+	_, err := p.client.Get("/channels/"+p.channel.Name+"/presence", &msgs)
+	if err != nil {
+		return nil, err
+	}
+	return msgs, nil
+}
+
+func (p *Presence) History() ([]*protocol.PresenceMessage, error) {
+	msgs := []*protocol.PresenceMessage{}
+	_, err := p.client.Get("/channels/"+p.channel.Name+"/presence/history", &msgs)
+	if err != nil {
+		return nil, err
+	}
+	return msgs, nil
+}

--- a/rest/presence_test.go
+++ b/rest/presence_test.go
@@ -1,6 +1,8 @@
 package rest_test
 
 import (
+	"time"
+
 	"github.com/ably/ably-go/config"
 	"github.com/ably/ably-go/protocol"
 	"github.com/ably/ably-go/rest"
@@ -48,11 +50,30 @@ var _ = Describe("Presence", func() {
 		Describe("History", func() {
 			It("returns a list of presence messages", func() {
 				paginatedMessages, err := presence.History(nil)
-				messages := paginatedMessages.Current
 				Expect(err).NotTo(HaveOccurred())
+
+				messages := paginatedMessages.Current
 				Expect(messages).To(BeAssignableToTypeOf([]*protocol.PresenceMessage{}))
 				Expect(len(messages)).To(Equal(len(testApp.Config.Channels[0].Presence)))
 			})
+
+			Context("with start and end time", func() {
+				It("can return older items from a certain date given a start / end timestamp", func() {
+					params := &config.PaginateParams{
+						ScopeParams: config.ScopeParams{
+							Start: config.NewTimestamp(time.Now().Add(-24 * time.Hour)),
+							End:   config.NewTimestamp(time.Now()),
+						},
+					}
+					paginatedMessages, err := presence.History(params)
+					Expect(err).NotTo(HaveOccurred())
+
+					messages := paginatedMessages.Current
+					Expect(messages).To(BeAssignableToTypeOf([]*protocol.PresenceMessage{}))
+					Expect(len(messages)).To(Equal(len(testApp.Config.Channels[0].Presence)))
+				})
+			})
+
 		})
 	})
 })

--- a/rest/presence_test.go
+++ b/rest/presence_test.go
@@ -1,0 +1,32 @@
+package rest_test
+
+import (
+	"github.com/ably/ably-go/protocol"
+
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
+)
+
+var _ = FDescribe("Presence", func() {
+	BeforeEach(func() {
+		channel = client.Channel("persisted:presence_fixtures")
+	})
+
+	Describe("Get", func() {
+		It("returns a list of members", func() {
+			members, err := channel.Presence.Get()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(members).To(BeAssignableToTypeOf([]*protocol.PresenceMessage{}))
+			Expect(len(members)).To(Equal(len(testApp.Config.Channels[0].Presence)))
+		})
+	})
+
+	Describe("History", func() {
+		It("returns a list of presence messages", func() {
+			presenceMessages, err := channel.Presence.History()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(presenceMessages).To(BeAssignableToTypeOf([]*protocol.PresenceMessage{}))
+			Expect(len(presenceMessages)).To(Equal(len(testApp.Config.Channels[0].Presence)))
+		})
+	})
+})

--- a/rest/presence_test.go
+++ b/rest/presence_test.go
@@ -22,8 +22,8 @@ var _ = Describe("Presence", func() {
 
 		Describe("Get", func() {
 			It("returns current members on the channel", func() {
-				paginatedMessages, err := presence.Get(nil)
-				messages := paginatedMessages.Current
+				members, err := presence.Get(nil)
+				messages := members.Current
 				Expect(err).NotTo(HaveOccurred())
 				Expect(messages).To(BeAssignableToTypeOf([]*protocol.PresenceMessage{}))
 				Expect(len(messages)).To(Equal(len(testApp.Config.Channels[0].Presence)))
@@ -31,17 +31,19 @@ var _ = Describe("Presence", func() {
 
 			Context("with a limit option", func() {
 				It("returns a paginated response", func() {
-					paginatedMessages, err := presence.Get(&config.PaginateParams{Limit: 2})
-					messagesSet1 := paginatedMessages.Current
+					members1, err := presence.Get(&config.PaginateParams{Limit: 2})
+					messagesSet1 := members1.Current
 					Expect(err).NotTo(HaveOccurred())
 					Expect(len(messagesSet1)).To(Equal(2))
 
-					messagesSet2, err := paginatedMessages.NextPage()
+					members2, err := members1.NextPage()
 					Expect(err).NotTo(HaveOccurred())
+
+					messagesSet2 := members2.Current
 					Expect(len(messagesSet2)).To(Equal(2))
 					Expect(messagesSet1).NotTo(Equal(messagesSet2))
 
-					_, err = paginatedMessages.NextPage()
+					_, err = members2.NextPage()
 					Expect(err).To(HaveOccurred())
 				})
 			})
@@ -49,10 +51,10 @@ var _ = Describe("Presence", func() {
 
 		Describe("History", func() {
 			It("returns a list of presence messages", func() {
-				paginatedMessages, err := presence.History(nil)
+				members, err := presence.History(nil)
 				Expect(err).NotTo(HaveOccurred())
 
-				messages := paginatedMessages.Current
+				messages := members.Current
 				Expect(messages).To(BeAssignableToTypeOf([]*protocol.PresenceMessage{}))
 				Expect(len(messages)).To(Equal(len(testApp.Config.Channels[0].Presence)))
 			})
@@ -65,10 +67,10 @@ var _ = Describe("Presence", func() {
 							End:   config.NewTimestamp(time.Now()),
 						},
 					}
-					paginatedMessages, err := presence.History(params)
+					members, err := presence.History(params)
 					Expect(err).NotTo(HaveOccurred())
 
-					messages := paginatedMessages.Current
+					messages := members.Current
 					Expect(messages).To(BeAssignableToTypeOf([]*protocol.PresenceMessage{}))
 					Expect(len(messages)).To(Equal(len(testApp.Config.Channels[0].Presence)))
 				})

--- a/rest/presence_test.go
+++ b/rest/presence_test.go
@@ -1,32 +1,47 @@
 package rest_test
 
 import (
+	"github.com/ably/ably-go/config"
 	"github.com/ably/ably-go/protocol"
+	"github.com/ably/ably-go/rest"
 
 	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
 	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 )
 
-var _ = FDescribe("Presence", func() {
-	BeforeEach(func() {
-		channel = client.Channel("persisted:presence_fixtures")
-	})
+var _ = Describe("Presence", func() {
+	Context("tested against presence fixture data set up in test app", func() {
+		var presence *rest.Presence
 
-	Describe("Get", func() {
-		It("returns a list of members", func() {
-			members, err := channel.Presence.Get()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(members).To(BeAssignableToTypeOf([]*protocol.PresenceMessage{}))
-			Expect(len(members)).To(Equal(len(testApp.Config.Channels[0].Presence)))
+		BeforeEach(func() {
+			channel = client.Channel("persisted:presence_fixtures")
+			presence = channel.Presence
 		})
-	})
 
-	Describe("History", func() {
-		It("returns a list of presence messages", func() {
-			presenceMessages, err := channel.Presence.History()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(presenceMessages).To(BeAssignableToTypeOf([]*protocol.PresenceMessage{}))
-			Expect(len(presenceMessages)).To(Equal(len(testApp.Config.Channels[0].Presence)))
+		Describe("Get", func() {
+			It("returns current members on the channel", func() {
+				members, err := presence.Get(nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(members).To(BeAssignableToTypeOf([]*protocol.PresenceMessage{}))
+				Expect(len(members)).To(Equal(len(testApp.Config.Channels[0].Presence)))
+			})
+
+			Context("with a limit option", func() {
+				It("returns a paginated response", func() {
+					members, err := presence.Get(&config.PaginateParams{Limit: 2})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(len(members)).To(Equal(2))
+				})
+			})
+		})
+
+		Describe("History", func() {
+			It("returns a list of presence messages", func() {
+				presenceMessages, err := presence.History(nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(presenceMessages).To(BeAssignableToTypeOf([]*protocol.PresenceMessage{}))
+				Expect(len(presenceMessages)).To(Equal(len(testApp.Config.Channels[0].Presence)))
+			})
 		})
 	})
 })

--- a/rest/presence_test.go
+++ b/rest/presence_test.go
@@ -20,27 +20,38 @@ var _ = Describe("Presence", func() {
 
 		Describe("Get", func() {
 			It("returns current members on the channel", func() {
-				members, err := presence.Get(nil)
+				paginatedMessages, err := presence.Get(nil)
+				messages := paginatedMessages.Current
 				Expect(err).NotTo(HaveOccurred())
-				Expect(members).To(BeAssignableToTypeOf([]*protocol.PresenceMessage{}))
-				Expect(len(members)).To(Equal(len(testApp.Config.Channels[0].Presence)))
+				Expect(messages).To(BeAssignableToTypeOf([]*protocol.PresenceMessage{}))
+				Expect(len(messages)).To(Equal(len(testApp.Config.Channels[0].Presence)))
 			})
 
 			Context("with a limit option", func() {
 				It("returns a paginated response", func() {
-					members, err := presence.Get(&config.PaginateParams{Limit: 2})
+					paginatedMessages, err := presence.Get(&config.PaginateParams{Limit: 2})
+					messagesSet1 := paginatedMessages.Current
 					Expect(err).NotTo(HaveOccurred())
-					Expect(len(members)).To(Equal(2))
+					Expect(len(messagesSet1)).To(Equal(2))
+
+					messagesSet2, err := paginatedMessages.NextPage()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(len(messagesSet2)).To(Equal(2))
+					Expect(messagesSet1).NotTo(Equal(messagesSet2))
+
+					_, err = paginatedMessages.NextPage()
+					Expect(err).To(HaveOccurred())
 				})
 			})
 		})
 
 		Describe("History", func() {
 			It("returns a list of presence messages", func() {
-				presenceMessages, err := presence.History(nil)
+				paginatedMessages, err := presence.History(nil)
+				messages := paginatedMessages.Current
 				Expect(err).NotTo(HaveOccurred())
-				Expect(presenceMessages).To(BeAssignableToTypeOf([]*protocol.PresenceMessage{}))
-				Expect(len(presenceMessages)).To(Equal(len(testApp.Config.Channels[0].Presence)))
+				Expect(messages).To(BeAssignableToTypeOf([]*protocol.PresenceMessage{}))
+				Expect(len(messages)).To(Equal(len(testApp.Config.Channels[0].Presence)))
 			})
 		})
 	})

--- a/test/support/test_app.go
+++ b/test/support/test_app.go
@@ -24,8 +24,8 @@ type testAppKey struct {
 }
 
 type testAppPresenceConfig struct {
-	ClientID   string `json:"clientId"`
-	ClientData string `json:"clientData"`
+	ClientID string `json:"clientId"`
+	Data     string `json:"data"`
 }
 
 type testAppChannels struct {
@@ -161,10 +161,10 @@ func NewTestApp() *TestApp {
 				{
 					Name: "persisted:presence_fixtures",
 					Presence: []testAppPresenceConfig{
-						{ClientID: "client_bool", ClientData: "true"},
-						{ClientID: "client_int", ClientData: "true"},
-						{ClientID: "client_string", ClientData: "true"},
-						{ClientID: "client_json", ClientData: "{ \"test\" => 'This is a JSONObject clientData payload'}"},
+						{ClientID: "client_bool", Data: "true"},
+						{ClientID: "client_int", Data: "true"},
+						{ClientID: "client_string", Data: "true"},
+						{ClientID: "client_json", Data: "{ \"test\" => 'This is a JSONObject clientData payload'}"},
 					},
 				},
 			},


### PR DESCRIPTION
Get presence and presence history. I added the paginated result struct that will also be used in `channel.History()`.

I don't cover encryption yet, and I will certainly move on to adding the pagination to history first before hitting the encryption/auth subject.

As a side note, since overloading is not a thing in go, the normal call to `Presence.Get` and `Presence.History` have a `PaginatedPresenceMessages` parameter. Anyway the java library seems to do the same and even use `asArray()` to transform the paginated object in an array of messages. I use `paginatedPresenceMessages.Current` but I could just do the same as the java library on this point if necessary.

cc/ @mattheworiordan @paddybyers 