### PR TITLE
RTN23a: Receive from WebSocket with a timeout.

### DIFF
--- a/ably/internal/ablyutil/websocket.go
+++ b/ably/internal/ablyutil/websocket.go
@@ -3,6 +3,7 @@ package ablyutil
 import (
 	"errors"
 	"net/url"
+	"time"
 
 	"github.com/ably/ably-go/ably/proto"
 
@@ -18,8 +19,14 @@ func (ws *WebsocketConn) Send(msg *proto.ProtocolMessage) error {
 	return ws.codec.Send(ws.conn, msg)
 }
 
-func (ws *WebsocketConn) Receive() (*proto.ProtocolMessage, error) {
+func (ws *WebsocketConn) Receive(deadline time.Time) (*proto.ProtocolMessage, error) {
 	msg := &proto.ProtocolMessage{}
+	if !deadline.IsZero() {
+		err := ws.conn.SetReadDeadline(deadline)
+		if err != nil {
+			return nil, err
+		}
+	}
 	err := ws.codec.Receive(ws.conn, &msg)
 	if err != nil {
 		return nil, err

--- a/ably/proto/protocol_message.go
+++ b/ably/proto/protocol_message.go
@@ -3,6 +3,7 @@ package proto
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 )
 
 const (
@@ -23,6 +24,7 @@ type ConnectionDetails struct {
 	MaxFrameSize       int64  `json:"maxFrameSize,omitempty" codec:"maxFrameSize,omitempty"`
 	MaxInboundRate     int64  `json:"maxInboundRate,omitempty" codec:"maxInboundRate,omitempty"`
 	ConnectionStateTTL int64  `json:"connectionStateTtl,omitempty" codec:"connectionStateTtl,omitempty"`
+	MaxIdleInterval    int64  `json:"maxIdleInterval,omitempty" codec:"maxIdleInterval,omitempty"`
 }
 
 func (c *ConnectionDetails) FromMap(ctx map[string]interface{}) {
@@ -213,7 +215,10 @@ type Conn interface {
 
 	// Receive reads ProtocolMessage from the connection.
 	// It is expected to block until whole message is read.
-	Receive() (*ProtocolMessage, error)
+	//
+	// If the deadline is greater than zero and no message is received before
+	// then, a net.Error with Timeout() == true is returned.
+	Receive(deadline time.Time) (*ProtocolMessage, error)
 
 	// Close closes the connection.
 	Close() error

--- a/ably/realtime_client_test.go
+++ b/ably/realtime_client_test.go
@@ -45,7 +45,7 @@ func TestRealtimeClient_RealtimeHost(t *testing.T) {
 			t.Errorf("want state=%v; got %s", ably.StateConnFailed, state)
 			continue
 		}
-		if err := checkError(80000, client.Close()); err != nil {
+		if err := client.Close(); err != nil {
 			t.Errorf("%s (host=%s)", err, host)
 			continue
 		}
@@ -163,9 +163,5 @@ func TestRealtimeClient_multiple(t *testing.T) {
 func TestRealtimeClient_DontCrashOnCloseWhenEchoOff(t *testing.T) {
 	t.Parallel()
 	app, client := ablytest.NewRealtimeClient(&ably.ClientOptions{NoConnect: true})
-	defer safeclose(t, app)
-
-	if err := checkError(80002, client.Close()); err != nil {
-		t.Fatal(err)
-	}
+	defer safeclose(t, app, client)
 }

--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -12,8 +12,7 @@ import (
 )
 
 var (
-	errQueueing      = errors.New("unable to send messages in current state with disabled queueing")
-	errCloseInactive = errors.New("attempted to close inactive connection")
+	errQueueing = errors.New("unable to send messages in current state with disabled queueing")
 )
 
 // Conn represents a single connection RealtimeClient instantiates for
@@ -155,10 +154,13 @@ func (c *Conn) close() (Result, error) {
 	c.state.Lock()
 	defer c.state.Unlock()
 	switch c.state.current {
-	case StateConnClosing, StateConnClosed:
+	case
+		StateConnClosing,
+		StateConnClosed,
+		StateConnInitialized,
+		StateConnFailed,
+		StateConnDisconnected:
 		return nopResult, nil
-	case StateConnInitialized, StateConnFailed, StateConnDisconnected:
-		return nil, stateError(c.state.current, errCloseInactive)
 	}
 	res := c.state.listenResult(closeResultStates...)
 	c.state.set(StateConnClosing, nil)

--- a/ably/realtime_conn_test.go
+++ b/ably/realtime_conn_test.go
@@ -191,6 +191,7 @@ func TestRealtimeConn_ReceiveTimeout(t *testing.T) {
 	}
 
 	// TODO: Should be Disconnected, not Failed
+	// Part of https://ably.atlassian.net/browse/FEA-391
 	if expected, got := ably.StateConnFailed, state.State; expected != got {
 		t.Fatalf("expected %v, got %v", expected, got)
 	}

--- a/ably/realtime_conn_test.go
+++ b/ably/realtime_conn_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ably/ably-go/ably"
 	"github.com/ably/ably-go/ably/ablytest"
+	"github.com/ably/ably-go/ably/proto"
 )
 
 func await(fn func() ably.StateEnum, state ably.StateEnum) error {
@@ -137,5 +138,60 @@ func TestRealtimeConn_AuthError(t *testing.T) {
 	}
 	if err = client.Close(); err == nil {
 		t.Fatal("Close(): want err != nil")
+	}
+}
+
+func TestRealtimeConn_ReceiveTimeout(t *testing.T) {
+	t.Parallel()
+
+	const maxIdleInterval = 20
+	const realtimeRequestTimeout = 10 * time.Millisecond
+
+	in := make(chan *proto.ProtocolMessage, 16)
+	out := make(chan *proto.ProtocolMessage, 16)
+
+	connected := &proto.ProtocolMessage{
+		Action:       proto.ActionConnected,
+		ConnectionID: "connection-id",
+		ConnectionDetails: &proto.ConnectionDetails{
+			MaxIdleInterval: maxIdleInterval,
+		},
+	}
+	in <- connected
+
+	app, client := ablytest.NewRealtimeClient(&ably.ClientOptions{
+		Dial:                   ablytest.MessagePipe(in, out),
+		RealtimeRequestTimeout: 10 * time.Millisecond,
+		NoConnect:              true,
+	})
+	defer safeclose(t, app)
+
+	states := make(chan ably.State, 10)
+	client.Connection.On(states, ably.StateConnConnected, ably.StateConnFailed)
+
+	client.Connection.Connect()
+
+	var state ably.State
+
+	select {
+	case state = <-states:
+	case <-time.After(10 * time.Millisecond):
+		t.Fatal("didn't receive state change event")
+	}
+
+	if expected, got := ably.StateConnConnected, state.State; expected != got {
+		t.Fatalf("expected %v, got %v", expected, got)
+	}
+
+	leeway := 10 * time.Millisecond
+	select {
+	case state = <-states:
+	case <-time.After(realtimeRequestTimeout + time.Duration(maxIdleInterval)*time.Millisecond + leeway):
+		t.Fatal("didn't receive state change event")
+	}
+
+	// TODO: Should be Disconnected, not Failed
+	if expected, got := ably.StateConnFailed, state.State; expected != got {
+		t.Fatalf("expected %v, got %v", expected, got)
 	}
 }

--- a/ably/realtime_conn_test.go
+++ b/ably/realtime_conn_test.go
@@ -130,14 +130,12 @@ func TestRealtimeConn_AuthError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRealtimeClient()=%v", err)
 	}
+	defer safeclose(t, client)
 	if err = ablytest.Wait(client.Connection.Connect()); err == nil {
 		t.Fatal("Connect(): want err != nil")
 	}
 	if state := client.Connection.State(); state != ably.StateConnFailed {
 		t.Fatalf("want state=%s; got %s", ably.StateConnFailed, state)
-	}
-	if err = client.Close(); err == nil {
-		t.Fatal("Close(): want err != nil")
 	}
 }
 


### PR DESCRIPTION
> If a transport does not receive any indication of activity on a
> transport for a period greater than the sum of the maxIdleInterval
> (which will be sent in the connectionDetails of the most recent
> CONNECTED message received on that transport) and the
> realtimeRequestTimeout, that transport should be disconnected.