### PR TITLE
Have a single Travis build as originally intended.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ go:
 before_install:
   - go get -t -v ./ably/...
 env:
-  - GOMAXPROCS=4
-  - GO111MODULE=on
+  - GOMAXPROCS=4 GO111MODULE=on
 sudo: false
 script:
   - make test


### PR DESCRIPTION
We're running two parallel builds, one with GOMAXPROCS=4, the
other with GO111MODULE=on. What we want is a single build with
those two env vars set.