### PR TITLE
don't set message data  encoding  to utf-8 when it is a string

### DIFF
--- a/ably/rest_channel.go
+++ b/ably/rest_channel.go
@@ -44,7 +44,7 @@ func newRestChannel(name string, client *RestClient) *RestChannel {
 
 func (c *RestChannel) Publish(name string, data string) error {
 	messages := []*proto.Message{
-		{Name: name, Data: data, Encoding: proto.UTF8},
+		{Name: name, Data: data},
 	}
 	return c.PublishAll(messages)
 }

--- a/ably/rest_channel_test.go
+++ b/ably/rest_channel_test.go
@@ -28,7 +28,6 @@ var _ = Describe("RestChannel", func() {
 			Expect(len(messages)).NotTo(Equal(0))
 			Expect(messages[0].Name).To(Equal(event))
 			Expect(messages[0].Data).To(Equal(message))
-			Expect(messages[0].Encoding).To(Equal(proto.UTF8))
 		})
 	})
 


### PR DESCRIPTION
Fixes  #106