### PR TITLE
Make IdempotentRestPublishing default to false for 1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 all: vet build test
 
 vet:
-	go get golang.org/x/tools/cmd/vet
-	find . -type f -name '*.go' -not -path './Godeps/*' | xargs -L 1 go vet -x
+	go vet ./ably ./scripts
 
 build:
 	go build ./...

--- a/ably/options.go
+++ b/ably/options.go
@@ -31,6 +31,7 @@ var defaultOptions = &ClientOptions{
 	TimeoutDisconnect:    30 * time.Second,
 	TimeoutSuspended:     2 * time.Minute,
 	FallbackRetryTimeout: 10 * time.Minute,
+	IdempotentRestPublishing: false,
 }
 
 func DefaultFallbackHosts() []string {
@@ -194,9 +195,9 @@ type ClientOptions struct {
 	NoQueueing       bool // when true drops messages published during regaining connection
 	NoBinaryProtocol bool // when true uses JSON for network serialization protocol instead of MsgPack
 
-	// When true idempotent rest publishing will be disabled.
+	// When true idempotent rest publishing will be enabled.
 	// Spec TO3n
-	NoIdempotentRestPublishing bool
+	IdempotentRestPublishing   bool
 	TimeoutConnect             time.Duration // time period after which connect request is failed
 	TimeoutDisconnect          time.Duration // time period after which disconnect request is failed
 	TimeoutSuspended           time.Duration // time period after which no more reconnection attempts are performed
@@ -303,6 +304,10 @@ func (opts *ClientOptions) protocol() string {
 		return protocolJSON
 	}
 	return protocolMsgPack
+}
+
+func (opts *ClientOptions) idempotentRestPublishing() bool {
+	return opts.IdempotentRestPublishing
 }
 
 // Time returns the given time as a timestamp in milliseconds since epoch.

--- a/ably/rest_channel.go
+++ b/ably/rest_channel.go
@@ -62,7 +62,7 @@ func (c *RestChannel) PublishAll(messages []*proto.Message) error {
 			v.ChannelOptions = c.options
 		}
 	}
-	useIdempotent := !c.client.opts.NoIdempotentRestPublishing
+	useIdempotent := c.client.opts.idempotentRestPublishing()
 	if useIdempotent {
 		switch len(messages) {
 		case 1:

--- a/ably/rest_channel_test.go
+++ b/ably/rest_channel_test.go
@@ -206,7 +206,7 @@ func TestIdempotentPublishing(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer app.Close()
-	options := app.Options()
+	options := app.Options(&ably.ClientOptions{IdempotentRestPublishing:true})
 	client, err := ably.NewRestClient(options)
 	if err != nil {
 		t.Fatal(err)
@@ -430,6 +430,7 @@ func TestIdempotent_retry(t *testing.T) {
 		nopts := &ably.ClientOptions{
 			NoTLS:                   true,
 			FallbackHostsUseDefault: true,
+			IdempotentRestPublishing: true,
 			AuthOptions: ably.AuthOptions{
 				UseTokenAuth: true,
 			},


### PR DESCRIPTION
In a recent specification change, `IdempotentRestPublishing` will only become `true` by default in library version 1.2. This PR makes the default `false`.