### PR TITLE
rest: improve RestClient API

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,11 @@ TODO
 All examples assume a client and/or channel has been created as follows:
 
 ```go
-client := ably.NewRestClient(ably.ClientOptions{ApiKey: "xxxx"})
-channel := client.Channel('test')
+client, err := ably.NewRestClient(&ably.ClientOptions{Key: "xxx:xxx"})
+if err != nil {
+	panic(err)
+}
+channel := client.Channel("test")
 ```
 
 ### Publishing a message to a channel

--- a/ably/ably_suite_test.go
+++ b/ably/ably_suite_test.go
@@ -28,7 +28,9 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = BeforeEach(func() {
-	client = ably.NewRestClient(testApp.Options)
+	var err error
+	client, err = ably.NewRestClient(testApp.Options())
+	Expect(err).NotTo(HaveOccurred())
 	channel = client.Channel("test")
 })
 

--- a/ably/auth.go
+++ b/ably/auth.go
@@ -12,8 +12,6 @@ import (
 	"github.com/ably/ably-go/Godeps/_workspace/src/github.com/flynn/flynn/pkg/random"
 )
 
-// TODO(rjeczalik): add support for :query_time
-
 type Capability map[string][]string
 
 func (c Capability) MarshalJSON() ([]byte, error) {
@@ -88,21 +86,16 @@ func (req *TokenRequest) sign(secret []byte) {
 }
 
 type Auth struct {
-	Options *ClientOptions
-	client  *RestClient
-}
-
-func NewAuth(options *ClientOptions, client *RestClient) *Auth {
-	return &Auth{
-		Options: options,
-		client:  client,
-	}
+	options   ClientOptions
+	client    *RestClient
+	keyName   string
+	keySecret string
 }
 
 func (a *Auth) CreateTokenRequest() *TokenRequest {
 	return &TokenRequest{
-		KeyName:  a.Options.Token,
-		ClientID: a.Options.ClientID,
+		KeyName:  a.keyName,
+		ClientID: a.options.ClientID,
 	}
 }
 
@@ -110,7 +103,7 @@ func (a *Auth) RequestToken(req *TokenRequest) (*Token, error) {
 	if req == nil {
 		req = a.CreateTokenRequest()
 	}
-	req.sign([]byte(a.Options.Secret))
+	req.sign([]byte(a.keySecret))
 	resp := &Token{}
 	_, err := a.client.Post("/keys/"+req.KeyName+"/requestToken", req, resp)
 	if err != nil {

--- a/ably/auth_test.go
+++ b/ably/auth_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Auth", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(token.Token).To(ContainSubstring(testApp.Config.ApiID))
-			Expect(token.KeyName).To(Equal(testApp.AppKeyId()))
+			Expect(token.KeyName).To(Equal(testApp.KeyName()))
 			Expect(token.Issued).NotTo(Equal(int64(0)))
 			Expect(token.Capability).To(Equal(req.Capability))
 		})

--- a/ably/export_test.go
+++ b/ably/export_test.go
@@ -1,6 +1,6 @@
 package ably
 
-func (p *PaginatedResource) BuildPath(base, rel string) (string, error) {
+func (p *PaginatedResult) BuildPath(base, rel string) (string, error) {
 	return p.buildPath(base, rel)
 }
 

--- a/ably/export_test.go
+++ b/ably/export_test.go
@@ -1,5 +1,13 @@
 package ably
 
-var BuildPath = func(p *PaginatedResource, base, rel string) (string, error) {
+func (p *PaginatedResource) BuildPath(base, rel string) (string, error) {
 	return p.buildPath(base, rel)
+}
+
+func (opts *ClientOptions) RestURL() string {
+	return opts.restURL()
+}
+
+func (opts *ClientOptions) RealtimeURL() string {
+	return opts.realtimeURL()
 }

--- a/ably/paginated_resource_test.go
+++ b/ably/paginated_resource_test.go
@@ -16,7 +16,7 @@ var _ = Describe("PaginatedResource", func() {
 		})
 
 		It("returns a string pointing to the new path based on the given path", func() {
-			newPath, err := ably.BuildPath(&paginatedResource, "/path/to/resource?hello", "./newresource?world")
+			newPath, err := paginatedResource.BuildPath("/path/to/resource?hello", "./newresource?world")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(newPath).To(Equal("/path/to/newresource?world"))
 		})

--- a/ably/paginated_result_test.go
+++ b/ably/paginated_result_test.go
@@ -7,16 +7,16 @@ import (
 	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 )
 
-var _ = Describe("PaginatedResource", func() {
-	var paginatedResource ably.PaginatedResource
+var _ = Describe("PaginatedResult", func() {
+	var result *ably.PaginatedResult
 
 	Describe("BuildPath", func() {
 		BeforeEach(func() {
-			paginatedResource = ably.PaginatedResource{}
+			result = &ably.PaginatedResult{}
 		})
 
 		It("returns a string pointing to the new path based on the given path", func() {
-			newPath, err := paginatedResource.BuildPath("/path/to/resource?hello", "./newresource?world")
+			newPath, err := result.BuildPath("/path/to/resource?hello", "./newresource?world")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(newPath).To(Equal("/path/to/newresource?world"))
 		})

--- a/ably/realtime_channel_test.go
+++ b/ably/realtime_channel_test.go
@@ -11,11 +11,13 @@ var _ = Describe("RealtimeChannel", func() {
 	var (
 		client  *ably.RealtimeClient
 		channel *ably.RealtimeChannel
+		err     error
 	)
 
 	BeforeEach(func() {
-		client = ably.NewRealtimeClient(testApp.Options)
-		channel = client.RealtimeChannel("test")
+		client, err = ably.NewRealtimeClient(*testApp.Options())
+		channel = client.Channel("test")
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {

--- a/ably/realtime_connection_test.go
+++ b/ably/realtime_connection_test.go
@@ -10,10 +10,14 @@ import (
 )
 
 var _ = Describe("Connection", func() {
-	var client *ably.RealtimeClient
+	var (
+		client *ably.RealtimeClient
+		err    error
+	)
 
 	BeforeEach(func() {
-		client = ably.NewRealtimeClient(testApp.Options)
+		client, err = ably.NewRealtimeClient(*testApp.Options())
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {

--- a/ably/rest_channel.go
+++ b/ably/rest_channel.go
@@ -14,12 +14,10 @@ func newRestChannel(name string, client *RestClient) *RestChannel {
 		Name:   name,
 		client: client,
 	}
-
 	c.Presence = &RestPresence{
 		client:  client,
 		channel: c,
 	}
-
 	return c
 }
 
@@ -35,13 +33,10 @@ func (c *RestChannel) Publish(name string, data string) error {
 // using the Rest API.
 func (c *RestChannel) PublishAll(messages []*proto.Message) error {
 	res, err := c.client.Post("/channels/"+c.Name+"/messages", messages, nil)
-
 	if err != nil {
 		return err
 	}
-
-	defer res.Body.Close()
-
+	res.Body.Close()
 	return nil
 }
 

--- a/ably/rest_channel.go
+++ b/ably/rest_channel.go
@@ -41,9 +41,9 @@ func (c *RestChannel) PublishAll(messages []*proto.Message) error {
 }
 
 // History gives the channel's message history according to the given parameters.
-// The returned resource can be inspected for the messages via the Messages()
+// The returned result can be inspected for the messages via the Messages()
 // method.
-func (c *RestChannel) History(params *PaginateParams) (*PaginatedResource, error) {
+func (c *RestChannel) History(params *PaginateParams) (*PaginatedResult, error) {
 	path := "/channels/" + c.Name + "/history"
-	return newPaginatedResource(msgType, path, params, query(c.client.Get))
+	return newPaginatedResult(msgType, path, params, query(c.client.Get))
 }

--- a/ably/rest_channel_test.go
+++ b/ably/rest_channel_test.go
@@ -1,10 +1,11 @@
 package ably_test
 
 import (
-	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
-	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 	"github.com/ably/ably-go/ably"
 	"github.com/ably/ably-go/ably/proto"
+
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/ably/ably-go/Godeps/_workspace/src/github.com/onsi/gomega"
 )
 
 var _ = Describe("RestChannel", func() {
@@ -24,6 +25,7 @@ var _ = Describe("RestChannel", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			messages := page.Messages()
+			Expect(len(messages)).NotTo(Equal(0))
 			Expect(messages[0].Name).To(Equal(event))
 			Expect(messages[0].Data).To(Equal(message))
 		})

--- a/ably/rest_client.go
+++ b/ably/rest_client.go
@@ -80,10 +80,10 @@ func (c *RestClient) Channel(name string) *RestChannel {
 }
 
 // Stats gives the channel's metrics according to the given parameters.
-// The returned resource can be inspected for the statistics via the Stats()
+// The returned result can be inspected for the statistics via the Stats()
 // method.
-func (c *RestClient) Stats(params *PaginateParams) (*PaginatedResource, error) {
-	return newPaginatedResource(statType, "/stats", params, query(c.Get))
+func (c *RestClient) Stats(params *PaginateParams) (*PaginatedResult, error) {
+	return newPaginatedResult(statType, "/stats", params, query(c.Get))
 }
 
 func (c *RestClient) Get(path string, out interface{}) (*http.Response, error) {

--- a/ably/rest_http_error.go
+++ b/ably/rest_http_error.go
@@ -6,15 +6,16 @@ import (
 )
 
 type RestHttpError struct {
-	Msg      string
-	Response *http.Response
-
+	Msg          string
 	ResponseBody string
+
+	resp *http.Response
 }
 
-func NewRestHttpError(response *http.Response, message string) *RestHttpError {
-	err := &RestHttpError{Response: response, Msg: message}
+func NewRestHttpError(resp *http.Response, message string) *RestHttpError {
+	err := &RestHttpError{Msg: message, resp: resp}
 	err.readBody()
+	err.resp = nil
 	return err
 }
 
@@ -23,12 +24,12 @@ func (e *RestHttpError) Error() string {
 }
 
 func (e *RestHttpError) readBody() {
-	if e.Response == nil {
+	if e.resp == nil {
 		return
 	}
-
-	if body, err := ioutil.ReadAll(e.Response.Body); err == nil {
-		defer e.Response.Body.Close()
+	body, err := ioutil.ReadAll(e.resp.Body)
+	e.resp.Body.Close()
+	if err == nil {
 		e.ResponseBody = string(body)
 	}
 }

--- a/ably/rest_presence.go
+++ b/ably/rest_presence.go
@@ -6,17 +6,17 @@ type RestPresence struct {
 }
 
 // Get gives the channel's presence messages according to the given parameters.
-// The returned resource can be inspected for the presence messages via
+// The returned result can be inspected for the presence messages via
 // the PresenceMessages() method.
-func (p *RestPresence) Get(params *PaginateParams) (*PaginatedResource, error) {
+func (p *RestPresence) Get(params *PaginateParams) (*PaginatedResult, error) {
 	path := "/channels/" + p.channel.Name + "/presence"
-	return newPaginatedResource(presMsgType, path, params, query(p.client.Get))
+	return newPaginatedResult(presMsgType, path, params, query(p.client.Get))
 }
 
 // History gives the channel's presence messages history according to the given
-// parameters. The returned resource can be inspected for the presence messages
+// parameters. The returned result can be inspected for the presence messages
 // via the PresenceMessages() method.
-func (p *RestPresence) History(params *PaginateParams) (*PaginatedResource, error) {
+func (p *RestPresence) History(params *PaginateParams) (*PaginatedResult, error) {
 	path := "/channels/" + p.channel.Name + "/presence/history"
-	return newPaginatedResource(presMsgType, path, params, query(p.client.Get))
+	return newPaginatedResult(presMsgType, path, params, query(p.client.Get))
 }

--- a/ably/rest_presence_test.go
+++ b/ably/rest_presence_test.go
@@ -12,6 +12,7 @@ import (
 var _ = Describe("Presence", func() {
 	Context("tested against presence fixture data set up in test app", func() {
 		var presence *ably.RestPresence
+		var channel *ably.RestChannel
 
 		BeforeEach(func() {
 			channel = client.Channel("persisted:presence_fixtures")


### PR DESCRIPTION
This CL cleans up RestClient API, fixing couple of incosistencies and
shortcommings, like:

  - when (*RestClient).Options is changed by the user, changes are
    not reflected in *Auth
  - all the tests were modyfing global client instance, not it's more
    COW like
  - ~~RestClient and ClientOptions are fully zero-value friendly~~
  - ClientOptions properly manages TLS / NoTLS transitions

RestClient would require more work, like support for token auth
(it's using BasicAuth for requests), proper TLS/NoTLS testing. This is
what I've seen from the code itself, possibly there's more if compared
to SPEC.md.

~~Changes in Go API:~~

- ~~added function for initializing RestClient from key:~~

  ```
  client, err := ably.NewRestClient("xxx:xxx")
  ```

- ~~RestClient can be initialized from ClientOptions for more control
  over behaviour: (added correct handling of zero-value struct)~~

  ```
  opts := &ably.ClientOptions{Token: "xxx", Secret: "xxx"}
  client := &alby.RestClient{Options: opts}
  ```

- ~~ClientOptions has no `Key` nor `NoTLS` fields, as it's not possible to
  keep them in sync with dependant fields like Token, Secret for Key or
  RestEndpoint, RealtimeEndpoint for `NoTLS`, e.g.~~

  ```go
  /* old API */
  client := ably.NewRestClient(&ably.Options{Key: "xxx:xxx"})
  // ...
  client.Options.Key = "yyy:yyy"
  // all calls to REST API are going to fail, as Token and Secret fields
  // are still "xxx"

  /* new API */
  client, err := ably.NewRestClient("xxx:xxx")
  // ...
  err := client.Options.SetKey("yyy:yyy")
  // correctly handled here
  ```

~~The same applies to NoTLS, where flipping its value should rewrite URLs
of RestEndpoint and RealtimeEndpoint. With new API it's done with:~~

  ```go
  client.SetTLS(false)
  ```

/cc @kouno Please take a look.

BTW I have trello dashboard for ably-go, as I needed to store somewhere my thoughts while working with current library: https://trello.com/b/pHESio8l/ably-go