### PR TITLE
Fix race condition in RTN15i test

### DIFF
--- a/ably/realtime_conn_spec_test.go
+++ b/ably/realtime_conn_spec_test.go
@@ -1016,6 +1016,9 @@ func TestRealtimeConn_RTN15i_OnErrorWhenConnected(t *testing.T) {
 
 	errorCode := 50123
 
+	channelFailed := make(chan ably.State, 1)
+	channel.On(channelFailed, ably.StateChanFailed)
+
 	err = ablytest.ConnWaiter(c, func() {
 		in <- &proto.ProtocolMessage{
 			Action: proto.ActionError,
@@ -1039,7 +1042,10 @@ func TestRealtimeConn_RTN15i_OnErrorWhenConnected(t *testing.T) {
 		t.Fatalf("expected %v; got %v", expected, got)
 	}
 
-	// The channel should have been moved to FAILED too.
+	// The channel should be moved to FAILED too.
+
+	ablytest.Instantly.Recv(t, nil, channelFailed, t.Fatalf)
+
 	if expected, got := ably.StateChanFailed, channel.State(); expected != got {
 		t.Fatalf("expected channel in state %v; got %v", expected, got)
 	}


### PR DESCRIPTION
Transitions on channel and connection states are concurrent, so
we shouldn't expect one to have happened already when the other
happens. So, wait for both transitions.