### PR TITLE
Don't verify hostname if HTTP_PROXY is set

### DIFF
--- a/config/params.go
+++ b/config/params.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"log"
+	"net/http"
 	"os"
 	"strings"
 )
@@ -25,6 +26,8 @@ type Params struct {
 
 	Protocol ProtocolType
 	Tls      bool
+
+	HTTPClient *http.Client
 
 	AblyLogger *AblyLogger
 	LogLevel   string

--- a/rest/client.go
+++ b/rest/client.go
@@ -19,7 +19,7 @@ type Client struct {
 	RestEndpoint string
 	Protocol     config.ProtocolType
 
-	HttpClient *http.Client
+	HTTPClient *http.Client
 
 	channels map[string]*Channel
 	chanMtx  sync.Mutex
@@ -28,7 +28,7 @@ type Client struct {
 func NewClient(params config.Params) *Client {
 	client := &Client{
 		RestEndpoint: params.RestEndpoint,
-		HttpClient:   http.DefaultClient,
+		HTTPClient:   params.HTTPClient,
 		channels:     make(map[string]*Channel),
 	}
 
@@ -36,6 +36,13 @@ func NewClient(params config.Params) *Client {
 	client.Protocol = params.Protocol
 
 	return client
+}
+
+func (c *Client) httpclient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return http.DefaultClient
 }
 
 func (c *Client) Time() (*time.Time, error) {
@@ -75,7 +82,7 @@ func (c *Client) Get(path string, out interface{}) (*http.Response, error) {
 	}
 	req.Header.Set("Accept", "application/json")
 	req.SetBasicAuth(c.Auth.AppID, c.Auth.AppSecret)
-	res, err := c.HttpClient.Do(req)
+	res, err := c.httpclient().Do(req)
 
 	if err != nil {
 		return nil, err
@@ -106,7 +113,7 @@ func (c *Client) Post(path string, in, out interface{}) (*http.Response, error) 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 	req.SetBasicAuth(c.Auth.AppID, c.Auth.AppSecret)
-	res, err := c.HttpClient.Do(req)
+	res, err := c.httpclient().Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/rest/client_test.go
+++ b/rest/client_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Client", func() {
 			}))
 
 			client.RestEndpoint = strings.Replace(client.RestEndpoint, "https", "http", 1)
-			client.HttpClient = createMockedClient(server)
+			client.HTTPClient = createMockedClient(server)
 
 			var err error
 			request, err = http.NewRequest("POST", client.RestEndpoint+"/any_path", bytes.NewBuffer([]byte{}))
@@ -110,7 +110,7 @@ var _ = Describe("Client", func() {
 				client = ably.NewRestClient(testParamsCopy)
 
 				client.RestEndpoint = strings.Replace(client.RestEndpoint, "https", "http", 1)
-				client.HttpClient = createMockedClient(server)
+				client.HTTPClient = createMockedClient(server)
 
 				err := client.Channel("test").Publish("ping", "pong")
 				Expect(err).NotTo(HaveOccurred())
@@ -130,7 +130,7 @@ var _ = Describe("Client", func() {
 				client = ably.NewRestClient(testParamsCopy)
 
 				client.RestEndpoint = strings.Replace(client.RestEndpoint, "https", "http", 1)
-				client.HttpClient = createMockedClient(server)
+				client.HTTPClient = createMockedClient(server)
 
 				err := client.Channel("test").Publish("ping", "pong")
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Non-invasive CL for tests, to make them work with `HTTP_PROXY` env - useful for inspecting payloads with MITM proxies.