### PR TITLE
Fix resource count  value types

### DIFF
--- a/ably/proto/stat.go
+++ b/ably/proto/stat.go
@@ -5,9 +5,9 @@ import "time"
 type Stat struct {
 	// The following fields hold statistical information only for Channels
 	// and Connections fields, for the rest they are going to be always zero.
-	Peak   int64 `json:"peak" msgpack:"peak"`
-	Mean   int64 `json:"mean" msgpack:"mean"`
-	Opened int64 `json:"opened" msgpack:"opened"`
+	Peak   float64 `json:"peak" msgpack:"peak"`
+	Mean   float64 `json:"mean" msgpack:"mean"`
+	Opened float64 `json:"opened" msgpack:"opened"`
 
 	// The following fields hold statistical information only for
 	// APIRequests and TokenRequests fields, for the rest they are going

--- a/ably/rest_client_test.go
+++ b/ably/rest_client_test.go
@@ -33,7 +33,6 @@ var _ = Describe("RestClient", func() {
 	)
 
 	Context("with a failing request", func() {
-		var client *ably.RestClient
 
 		BeforeEach(func() {
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
- removed unused variable
- changed resource count  values to use `float54`
