### PR TITLE
bug: TestRestClient Stats failure due to race cond with sandbox

### DIFF
--- a/ably/rest_client_test.go
+++ b/ably/rest_client_test.go
@@ -3,6 +3,7 @@ package ably_test
 import (
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -187,21 +188,52 @@ func TestRestClient(t *testing.T) {
 		}
 		res.Body.Close()
 
-		longAgo := lastInterval.Add(-120 * time.Minute)
-		page, err := client.Stats(&ably.PaginateParams{
-			Limit: 1,
-			ScopeParams: ably.ScopeParams{
-				Start: ably.Time(longAgo),
-				Unit:  proto.StatGranularityMinute,
-			},
-		})
-		if err != nil {
+		statsCh := make(chan []*proto.Stats, 1)
+		errCh := make(chan error, 1)
+
+		go func() {
+			longAgo := lastInterval.Add(-120 * time.Minute)
+
+			timeout := time.After(time.Second * 10)
+			tick := time.Tick(time.Millisecond * 500)
+
+			// keep trying until we get a pagination result, error, or timeout
+			for {
+				select {
+				case <-timeout:
+					errCh <- errors.New("timeout waiting for client.Stats to return nonempty value")
+					return
+				case <-tick:
+					page, err := client.Stats(&ably.PaginateParams{
+						Limit: 1,
+						ScopeParams: ably.ScopeParams{
+							Start: ably.Time(longAgo),
+							Unit:  proto.StatGranularityMinute,
+						},
+					})
+					if err != nil {
+						errCh <- err
+						return
+					}
+
+					if stats := page.Stats(); len(stats) != 0 {
+						statsCh <- stats
+						return
+					}
+				}
+			}
+		}()
+
+		select {
+		case pageStats := <-statsCh:
+			fmt.Println(pageStats)
+			re := regexp.MustCompile("[0-9]+\\-[0-9]+\\-[0-9]+:[0-9]+:[0-9]+")
+			interval := pageStats[0].IntervalID
+			if !re.MatchString(interval) {
+				ts.Errorf("got %s which is wrong interval format", interval)
+			}
+		case err := <-errCh:
 			ts.Fatal(err)
-		}
-		re := regexp.MustCompile("[0-9]+\\-[0-9]+\\-[0-9]+:[0-9]+:[0-9]+")
-		interval := page.Stats()[0].IntervalID
-		if !re.MatchString(interval) {
-			ts.Errorf("got %s which is wrong interval format", interval)
 		}
 	})
 }


### PR DESCRIPTION
The Stats test sends a [POST request](https://github.com/ably/ably-go/blob/664f3c9e5529cec11429d9d5af02a93b8704f1e6/ably/rest_client_test.go#L184) to the ably sandbox, and then follows up with
a [GET request](https://github.com/ably/ably-go/blob/664f3c9e5529cec11429d9d5af02a93b8704f1e6/ably/rest_client_test.go#L191). If the GET request happens too quickly after the POST, the sandbox
will not have populated data yet and the Stats request will not return data,
which causes the test to fail.

A loop is added that will call client.Stats every 500ms and check for a
nonempty result. If after 10s no result is present the test will timeout.

Failure from running the tests on my local machine:

![image](https://user-images.githubusercontent.com/2430381/77605511-7951df00-6eeb-11ea-931c-34080a78184f.png)

edit: looks like the test failure is in an unrelated part of the codebase, I have seen that test case fail on [other commits](https://travis-ci.org/github/ably/ably-go/jobs/639412366#L547) in the repo, likely a bug that surfaces when `-race` creates the right conditions. The linked build failure was from a changelog update commit so the failure is definitely not related to code changes.