### PR TITLE
bug: unpinned range scope variables in tests

### DIFF
--- a/ably/proto/message_test.go
+++ b/ably/proto/message_test.go
@@ -86,6 +86,8 @@ func TestMessage(t *testing.T) {
 	}
 
 	for _, v := range sample {
+		// pin
+		v := v
 		t.Run(v.desc, func(ts *testing.T) {
 			msg := &proto.Message{
 				Data:           v.data,
@@ -124,6 +126,8 @@ func TestMessage_CryptoDataFixtures_RSL6a1_RSL5b_RSL5c(t *testing.T) {
 	}
 
 	for _, fixture := range fixtures {
+		// pin
+		fixture := fixture
 		t.Run(fixture.desc, func(ts *testing.T) {
 			test, key, iv, err := ablytest.LoadCryptoData(fixture.file)
 			if err != nil {

--- a/ably/proto/presence_message_test.go
+++ b/ably/proto/presence_message_test.go
@@ -18,6 +18,8 @@ func TestPresenceMessage(t *testing.T) {
 	}
 
 	for _, a := range actions {
+		// pin
+		a := a
 		id := fmt.Sprint(a)
 		m := proto.PresenceMessage{
 			Message: proto.Message{


### PR DESCRIPTION
Ran https://github.com/kyoh86/scopelint to find unpinned variables and corrected
them.

When a closure is used inside of a goroutine the closure is bound once and the
variable can get out of sync. Variables declared inside the body of a loop are
not shared between iterations, so we pin the value inside the loop body to
prevent this bug from happening. See
https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
for more details.