### PR TITLE
Specify msgpack decode option to return strings for appropriate types

### DIFF
--- a/ably/internal/ablyutil/msgpack.go
+++ b/ably/internal/ablyutil/msgpack.go
@@ -12,6 +12,7 @@ var handle codec.MsgpackHandle
 func init() {
 	handle.Raw = true
 	handle.WriteExt = true
+	handle.RawToString = true
 }
 
 // Unmarshal decodes the MessagePack-encoded data and stores the result in the

--- a/ably/rest_client_test.go
+++ b/ably/rest_client_test.go
@@ -109,15 +109,15 @@ func TestRestClient(t *testing.T) {
 			if err != nil {
 				ts.Fatal(err)
 			}
-			name := anyMsgPack[0]["name"].([]byte)
-			data := anyMsgPack[0]["data"].([]byte)
+			name := anyMsgPack[0]["name"].(string)
+			data := anyMsgPack[0]["data"].(string)
 
 			expectName := "ping"
 			expectData := "pong"
-			if string(name) != expectName {
+			if name != expectName {
 				ts.Errorf("expected %s got %s", expectName, string(name))
 			}
-			if string(data) != expectData {
+			if data != expectData {
 				ts.Errorf("expected %s got %s", expectData, string(data))
 			}
 		})


### PR DESCRIPTION
We need to specify `RawToString: true`: https://github.com/ugorji/go/blob/master/codec/msgpack.go#L521