### PR TITLE
REST client tests: a few fixes for test regressions

### DIFF
--- a/ably/ablytest/ablytest.go
+++ b/ably/ablytest/ablytest.go
@@ -15,7 +15,6 @@ var Timeout = 30 * time.Second
 var NoBinaryProtocol bool
 var DefaultLogger = ably.LoggerOptions{Level: ably.LogNone}
 var Environment = "sandbox"
-var IdempotentEnvironment = "idempotent-dev"
 
 func nonil(err ...error) error {
 	for _, err := range err {

--- a/ably/rest_channel_test.go
+++ b/ably/rest_channel_test.go
@@ -201,7 +201,7 @@ func TestRestChannel(t *testing.T) {
 
 func TestIdempotentPublishing(t *testing.T) {
 	t.Parallel()
-	app, err := ablytest.NewSandboxWIthEnv(nil, ablytest.IdempotentEnvironment)
+	app, err := ablytest.NewSandboxWIthEnv(nil, ablytest.Environment)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -409,7 +409,7 @@ func TestIdempotentPublishing(t *testing.T) {
 
 func TestIdempotent_retry(t *testing.T) {
 	t.Parallel()
-	app, err := ablytest.NewSandboxWIthEnv(nil, ablytest.IdempotentEnvironment)
+	app, err := ablytest.NewSandboxWIthEnv(nil, ablytest.Environment)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,9 @@
 module github.com/ably/ably-go
 
 require (
+	github.com/stretchr/testify v1.4.0
 	github.com/ugorji/go/codec v0.0.0-20181209151446-772ced7fd4c2
 	golang.org/x/net v0.0.0-20190110200230-915654e7eabc
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,14 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/ugorji/go/codec v0.0.0-20181209151446-772ced7fd4c2 h1:EICbibRW4JNKMcY+LsWmuwob+CRS1BmdRdjphAm9mH4=
 github.com/ugorji/go/codec v0.0.0-20181209151446-772ced7fd4c2/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 golang.org/x/net v0.0.0-20190110200230-915654e7eabc h1:Yx9JGxI1SBhVLFjpAkWMaO1TF+xyqtHLjZpvQboJGiM=
 golang.org/x/net v0.0.0-20190110200230-915654e7eabc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
A few fixes for tests that have stopped working since the last time we made a release:

- don't use the custom `dev-idempotent` endpoint for idempotent tests;
- suppress HTTP2 in custom HTTPClients used by tests;
- set `Host` header on requests that are forwarded by test client proxies to the valid endpoint;
- a couple of other fixes to make the tests actually test what they claim to test.