### PR TITLE
fix RealtimePresence race; add StateEnum type

### DIFF
--- a/ably/realtime_channel_test.go
+++ b/ably/realtime_channel_test.go
@@ -91,7 +91,7 @@ func TestRealtimeChannel_Subscribe(t *testing.T) {
 	}
 }
 
-var chanCloseTransitions = []int{
+var chanCloseTransitions = [][]ably.StateEnum{{
 	ably.StateConnConnecting,
 	ably.StateChanAttaching,
 	ably.StateConnConnected,
@@ -100,7 +100,16 @@ var chanCloseTransitions = []int{
 	ably.StateChanDetached,
 	ably.StateConnClosing,
 	ably.StateConnClosed,
-}
+}, {
+	ably.StateConnConnecting,
+	ably.StateConnConnected,
+	ably.StateChanAttaching,
+	ably.StateChanAttached,
+	ably.StateChanDetaching,
+	ably.StateChanDetached,
+	ably.StateConnClosing,
+	ably.StateConnClosed,
+}}
 
 func TestRealtimeChannel_Close(t *testing.T) {
 	states, listen, wg := record()
@@ -146,7 +155,10 @@ func TestRealtimeChannel_Close(t *testing.T) {
 	}
 	close(listen)
 	wg.Wait()
-	if !reflect.DeepEqual(*states, chanCloseTransitions) {
-		t.Fatalf("expected states=%v; got %v", chanCloseTransitions, states)
+	for _, expected := range chanCloseTransitions {
+		if reflect.DeepEqual(*states, expected) {
+			return
+		}
 	}
+	t.Fatalf("unexpected state transitions %v", *states)
 }

--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -78,7 +78,7 @@ func (c *Conn) Connect() (Result, error) {
 	return c.connect(true)
 }
 
-var connectResultStates = []int{
+var connectResultStates = []StateEnum{
 	StateConnConnected, // expected state
 	StateConnFailed,
 	StateConnDisconnected,
@@ -138,7 +138,7 @@ func (c *Conn) Close() error {
 	return nil
 }
 
-var closeResultStates = []int{
+var closeResultStates = []StateEnum{
 	StateConnClosed, // expected state
 	StateConnFailed,
 	StateConnDisconnected,
@@ -204,7 +204,7 @@ func (c *Conn) Serial() int64 {
 }
 
 // State returns current state of the connection.
-func (c *Conn) State() int {
+func (c *Conn) State() StateEnum {
 	c.state.Lock()
 	defer c.state.Unlock()
 	return c.state.current
@@ -217,7 +217,7 @@ func (c *Conn) State() int {
 // If no states are given, c is registered for all of them.
 // If c is nil, the method panics.
 // If c is alreadt registered, its state set is expanded.
-func (c *Conn) On(ch chan<- State, states ...int) {
+func (c *Conn) On(ch chan<- State, states ...StateEnum) {
 	c.state.on(ch, states...)
 }
 
@@ -226,7 +226,7 @@ func (c *Conn) On(ch chan<- State, states ...int) {
 // If no states are given, c is removed for all of the connection's states.
 // If c is nil, the method panics.
 // If c was not registered or is already removed, the method is a nop.
-func (c *Conn) Off(ch chan<- State, states ...int) {
+func (c *Conn) Off(ch chan<- State, states ...StateEnum) {
 	c.state.off(ch, states...)
 }
 

--- a/ably/realtime_conn_test.go
+++ b/ably/realtime_conn_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/ably/ably-go/ably/testutil"
 )
 
-func record() (*[]int, chan<- ably.State, *sync.WaitGroup) {
+func record() (*[]ably.StateEnum, chan<- ably.State, *sync.WaitGroup) {
 	listen := make(chan ably.State, 16)
-	states := make([]int, 0, 16)
+	states := make([]ably.StateEnum, 0, 16)
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
-	go func(states *[]int) {
+	go func(states *[]ably.StateEnum) {
 		defer wg.Done()
 		for state := range listen {
 			*states = append(*states, state.State)
@@ -25,13 +25,12 @@ func record() (*[]int, chan<- ably.State, *sync.WaitGroup) {
 	return &states, listen, wg
 }
 
-func await(fn func() int, state int) error {
+func await(fn func() ably.StateEnum, state ably.StateEnum) error {
 	t := time.After(timeout)
 	for {
 		select {
 		case <-t:
-			return fmt.Errorf("waiting for %s state has timed out after %v",
-				ably.StateText(state), timeout)
+			return fmt.Errorf("waiting for %s state has timed out after %v", state, timeout)
 		default:
 			if fn() == state {
 				return nil
@@ -40,7 +39,7 @@ func await(fn func() int, state int) error {
 	}
 }
 
-var connTransitions = []int{
+var connTransitions = []ably.StateEnum{
 	ably.StateConnConnecting,
 	ably.StateConnConnected,
 	ably.StateConnClosing,
@@ -84,7 +83,7 @@ func TestRealtimeConn_NoConnect(t *testing.T) {
 	}
 }
 
-var connCloseTransitions = []int{
+var connCloseTransitions = []ably.StateEnum{
 	ably.StateConnConnecting,
 	ably.StateConnConnected,
 	ably.StateConnClosing,

--- a/ably/realtime_presence_test.go
+++ b/ably/realtime_presence_test.go
@@ -37,9 +37,12 @@ func TestRealtimePresence_Sync(t *testing.T) {
 	app, client := testutil.ProvisionRealtime(nil, nil)
 	defer multiclose(client, app)
 
-	members := client.Channels.TestGet("persisted:presence_fixtures").Presence.Get(true)
+	members, err := client.Channels.TestGet("persisted:presence_fixtures").Presence.Get(true)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	err := contains(members, "client_bool", "client_int", "client_string", "client_json")
+	err = contains(members, "client_bool", "client_int", "client_string", "client_json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +88,10 @@ func TestRealtimePresence_Sync250(t *testing.T) {
 	if err = contains(members2, clients...); err != nil {
 		t.Fatalf("members2: %v", err)
 	}
-	members3 := client3.Channels.TestGet("sync250").Presence.Get(true)
+	members3, err := client3.Channels.TestGet("sync250").Presence.Get(true)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err = contains(members3, clients...); err != nil {
 		t.Fatalf("members3: %v", err)
 	}

--- a/ably/rest_client_test.go
+++ b/ably/rest_client_test.go
@@ -1,7 +1,6 @@
 package ably_test
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -52,7 +51,7 @@ var _ = Describe("RestClient", func() {
 			client, err = ably.NewRestClient(testApp.Options(options))
 			Expect(err).NotTo(HaveOccurred())
 
-			request, err = http.NewRequest("POST", options.RestURL()+"/any_path", bytes.NewBuffer([]byte{}))
+			request, err = http.NewRequest("POST", options.RestURL()+"/any_path", nil)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -72,7 +71,7 @@ var _ = Describe("RestClient", func() {
 
 		Describe("Post", func() {
 			It("fails with a meaningful error", func() {
-				_, err := client.Post("/any_path", request, nil)
+				_, err := client.Post("/any_path", nil, nil)
 				Expect(err).To(HaveOccurred())
 
 				e, ok := err.(*ably.Error)


### PR DESCRIPTION
Channel may get attached after blocking Get is called on
RealtimePresence - when that happens, Get returns empty presence list.
This CL makes Get also wait for the channel until it's attached.

A StateEnum type was added to have connection/channel states human
readable when printed.