### PR TITLE
Drop dependency on subpackage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ably/ably-go
 
 require (
-	github.com/ugorji/go/codec v0.0.0-20181209151446-772ced7fd4c2
+	github.com/ugorji/go v1.1.4
 	golang.org/x/net v0.0.0-20190110200230-915654e7eabc
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/ugorji/go v1.1.4 h1:j4s+tAvLfL3bZyefP2SEWmhBzmuIlH/eqNuPdFPgngw=
+github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181209151446-772ced7fd4c2 h1:EICbibRW4JNKMcY+LsWmuwob+CRS1BmdRdjphAm9mH4=
 github.com/ugorji/go/codec v0.0.0-20181209151446-772ced7fd4c2/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 golang.org/x/net v0.0.0-20190110200230-915654e7eabc h1:Yx9JGxI1SBhVLFjpAkWMaO1TF+xyqtHLjZpvQboJGiM=


### PR DESCRIPTION
This project had a dependency on `github.com/ugorji/go/codec` which is a subpackage of the Go modules project `github.com/ugorji/go`. This causes this error when trying to use this package in other Go modules projects:
```
cannot load github.com/ugorji/go/codec: ambiguous import: found github.com/ugorji/go/codec in multiple modules:
        github.com/ugorji/go v1.1.4 (/Users/david/pkg/mod/github.com/ugorji/go@v1.1.4/codec)
        github.com/ugorji/go/codec v0.0.0-20181209151446-772ced7fd4c2 (/Users/david/pkg/mod/github.com/ugorji/go/codec@v0.0.0-20181209151446-772ced7fd4c2)
```