### PR TITLE
Implement and test RTC1a, RTC1b.

### DIFF
--- a/ably/ablytest/recorders.go
+++ b/ably/ablytest/recorders.go
@@ -431,7 +431,7 @@ func NewRecorder(httpClient *http.Client) *HostRecorder {
 func (hr *HostRecorder) Options(host string) *ably.ClientOptions {
 	return &ably.ClientOptions{
 		RealtimeHost: host,
-		NoConnect:    true,
+		AutoConnect:  false,
 		HTTPClient:   hr.httpClient,
 		Dial:         hr.dialWS,
 	}

--- a/ably/auth_test.go
+++ b/ably/auth_test.go
@@ -646,8 +646,8 @@ func TestAuth_ClientID(t *testing.T) {
 			UseTokenAuth: true,
 			Force:        true,
 		},
-		Dial:      ablytest.MessagePipe(in, out),
-		NoConnect: true,
+		Dial:        ablytest.MessagePipe(in, out),
+		AutoConnect: false,
 	}
 	client := app.NewRealtimeClient(opts) // no client.Close as the connection is mocked
 
@@ -808,9 +808,9 @@ func TestAuth_RealtimeAccessToken(t *testing.T) {
 	t.Parallel()
 	rec := ablytest.NewMessageRecorder()
 	opts := &ably.ClientOptions{
-		ClientID:  "explicit",
-		NoConnect: true,
-		Dial:      rec.Dial,
+		ClientID:    "explicit",
+		AutoConnect: false,
+		Dial:        rec.Dial,
 	}
 	opts.UseTokenAuth = true
 	app, client := ablytest.NewRealtimeClient(opts)

--- a/ably/error_test.go
+++ b/ably/error_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 func TestErrorResponseWithInvalidKey(t *testing.T) {
-	opts := ably.NewClientOptions(":")
+	opts := ably.NewClientOptions()
+	opts.Key = ":"
 	_, e := ably.NewRestClient(opts)
 	if e == nil {
 		t.Fatal("NewRestClient(): expected err != nil")
@@ -41,7 +42,8 @@ func TestIssue127ErrorResponse(t *testing.T) {
 
 	endpointURL, err := url.Parse(server.URL)
 	assert.Nil(t, err)
-	opts := ably.NewClientOptions("xxxxxxx.yyyyyyy:zzzzzzz")
+	opts := ably.NewClientOptions()
+	opts.Key = "xxxxxxx.yyyyyyy:zzzzzzz"
 	opts.NoTLS = true
 	opts.UseTokenAuth = true
 	opts.RestHost = endpointURL.Hostname()

--- a/ably/options.go
+++ b/ably/options.go
@@ -23,14 +23,14 @@ const (
 )
 
 var defaultOptions = &ClientOptions{
-	RestHost:             RestHost,
-	FallbackHosts:        DefaultFallbackHosts(),
-	HTTPMaxRetryCount:    3,
-	RealtimeHost:         "realtime.ably.io",
-	TimeoutConnect:       15 * time.Second,
-	TimeoutDisconnect:    30 * time.Second,
-	TimeoutSuspended:     2 * time.Minute,
-	FallbackRetryTimeout: 10 * time.Minute,
+	RestHost:                 RestHost,
+	FallbackHosts:            DefaultFallbackHosts(),
+	HTTPMaxRetryCount:        3,
+	RealtimeHost:             "realtime.ably.io",
+	TimeoutConnect:           15 * time.Second,
+	TimeoutDisconnect:        30 * time.Second,
+	TimeoutSuspended:         2 * time.Minute,
+	FallbackRetryTimeout:     10 * time.Minute,
 	IdempotentRestPublishing: false,
 }
 
@@ -166,8 +166,18 @@ func (opts *AuthOptions) KeySecret() string {
 	return ""
 }
 
+// ClientOptions configures a RestClient or RealtimeClient. Use NewClientOptions
+// to get sensible defaults.
 type ClientOptions struct {
 	AuthOptions
+
+	// In realtime connections, whether publishes are sent back to the
+	// publishing connection.
+	EchoMessages bool
+
+	// In realtime connections, whether the instance should connect right after
+	// being created, without an explicit call to the Connect method.
+	AutoConnect bool
 
 	RestHost                string // optional; overwrite endpoint hostname for REST client
 	FallbackHostsUseDefault bool
@@ -192,17 +202,15 @@ type ClientOptions struct {
 	FallbackRetryTimeout time.Duration
 
 	NoTLS            bool // when true REST and realtime client won't use TLS
-	NoConnect        bool // when true realtime client will not attempt to connect automatically
-	NoEcho           bool // when true published messages will not be echoed back
 	NoQueueing       bool // when true drops messages published during regaining connection
 	NoBinaryProtocol bool // when true uses JSON for network serialization protocol instead of MsgPack
 
 	// When true idempotent rest publishing will be enabled.
 	// Spec TO3n
-	IdempotentRestPublishing   bool
-	TimeoutConnect             time.Duration // time period after which connect request is failed
-	TimeoutDisconnect          time.Duration // time period after which disconnect request is failed
-	TimeoutSuspended           time.Duration // time period after which no more reconnection attempts are performed
+	IdempotentRestPublishing bool
+	TimeoutConnect           time.Duration // time period after which connect request is failed
+	TimeoutDisconnect        time.Duration // time period after which disconnect request is failed
+	TimeoutSuspended         time.Duration // time period after which no more reconnection attempts are performed
 
 	// Dial specifies the dial function for creating message connections used
 	// by RealtimeClient.
@@ -224,11 +232,10 @@ type ClientOptions struct {
 	Trace *httptrace.ClientTrace
 }
 
-func NewClientOptions(key string) *ClientOptions {
+func NewClientOptions() *ClientOptions {
 	return &ClientOptions{
-		AuthOptions: AuthOptions{
-			Key: key,
-		},
+		EchoMessages: true,
+		AutoConnect:  true,
 	}
 }
 

--- a/ably/options_test.go
+++ b/ably/options_test.go
@@ -10,7 +10,8 @@ import (
 func TestClientOptions(t *testing.T) {
 	t.Parallel()
 	t.Run("parses it into a set of known parameters", func(ts *testing.T) {
-		options := ably.NewClientOptions("name:secret")
+		options := ably.NewClientOptions()
+		options.Key = "name:secret"
 		_, err := ably.NewRestClient(options)
 		if err != nil {
 			ts.Fatal(err)
@@ -25,7 +26,9 @@ func TestClientOptions(t *testing.T) {
 		}
 	})
 	t.Run("must return error on invalid key", func(ts *testing.T) {
-		_, err := ably.NewRestClient(ably.NewClientOptions("invalid"))
+		opts := ably.NewClientOptions()
+		opts.Key = "invalid"
+		_, err := ably.NewRestClient(opts)
 		if err == nil {
 			ts.Error("expected an error")
 		}

--- a/ably/realtime_channel_test.go
+++ b/ably/realtime_channel_test.go
@@ -48,9 +48,9 @@ func TestRealtimeChannel_Failed(t *testing.T) {
 	t.Parallel()
 	rec := ablytest.NewStateChanRecorder(5)
 	opts := &ably.ClientOptions{
-		NoConnect:  true,
-		NoQueueing: true,
-		Listener:   rec.Channel(),
+		AutoConnect: false,
+		NoQueueing:  true,
+		Listener:    rec.Channel(),
 	}
 	app, client := ablytest.NewRealtimeClient(opts)
 	defer safeclose(t, client, app)
@@ -89,7 +89,7 @@ func TestRealtimeChannel_Subscribe(t *testing.T) {
 	t.Parallel()
 	app, client1 := ablytest.NewRealtimeClient(nil)
 	defer safeclose(t, client1, app)
-	client2 := app.NewRealtimeClient(&ably.ClientOptions{NoEcho: true})
+	client2 := app.NewRealtimeClient(&ably.ClientOptions{EchoMessages: false})
 	defer safeclose(t, client2)
 
 	channel1 := client1.Channels.Get("test")

--- a/ably/realtime_client_spec_test.go
+++ b/ably/realtime_client_spec_test.go
@@ -1,0 +1,17 @@
+package ably
+
+import "testing"
+
+func Test_RTC1a_EchoMessagesTrueByDefault(t *testing.T) {
+	o := NewClientOptions()
+	if e, g := true, o.EchoMessages; e != g {
+		t.Errorf("expected %v, got %v", e, g)
+	}
+}
+
+func Test_RTC1b_AutoConnectTrueByDefault(t *testing.T) {
+	o := NewClientOptions()
+	if e, g := true, o.AutoConnect; e != g {
+		t.Errorf("expected %v, got %v", e, g)
+	}
+}

--- a/ably/realtime_client_test.go
+++ b/ably/realtime_client_test.go
@@ -108,7 +108,7 @@ func TestRealtimeClient_multiple(t *testing.T) {
 			defer wg.Done()
 			opts := app.Options(nil)
 			opts.ClientID = fmt.Sprintf("client/%d", i)
-			opts.NoConnect = true
+			opts.AutoConnect = false
 			c, err := ably.NewRealtimeClient(opts)
 			if err != nil {
 				all.Add(nil, err)
@@ -162,7 +162,7 @@ func TestRealtimeClient_multiple(t *testing.T) {
 
 func TestRealtimeClient_DontCrashOnCloseWhenEchoOff(t *testing.T) {
 	t.Parallel()
-	app, client := ablytest.NewRealtimeClient(&ably.ClientOptions{NoConnect: true})
+	app, client := ablytest.NewRealtimeClient(&ably.ClientOptions{AutoConnect: false})
 	defer safeclose(t, app)
 
 	if err := checkError(80002, client.Close()); err != nil {

--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -46,7 +46,7 @@ func newConn(opts *ClientOptions, auth *Auth) (*Conn, error) {
 	if opts.Listener != nil {
 		c.On(opts.Listener)
 	}
-	if !opts.NoConnect {
+	if opts.AutoConnect {
 		if _, err := c.connect(false); err != nil {
 			return nil, err
 		}
@@ -101,7 +101,7 @@ func (c *Conn) connect(result bool) (Result, error) {
 		"echo":      []string{"true"},
 		"format":    []string{"msgpack"},
 	}
-	if c.opts.NoEcho {
+	if !c.opts.EchoMessages {
 		query.Set("echo", "false")
 	}
 	if c.opts.NoBinaryProtocol {

--- a/ably/realtime_conn_test.go
+++ b/ably/realtime_conn_test.go
@@ -54,8 +54,8 @@ func TestRealtimeConn_NoConnect(t *testing.T) {
 	t.Parallel()
 	rec := ablytest.NewStateRecorder(4)
 	opts := &ably.ClientOptions{
-		Listener:  rec.Channel(),
-		NoConnect: true,
+		Listener:    rec.Channel(),
+		AutoConnect: false,
 	}
 	app, client := ablytest.NewRealtimeClient(opts)
 	defer safeclose(t, client, app)
@@ -106,7 +106,7 @@ func TestRealtimeConn_ConnectClose(t *testing.T) {
 
 func TestRealtimeConn_AlreadyConnected(t *testing.T) {
 	t.Parallel()
-	app, client := ablytest.NewRealtimeClient(&ably.ClientOptions{NoConnect: true})
+	app, client := ablytest.NewRealtimeClient(&ably.ClientOptions{AutoConnect: false})
 	defer safeclose(t, client, app)
 
 	if err := ablytest.Wait(client.Connection.Connect()); err != nil {
@@ -123,7 +123,7 @@ func TestRealtimeConn_AuthError(t *testing.T) {
 			Key:          "abc:abc",
 			UseTokenAuth: true,
 		},
-		NoConnect: true,
+		AutoConnect: false,
 	}
 	client, err := ably.NewRealtimeClient(opts)
 	if err != nil {

--- a/ably/realtime_presence_test.go
+++ b/ably/realtime_presence_test.go
@@ -112,8 +112,8 @@ func TestRealtimePresence_EnsureChannelIsAttached(t *testing.T) {
 	}
 	rec := ablytest.NewStateRecorder(4)
 	opts := &ably.ClientOptions{
-		Listener:  rec.Channel(),
-		NoConnect: true,
+		Listener:    rec.Channel(),
+		AutoConnect: false,
 	}
 	app, client := ablytest.NewRealtimeClient(opts)
 	defer safeclose(t, client, app)


### PR DESCRIPTION
This was done a few weeks back, when we hadn't [formulated a plan](https://ably.atlassian.net/secure/RapidBoard.jspa?rapidView=22&projectKey=SDK&selectedIssue=FEA-391) yet and I just went "well let's just implement the spec from top to bottom".

Also, this inaugurates the v1.2 branch. ~A new major version is required due to breaking changes. The ".2" refers to the spec minor version it's supposed to implement: 2.2~ We'll be releasing this as a minor version, in spite of the breaking changes, so that it matches the spec version.

@QuintinWillison This is just renaming a couple variable and fixing a constructor signature.

Going forwards, so that we can get a spec-compliant API out as quickly as possible, my plan is to _append_ the new API alongside/on top of the old one, and, after that's done, just make the old one private in one stroke. We can then clean that up progressively.