### PR TITLE
ProtocolMessage: add the timestamp to each message on receipt

### DIFF
--- a/ably/realtime_channel.go
+++ b/ably/realtime_channel.go
@@ -375,6 +375,9 @@ func (c *RealtimeChannel) notify(msg *proto.ProtocolMessage) {
 		c.state.syncSet(StateChanFailed, newErrorProto(msg.Error))
 		c.queue.Fail(newErrorProto(msg.Error))
 	case proto.ActionMessage:
+		for _, m := range msg.Messages {
+			m.Timestamp = msg.Timestamp
+		}
 		c.subs.messageEnqueue(msg)
 	default:
 	}


### PR DESCRIPTION
This adds `Message.Timestamp`