### PR TITLE
RTN15f: Discard in-flight publishes on transport loss.

### DIFF
--- a/ably/state.go
+++ b/ably/state.go
@@ -431,6 +431,17 @@ func (q *pendingEmitter) Nack(serial int64, count int, err error) {
 	q.queue = q.queue[nack:]
 }
 
+func (q *pendingEmitter) NackAll(err error) {
+	if err == nil {
+		err = newError(50000, err)
+	}
+	for _, sch := range q.queue {
+		q.logger.Printf(LogVerbose, "received NACK for message serial %d", sch.serial)
+		sch.ch <- err
+	}
+	q.queue = nil
+}
+
 type msgch struct {
 	msg *proto.ProtocolMessage
 	ch  chan<- error


### PR DESCRIPTION
[RTN15f](https://docs.ably.io/client-lib-development-guide/features/#RTN15f)

> Therefore, once a transport drops, the client library must either fail the publish attempt, or re-attempt by re-sending the messages on a new transport if the resume was successful

We go with the "fail the publish attempt" option.