### PR TITLE
Properly set  Error.StatusCode

### DIFF
--- a/ably/error_test.go
+++ b/ably/error_test.go
@@ -1,19 +1,14 @@
 package ably_test
 
 import (
-	"crypto/tls"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strconv"
-	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/ably/ably-go/ably"
-	"github.com/ably/ably-go/ably/ablytest"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -59,83 +54,28 @@ func TestIssue127ErrorResponse(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), errMsg)
 }
-
 func TestIssue_154(t *testing.T) {
-	var retry atomic.Value
-	incrRetry := func() {
-		if v := retry.Load(); v != nil {
-			retry.Store(v.(int) + 1)
-		} else {
-			retry.Store(int(1))
-		}
-	}
-	count := func() int {
-		if v := retry.Load(); v != nil {
-			return v.(int)
-		}
-		return 0
-	}
-	ref := "Mon Jan 2 15:04:05 MST 2006"
-	errMsg := "This is an html error body"
-	ts, err := time.Parse(time.UnixDate, ref)
-	if err != nil {
-		t.Fatal(err)
-	}
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		incrRetry()
 		rw.Header().Set("Content-Type", "text/html")
-		rw.WriteHeader(http.StatusBadGateway)
-		rw.Write([]byte(fmt.Sprintf("<html><head></head><body>%s</body></html>", errMsg)))
+		rw.WriteHeader(http.StatusMethodNotAllowed)
 	}))
-	var d time.Duration
-	d.Milliseconds()
 	defer server.Close()
-	defaultServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		rw.Header().Set("Content-Type", "application/json")
-		rw.WriteHeader(http.StatusOK)
-		json.NewEncoder(rw).Encode([]int64{ts.UnixNano() / int64(time.Millisecond)})
-	}))
-	defer defaultServer.Close()
-	fallbackHosts := []string{"fallback0", "fallback1", "fallback2"}
-	opts := &ably.ClientOptions{
-		Environment:   ablytest.Environment,
-		NoTLS:         true,
-		FallbackHosts: fallbackHosts,
-		AuthOptions: ably.AuthOptions{
-			UseTokenAuth: true,
-		},
-	}
-	serverURL, _ := url.Parse(server.URL)
-	defaultURL, _ := url.Parse(defaultServer.URL)
-	proxy := func(r *http.Request) (*url.URL, error) {
-		retryCount := count()
-		if retryCount < 2 {
-			return serverURL, nil
-		} else {
-			r.Host = defaultURL.Hostname()
-			return defaultURL, nil
-		}
-	}
 
-	opts.HTTPClient = &http.Client{
-		Transport: &http.Transport{
-			Proxy:        proxy,
-			TLSNextProto: map[string]func(authority string, c *tls.Conn) http.RoundTripper{},
-		},
-	}
-	client, err := ably.NewRestClient(opts)
-	if err != nil {
-		t.Fatal(err)
-	}
-	tym, err := client.Time()
-	if err != nil {
-		t.Fatalf("didn't expect error got %v ", err)
-	}
-	if !tym.Equal(ts) {
-		t.Errorf("expected %v got %v", ts, tym)
-	}
-	c := count()
-	if c != 2 {
-		t.Errorf("expected 2 retries got %d", c)
+	endpointURL, err := url.Parse(server.URL)
+	assert.Nil(t, err)
+	opts := ably.NewClientOptions("xxxxxxx.yyyyyyy:zzzzzzz")
+	opts.NoTLS = true
+	opts.UseTokenAuth = true
+	opts.RestHost = endpointURL.Hostname()
+	port, _ := strconv.ParseInt(endpointURL.Port(), 10, 0)
+	opts.Port = int(port)
+	client, e := ably.NewRestClient(opts)
+	assert.Nil(t, e)
+
+	_, err = client.Time()
+	assert.NotNil(t, err)
+	et := err.(*ably.Error)
+	if et.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("expected %d got %d", http.StatusMethodNotAllowed, et.StatusCode)
 	}
 }

--- a/ably/error_test.go
+++ b/ably/error_test.go
@@ -1,14 +1,19 @@
 package ably_test
 
 import (
+	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/ably/ably-go/ably"
+	"github.com/ably/ably-go/ably/ablytest"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -53,4 +58,84 @@ func TestIssue127ErrorResponse(t *testing.T) {
 	_, err = client.Time()
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), errMsg)
+}
+
+func TestIssue_154(t *testing.T) {
+	var retry atomic.Value
+	incrRetry := func() {
+		if v := retry.Load(); v != nil {
+			retry.Store(v.(int) + 1)
+		} else {
+			retry.Store(int(1))
+		}
+	}
+	count := func() int {
+		if v := retry.Load(); v != nil {
+			return v.(int)
+		}
+		return 0
+	}
+	ref := "Mon Jan 2 15:04:05 MST 2006"
+	errMsg := "This is an html error body"
+	ts, err := time.Parse(time.UnixDate, ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		incrRetry()
+		rw.Header().Set("Content-Type", "text/html")
+		rw.WriteHeader(http.StatusBadGateway)
+		rw.Write([]byte(fmt.Sprintf("<html><head></head><body>%s</body></html>", errMsg)))
+	}))
+	var d time.Duration
+	d.Milliseconds()
+	defer server.Close()
+	defaultServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusOK)
+		json.NewEncoder(rw).Encode([]int64{ts.UnixNano() / int64(time.Millisecond)})
+	}))
+	defer defaultServer.Close()
+	fallbackHosts := []string{"fallback0", "fallback1", "fallback2"}
+	opts := &ably.ClientOptions{
+		Environment:   ablytest.Environment,
+		NoTLS:         true,
+		FallbackHosts: fallbackHosts,
+		AuthOptions: ably.AuthOptions{
+			UseTokenAuth: true,
+		},
+	}
+	serverURL, _ := url.Parse(server.URL)
+	defaultURL, _ := url.Parse(defaultServer.URL)
+	proxy := func(r *http.Request) (*url.URL, error) {
+		retryCount := count()
+		if retryCount < 2 {
+			return serverURL, nil
+		} else {
+			r.Host = defaultURL.Hostname()
+			return defaultURL, nil
+		}
+	}
+
+	opts.HTTPClient = &http.Client{
+		Transport: &http.Transport{
+			Proxy:        proxy,
+			TLSNextProto: map[string]func(authority string, c *tls.Conn) http.RoundTripper{},
+		},
+	}
+	client, err := ably.NewRestClient(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tym, err := client.Time()
+	if err != nil {
+		t.Fatalf("didn't expect error got %v ", err)
+	}
+	if !tym.Equal(ts) {
+		t.Errorf("expected %v got %v", ts, tym)
+	}
+	c := count()
+	if c != 2 {
+		t.Errorf("expected 2 retries got %d", c)
+	}
 }


### PR DESCRIPTION
fixes #154

newError was completely ignoring  response status code.
It was wrongly deriving it from error code.

This patch ensures Error,StatusCode is set with correct response status.