### PR TITLE
Proper Usage for RestChannels.Get Method in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ if err != nil {
 	panic(err)
 }
 
-channel := client.Channels.Get("test")
+channel := client.Channels.Get("test", nil)
 ```
 
 ### Publishing a message to a channel


### PR DESCRIPTION
`channel := client.Channels.Get("test")` throws an error because Get method for RestChannels requires 2 parameters.

Related method in source code:
https://github.com/ably/ably-go/blob/develop/ably/rest_client.go#L96