### PR TITLE
Don't read from connection on inactive state.

### DIFF
--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -312,7 +312,9 @@ func (c *Conn) isActive() bool {
 	return c.state.current == StateConnConnecting || c.state.current == StateConnConnected
 }
 
-func (c *Conn) canReceiveMessages() bool {
+func (c *Conn) lockCanReceiveMessages() bool {
+	c.state.Lock()
+	defer c.state.Unlock()
 	return c.state.current == StateConnConnecting || c.state.current == StateConnConnected || c.state.current == StateConnClosing
 }
 
@@ -334,7 +336,7 @@ func (c *Conn) logger() *LoggerOptions {
 func (c *Conn) eventloop() {
 	var receiveTimeout time.Duration
 
-	for c.canReceiveMessages() {
+	for c.lockCanReceiveMessages() {
 		var deadline time.Time
 		if receiveTimeout != 0 {
 			deadline = time.Now().Add(receiveTimeout) // RTN23a

--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -330,7 +330,7 @@ func (c *Conn) logger() *LoggerOptions {
 func (c *Conn) eventloop() {
 	var receiveTimeout time.Duration
 
-	for {
+	for c.lockIsActive() {
 		var deadline time.Time
 		if receiveTimeout != 0 {
 			deadline = time.Now().Add(receiveTimeout) // RTN23a

--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -312,6 +312,10 @@ func (c *Conn) isActive() bool {
 	return c.state.current == StateConnConnecting || c.state.current == StateConnConnected
 }
 
+func (c *Conn) canReceiveMessages() bool {
+	return c.state.current == StateConnConnecting || c.state.current == StateConnConnected || c.state.current == StateConnClosing
+}
+
 func (c *Conn) lockIsActive() bool {
 	c.state.Lock()
 	defer c.state.Unlock()
@@ -330,7 +334,7 @@ func (c *Conn) logger() *LoggerOptions {
 func (c *Conn) eventloop() {
 	var receiveTimeout time.Duration
 
-	for c.lockIsActive() {
+	for c.canReceiveMessages() {
 		var deadline time.Time
 		if receiveTimeout != 0 {
 			deadline = time.Now().Add(receiveTimeout) // RTN23a


### PR DESCRIPTION
After the connection gets to an inactive state (ie. not CONNECTING,
CONNECTED, CLOSING), no further messages are expected. Instead, moving
back to an active state will start the loop again by calling setConn.