### PR TITLE
Skip nil options

### DIFF
--- a/ably/options.go
+++ b/ably/options.go
@@ -660,7 +660,9 @@ func (os ClientOptions) applyWithDefaults() *clientOptions {
 	to := defaultOptions
 
 	for _, set := range os {
-		set(&to)
+		if set != nil {
+			set(&to)
+		}
 	}
 
 	if to.DefaultTokenParams == nil {
@@ -676,7 +678,9 @@ func (os AuthOptions) applyWithDefaults() *authOptions {
 	to := defaultOptions.authOptions
 
 	for _, set := range os {
-		set(&to)
+		if set != nil {
+			set(&to)
+		}
 	}
 
 	if to.DefaultTokenParams == nil {

--- a/ably/rest_client.go
+++ b/ably/rest_client.go
@@ -96,7 +96,9 @@ func (c *RestChannels) Exists(name string) bool {
 func (c *RestChannels) Get(name string, options ...ChannelOption) *RestChannel {
 	var o channelOptions
 	for _, set := range options {
-		set(&o)
+		if set != nil {
+			set(&o)
+		}
 	}
 	return c.get(name, (*proto.ChannelOptions)(&o))
 }


### PR DESCRIPTION
Options can be `nil` which may result in panics. This ensures we only apply non nil options.