### PR TITLE
RTL2: EventEmitter for channel events; remove old State

### DIFF
--- a/ably/ablytest/ablytest.go
+++ b/ably/ablytest/ablytest.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"reflect"
 	"strconv"
 	"time"
 
@@ -74,4 +75,20 @@ func protocol(opts ably.ClientOptions) string {
 		return "application/x-msgpack"
 	}
 	return "application/json"
+}
+
+func Contains(s, sub interface{}) bool {
+	return reflectContains(reflect.ValueOf(s), reflect.ValueOf(sub))
+}
+
+func reflectContains(s, sub reflect.Value) bool {
+	for i := 0; i+sub.Len() <= s.Len(); i++ {
+		if reflect.DeepEqual(
+			s.Slice(i, i+sub.Len()).Interface(),
+			sub.Interface(),
+		) {
+			return true
+		}
+	}
+	return false
 }

--- a/ably/ablytest/timeout.go
+++ b/ably/ablytest/timeout.go
@@ -63,3 +63,20 @@ func (wt WithTimeout) recv(into interface{}, from interface{}) (ok, timeout bool
 	}
 	return ok, chosen == 1
 }
+
+func (wt WithTimeout) IsTrue(pred func() bool) bool {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	timeout := time.NewTimer(wt.before)
+	defer timeout.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if pred() {
+				return true
+			}
+		case <-timeout.C:
+			return pred()
+		}
+	}
+}

--- a/ably/auth_test.go
+++ b/ably/auth_test.go
@@ -663,8 +663,8 @@ func TestAuth_ClientID(t *testing.T) {
 	time.Sleep(time.Duration(params.TTL) * time.Millisecond)
 	tokenExpiredAt := time.Now()
 
-	failed := make(chan ably.State, 1)
-	client.Connection.OnState(failed, ably.StateConnFailed)
+	failed := make(ably.ConnStateChanges, 1)
+	client.Connection.On(ably.ConnectionEventFailed, failed.Receive)
 
 	// Allow some extra time for the server to reject our token.
 	err = nil
@@ -701,11 +701,11 @@ func TestAuth_ClientID(t *testing.T) {
 	}
 	select {
 	case state := <-failed:
-		if state.State != ably.StateConnFailed {
-			t.Fatalf("want state=%q; got %q", ably.StateConnFailed, state.State)
+		if state.Current != ably.ConnectionStateFailed {
+			t.Fatalf("want state=%q; got %q", ably.ConnectionStateFailed, state.Current)
 		}
 	default:
-		t.Fatal("wanted to have StateConnFailed emitted; it wasn't")
+		t.Fatal("wanted to have ConnectionStateFailed emitted; it wasn't")
 	}
 }
 

--- a/ably/auth_test.go
+++ b/ably/auth_test.go
@@ -699,13 +699,11 @@ func TestAuth_ClientID(t *testing.T) {
 	if state := client.Connection.State(); state != ably.ConnectionStateFailed {
 		t.Fatalf("want state=%q; got %q", ably.ConnectionStateFailed, state)
 	}
-	select {
-	case state := <-failed:
-		if state.Current != ably.ConnectionStateFailed {
-			t.Fatalf("want state=%q; got %q", ably.ConnectionStateFailed, state.Current)
-		}
-	default:
-		t.Fatal("wanted to have ConnectionStateFailed emitted; it wasn't")
+
+	var state ably.ConnectionStateChange
+	ablytest.Soon.Recv(t, &state, failed, t.Fatalf)
+	if state.Current != ably.ConnectionStateFailed {
+		t.Fatalf("want state=%q; got %q", ably.ConnectionStateFailed, state.Current)
 	}
 }
 

--- a/ably/export_test.go
+++ b/ably/export_test.go
@@ -85,53 +85,16 @@ type EmitterString string
 func (EmitterString) isEmitterEvent() {}
 func (EmitterString) isEmitterData()  {}
 
-// TODO: Once channels have also an EventEmitter, refactor tests to use
-// EventEmitters for both connection and channels.
-
-func (c *Connection) OnState(ch chan<- State, states ...StateEnum) {
-	c.onState(ch, states...)
-}
-
-func (c *Connection) OffState(ch chan<- State, states ...StateEnum) {
-	c.offState(ch, states...)
-}
-
-func (c *RealtimeChannel) OnState(ch chan<- State, states ...StateEnum) {
-	c.onState(ch, states...)
-}
-
-func (c *RealtimeChannel) OffState(ch chan<- State, states ...StateEnum) {
-	c.offState(ch, states...)
-}
-
-func (c *Connection) StateEnum() StateEnum {
-	c.state.Lock()
-	defer c.state.Unlock()
-	return c.state.current
-}
-
-func (c *RealtimeChannel) StateEnum() StateEnum {
-	c.state.Lock()
-	defer c.state.Unlock()
-	return c.state.current
-}
-
 func (c *Connection) RemoveKey() {
-	c.state.Lock()
-	defer c.state.Unlock()
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.key = ""
 }
 
 func (c *Connection) MsgSerial() int64 {
-	c.state.Lock()
-	defer c.state.Unlock()
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	return c.msgSerial
-}
-
-func (os ClientOptions) Listener(ch chan<- State) ClientOptions {
-	return append(os, func(os *clientOptions) {
-		os.Listener = ch
-	})
 }
 
 func (os ClientOptions) RealtimeRequestTimeout(d time.Duration) ClientOptions {
@@ -161,3 +124,7 @@ func (os ClientOptions) After(after func(context.Context, time.Duration) <-chan 
 func (os ClientOptions) ApplyWithDefaults() *clientOptions {
 	return os.applyWithDefaults()
 }
+
+type ConnStateChanges = connStateChanges
+
+type ChannelStateChanges = channelStateChanges

--- a/ably/export_test.go
+++ b/ably/export_test.go
@@ -96,7 +96,21 @@ func (c *Connection) OffState(ch chan<- State, states ...StateEnum) {
 	c.offState(ch, states...)
 }
 
+func (c *RealtimeChannel) OnState(ch chan<- State, states ...StateEnum) {
+	c.onState(ch, states...)
+}
+
+func (c *RealtimeChannel) OffState(ch chan<- State, states ...StateEnum) {
+	c.offState(ch, states...)
+}
+
 func (c *Connection) StateEnum() StateEnum {
+	c.state.Lock()
+	defer c.state.Unlock()
+	return c.state.current
+}
+
+func (c *RealtimeChannel) StateEnum() StateEnum {
 	c.state.Lock()
 	defer c.state.Unlock()
 	return c.state.current

--- a/ably/options.go
+++ b/ably/options.go
@@ -212,11 +212,6 @@ type clientOptions struct {
 	// If Dial is nil, the default websocket connection is used.
 	Dial func(protocol string, u *url.URL) (proto.Conn, error)
 
-	// Listener if set, will be automatically registered with On method for every
-	// realtime connection and realtime channel created by realtime client.
-	// The listener will receive events for all state transitions.
-	Listener chan<- State
-
 	// HTTPClient specifies the client used for HTTP communication by RestClient.
 	//
 	// If HTTPClient is nil, the http.DefaultClient is used.

--- a/ably/realtime_channel.go
+++ b/ably/realtime_channel.go
@@ -475,15 +475,14 @@ func (c *RealtimeChannel) notify(msg *proto.ProtocolMessage) {
 func (c *RealtimeChannel) lockStartRetryAttachLoop(err error) {
 	// TODO: Move to SUSPENDED; move it to DETACHED for now.
 	c.lockSetState(ChannelStateDetached, err)
+
+	stateChange := make(channelStateChanges, 1)
+	off := c.internalEmitter.OnceAll(stateChange.Receive)
+
 	c.mtx.Unlock()
 
 	go func() {
-		// TODO: The listener should be set before unlocking the state.
-		// Will do once we have an EventEmitter.
-		stateChange := make(channelStateChanges, 10)
-		off := c.internalEmitter.OnAll(stateChange.Receive)
 		defer off()
-
 		for !c.retryAttach(stateChange) {
 		}
 	}()

--- a/ably/realtime_channel.go
+++ b/ably/realtime_channel.go
@@ -318,7 +318,7 @@ func (em ChannelEventEmitter) OnAll(handle func(ChannelStateChange)) (off func()
 //
 // See package-level documentation on Event Emitter for details.
 func (em ChannelEventEmitter) Once(e ChannelEvent, handle func(ChannelStateChange)) (off func()) {
-	return em.emitter.On(e, func(change emitterData) {
+	return em.emitter.Once(e, func(change emitterData) {
 		handle(change.(ChannelStateChange))
 	})
 }

--- a/ably/realtime_channel_test.go
+++ b/ably/realtime_channel_test.go
@@ -141,7 +141,7 @@ func TestRealtimeChannel_Detach(t *testing.T) {
 		}
 		done <- nil
 	}()
-	if state := channel.State(); state != ably.StateChanAttached {
+	if state := channel.StateEnum(); state != ably.StateChanAttached {
 		t.Fatalf("want state=%v; got %v", ably.StateChanAttached, state)
 	}
 	if err := ablytest.Wait(channel.Detach()); err != nil {

--- a/ably/realtime_channel_test.go
+++ b/ably/realtime_channel_test.go
@@ -96,26 +96,6 @@ func TestRealtimeChannel_Subscribe(t *testing.T) {
 	}
 }
 
-var chanCloseTransitions = [][]ably.StateEnum{{
-	ably.StateConnConnecting,
-	ably.StateChanAttaching,
-	ably.StateConnConnected,
-	ably.StateChanAttached,
-	ably.StateChanDetaching,
-	ably.StateChanDetached,
-	ably.StateConnClosing,
-	ably.StateConnClosed,
-}, {
-	ably.StateConnConnecting,
-	ably.StateConnConnected,
-	ably.StateChanAttaching,
-	ably.StateChanAttached,
-	ably.StateChanDetaching,
-	ably.StateChanDetached,
-	ably.StateConnClosing,
-	ably.StateConnClosed,
-}}
-
 func TestRealtimeChannel_Detach(t *testing.T) {
 	t.Parallel()
 	app, client := ablytest.NewRealtime(ably.ClientOptions{})
@@ -141,8 +121,8 @@ func TestRealtimeChannel_Detach(t *testing.T) {
 		}
 		done <- nil
 	}()
-	if state := channel.StateEnum(); state != ably.StateChanAttached {
-		t.Fatalf("want state=%v; got %v", ably.StateChanAttached, state)
+	if state := channel.State(); state != ably.ChannelStateAttached {
+		t.Fatalf("want state=%v; got %v", ably.ChannelStateAttached, state)
 	}
 	if err := ablytest.Wait(channel.Detach()); err != nil {
 		t.Fatalf("channel.Detach()=%v", err)

--- a/ably/realtime_client.go
+++ b/ably/realtime_client.go
@@ -75,7 +75,7 @@ func (c *Realtime) onReconnected(err *proto.ErrorInfo, isNewID bool) {
 	for _, ch := range c.Channels.All() {
 		switch ch.State() {
 		// TODO: SUSPENDED
-		case StateChanAttaching, StateChanAttached:
+		case ChannelStateAttaching, ChannelStateAttached:
 			ch.mayAttach(false, false)
 		}
 	}

--- a/ably/realtime_client.go
+++ b/ably/realtime_client.go
@@ -32,7 +32,9 @@ func NewRealtime(options ClientOptions) (*Realtime, error) {
 		c.onChannelMsg,
 		c.onReconnected,
 		c.onReconnectionFailed,
-		c.onConnStateChange,
+	})
+	conn.internalEmitter.OnAll(func(change ConnectionStateChange) {
+		c.Channels.broadcastConnStateChange(change)
 	})
 	if err != nil {
 		return nil, err
@@ -83,17 +85,12 @@ func (c *Realtime) onReconnected(err *proto.ErrorInfo, isNewID bool) {
 
 func (c *Realtime) onReconnectionFailed(err *proto.ErrorInfo) {
 	for _, ch := range c.Channels.All() {
-		ch.state.syncSet(StateChanFailed, newErrorProto(err))
+		ch.setState(ChannelStateFailed, newErrorProto(err))
 	}
 }
 
 func isTokenError(err *proto.ErrorInfo) bool {
 	return err.StatusCode == http.StatusUnauthorized && (40140 <= err.Code && err.Code < 40150)
-}
-
-func (c *Realtime) onConnStateChange(state State) {
-	// TODO: Replace with EventEmitter https://github.com/ably/ably-go/pull/144
-	c.Channels.broadcastConnStateChange(state)
 }
 
 func (c *Realtime) opts() *clientOptions {

--- a/ably/realtime_client_test.go
+++ b/ably/realtime_client_test.go
@@ -2,7 +2,6 @@ package ably_test
 
 import (
 	"fmt"
-	"reflect"
 	"sync"
 	"testing"
 
@@ -63,14 +62,17 @@ func TestRealtime_RealtimeHost(t *testing.T) {
 		}
 	}
 	want := []ably.ConnectionState{
+		ably.ConnectionStateInitialized,
 		ably.ConnectionStateConnecting,
 		ably.ConnectionStateFailed,
+		ably.ConnectionStateInitialized,
 		ably.ConnectionStateConnecting,
 		ably.ConnectionStateFailed,
+		ably.ConnectionStateInitialized,
 		ably.ConnectionStateConnecting,
 		ably.ConnectionStateFailed,
 	}
-	if expected, got := want, rec; !reflect.DeepEqual(expected, got) {
+	if expected, got := want, stateRec.States(); !ablytest.Contains(expected, got) {
 		t.Fatalf("expected %+v, got %+v", expected, got)
 	}
 	errors := errorsRec.Errors()

--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -364,7 +364,7 @@ func (em ConnectionEventEmitter) OnAll(handle func(ConnectionStateChange)) (off 
 //
 // See package-level documentation on Event Emitter for details.
 func (em ConnectionEventEmitter) Once(e ConnectionEvent, handle func(ConnectionStateChange)) (off func()) {
-	return em.emitter.On(e, func(change emitterData) {
+	return em.emitter.Once(e, func(change emitterData) {
 		handle(change.(ConnectionStateChange))
 	})
 }

--- a/ably/realtime_conn_spec_test.go
+++ b/ably/realtime_conn_spec_test.go
@@ -468,7 +468,7 @@ func TestRealtimeConn_RTN15c1(t *testing.T) {
 	}
 
 	chanStateChanges := make(chan ably.State)
-	channel.On(chanStateChanges)
+	channel.OnState(chanStateChanges)
 
 	stateChanges := make(chan ably.ConnectionStateChange, 16)
 	client.Connection.OnAll(func(c ably.ConnectionStateChange) {
@@ -578,7 +578,7 @@ func TestRealtimeConn_RTN15c2(t *testing.T) {
 		t.Fatal(err)
 	}
 	chanStateChanges := make(chan ably.State)
-	channel.On(chanStateChanges)
+	channel.OnState(chanStateChanges)
 
 	sub, err := channel.Subscribe()
 	if err != nil {
@@ -704,7 +704,7 @@ func TestRealtimeConn_RTN15c3_attached(t *testing.T) {
 		t.Fatal(err)
 	}
 	chanStateChanges := make(chan ably.State, 18)
-	channel.On(chanStateChanges, ably.StateChanAttaching)
+	channel.OnState(chanStateChanges, ably.StateChanAttaching)
 
 	stateChanges := make(chan ably.ConnectionStateChange, 16)
 	client.Connection.OnAll(func(c ably.ConnectionStateChange) {
@@ -855,7 +855,7 @@ func TestRealtimeConn_RTN15c3_attaching(t *testing.T) {
 
 	// we are testing to make sure we have initiated a new attach for channels
 	// in ATTACHING  state.
-	if expected, got := ably.StateChanAttaching, channel.State(); expected != got {
+	if expected, got := ably.StateChanAttaching, channel.StateEnum(); expected != got {
 		t.Fatalf("expected transition to %v, got %v", expected, got)
 	}
 	reason := client.Connection.ErrorReason()
@@ -912,7 +912,7 @@ func TestRealtimeConn_RTN15c4(t *testing.T) {
 		t.Fatal(err)
 	}
 	chanStateChanges := make(chan ably.State, 1)
-	channel.On(chanStateChanges, ably.StateChanFailed)
+	channel.OnState(chanStateChanges, ably.StateChanFailed)
 
 	stateChanges := make(chan ably.ConnectionStateChange, 16)
 	client.Connection.OnAll(func(c ably.ConnectionStateChange) {
@@ -1444,7 +1444,7 @@ func TestRealtimeConn_RTN15i_OnErrorWhenConnected(t *testing.T) {
 	errorCode := 50123
 
 	channelFailed := make(chan ably.State, 1)
-	channel.On(channelFailed, ably.StateChanFailed)
+	channel.OnState(channelFailed, ably.StateChanFailed)
 
 	err = ablytest.ConnWaiter(c, func() {
 		in <- &proto.ProtocolMessage{
@@ -1473,7 +1473,7 @@ func TestRealtimeConn_RTN15i_OnErrorWhenConnected(t *testing.T) {
 
 	ablytest.Instantly.Recv(t, nil, channelFailed, t.Fatalf)
 
-	if expected, got := ably.StateChanFailed, channel.State(); expected != got {
+	if expected, got := ably.StateChanFailed, channel.StateEnum(); expected != got {
 		t.Fatalf("expected channel in state %v; got %v", expected, got)
 	}
 }

--- a/ably/realtime_conn_test.go
+++ b/ably/realtime_conn_test.go
@@ -13,6 +13,7 @@ var connTransitions = []ably.ConnectionState{
 	ably.ConnectionStateConnecting,
 	ably.ConnectionStateConnected,
 	ably.ConnectionStateClosing,
+	ably.ConnectionStateClosed,
 }
 
 func TestRealtimeConn_Connect(t *testing.T) {
@@ -32,8 +33,10 @@ func TestRealtimeConn_Connect(t *testing.T) {
 	if err := ablytest.FullRealtimeCloser(client).Close(); err != nil {
 		t.Fatalf("ablytest.FullRealtimeCloser(client).Close()=%v", err)
 	}
-	if expected, got := connTransitions, rec.States(); !ablytest.Contains(got, expected) {
-		t.Fatalf("expected %+v, got %+v", expected, got)
+	if !ablytest.Soon.IsTrue(func() bool {
+		return ablytest.Contains(rec.States(), connTransitions)
+	}) {
+		t.Fatalf("expected %+v, got %+v", connTransitions, rec.States())
 	}
 }
 
@@ -56,15 +59,11 @@ func TestRealtimeConn_NoConnect(t *testing.T) {
 	if err := ablytest.FullRealtimeCloser(client).Close(); err != nil {
 		t.Fatalf("ablytest.FullRealtimeCloser(client).Close()=%v", err)
 	}
-	if expected, got := connTransitions, rec.States(); !ablytest.Contains(got, expected) {
-		t.Fatalf("expected %+v, got %+v", expected, got)
+	if !ablytest.Soon.IsTrue(func() bool {
+		return ablytest.Contains(rec.States(), connTransitions)
+	}) {
+		t.Fatalf("expected %+v, got %+v", connTransitions, rec.States())
 	}
-}
-
-var connCloseTransitions = []ably.ConnectionState{
-	ably.ConnectionStateConnecting,
-	ably.ConnectionStateConnected,
-	ably.ConnectionStateClosing,
 }
 
 func TestRealtimeConn_ConnectClose(t *testing.T) {
@@ -84,8 +83,10 @@ func TestRealtimeConn_ConnectClose(t *testing.T) {
 	if err := ablytest.ConnWaiter(client, nil, ably.ConnectionEventClosed).Wait(); err != nil {
 		t.Fatal(err)
 	}
-	if expected, got := connTransitions, rec.States(); !ablytest.Contains(got, expected) {
-		t.Fatalf("expected %+v, got %+v", expected, got)
+	if !ablytest.Soon.IsTrue(func() bool {
+		return ablytest.Contains(rec.States(), connTransitions)
+	}) {
+		t.Fatalf("expected %+v, got %+v", connTransitions, rec.States())
 	}
 }
 

--- a/ably/realtime_conn_test.go
+++ b/ably/realtime_conn_test.go
@@ -1,7 +1,6 @@
 package ably_test
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
@@ -14,7 +13,6 @@ var connTransitions = []ably.ConnectionState{
 	ably.ConnectionStateConnecting,
 	ably.ConnectionStateConnected,
 	ably.ConnectionStateClosing,
-	ably.ConnectionStateClosed,
 }
 
 func TestRealtimeConn_Connect(t *testing.T) {
@@ -34,7 +32,7 @@ func TestRealtimeConn_Connect(t *testing.T) {
 	if err := ablytest.FullRealtimeCloser(client).Close(); err != nil {
 		t.Fatalf("ablytest.FullRealtimeCloser(client).Close()=%v", err)
 	}
-	if expected, got := connTransitions, rec.States(); !reflect.DeepEqual(expected, got) {
+	if expected, got := connTransitions, rec.States(); !ablytest.Contains(got, expected) {
 		t.Fatalf("expected %+v, got %+v", expected, got)
 	}
 }
@@ -58,7 +56,7 @@ func TestRealtimeConn_NoConnect(t *testing.T) {
 	if err := ablytest.FullRealtimeCloser(client).Close(); err != nil {
 		t.Fatalf("ablytest.FullRealtimeCloser(client).Close()=%v", err)
 	}
-	if expected, got := connTransitions, rec.States(); !reflect.DeepEqual(expected, got) {
+	if expected, got := connTransitions, rec.States(); !ablytest.Contains(got, expected) {
 		t.Fatalf("expected %+v, got %+v", expected, got)
 	}
 }
@@ -67,7 +65,6 @@ var connCloseTransitions = []ably.ConnectionState{
 	ably.ConnectionStateConnecting,
 	ably.ConnectionStateConnected,
 	ably.ConnectionStateClosing,
-	ably.ConnectionStateClosed,
 }
 
 func TestRealtimeConn_ConnectClose(t *testing.T) {
@@ -87,7 +84,7 @@ func TestRealtimeConn_ConnectClose(t *testing.T) {
 	if err := ablytest.ConnWaiter(client, nil, ably.ConnectionEventClosed).Wait(); err != nil {
 		t.Fatal(err)
 	}
-	if expected, got := connTransitions, rec.States(); !reflect.DeepEqual(expected, got) {
+	if expected, got := connTransitions, rec.States(); !ablytest.Contains(got, expected) {
 		t.Fatalf("expected %+v, got %+v", expected, got)
 	}
 }

--- a/ably/realtime_conn_test.go
+++ b/ably/realtime_conn_test.go
@@ -1,7 +1,7 @@
 package ably_test
 
 import (
-	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -10,35 +10,23 @@ import (
 	"github.com/ably/ably-go/ably/proto"
 )
 
-func await(fn func() ably.StateEnum, state ably.StateEnum) error {
-	t := time.After(ablytest.Timeout)
-	for {
-		select {
-		case <-t:
-			return fmt.Errorf("waiting for %s state has timed out after %v", state, ablytest.Timeout)
-		default:
-			if fn() == state {
-				return nil
-			}
-		}
-	}
-}
-
-var connTransitions = []ably.StateEnum{
-	ably.StateConnConnecting,
-	ably.StateConnConnected,
-	ably.StateConnClosing,
-	ably.StateConnClosed,
+var connTransitions = []ably.ConnectionState{
+	ably.ConnectionStateConnecting,
+	ably.ConnectionStateConnected,
+	ably.ConnectionStateClosing,
+	ably.ConnectionStateClosed,
 }
 
 func TestRealtimeConn_Connect(t *testing.T) {
 	t.Parallel()
-	rec := ablytest.NewStateRecorder(4)
-	app, client := ablytest.NewRealtime(ably.ClientOptions{}.Listener(rec.Channel()))
+	var rec ablytest.ConnStatesRecorder
+	app, client := ablytest.NewRealtime(ably.ClientOptions{})
 	defer safeclose(t, ablytest.FullRealtimeCloser(client), app)
+	off := rec.Listen(client)
+	defer off()
 
-	if err := await(client.Connection.StateEnum, ably.StateConnConnected); err != nil {
-		t.Fatal(err)
+	if err := ablytest.ConnWaiter(client, nil, ably.ConnectionEventConnected).Wait(); err != nil {
+		t.Fatalf("Connect()=%v", err)
 	}
 	if serial := client.Connection.Serial(); serial != -1 {
 		t.Fatalf("want serial=-1; got %d", serial)
@@ -46,21 +34,21 @@ func TestRealtimeConn_Connect(t *testing.T) {
 	if err := ablytest.FullRealtimeCloser(client).Close(); err != nil {
 		t.Fatalf("ablytest.FullRealtimeCloser(client).Close()=%v", err)
 	}
-	if err := rec.WaitFor(connTransitions); err != nil {
-		t.Fatal(err)
+	if expected, got := connTransitions, rec.States(); !reflect.DeepEqual(expected, got) {
+		t.Fatalf("expected %+v, got %+v", expected, got)
 	}
 }
 
 func TestRealtimeConn_NoConnect(t *testing.T) {
 	t.Parallel()
-	rec := ablytest.NewStateRecorder(4)
+	var rec ablytest.ConnStatesRecorder
 	opts := ably.ClientOptions{}.
-		Listener(rec.Channel()).
 		AutoConnect(false)
 	app, client := ablytest.NewRealtime(opts)
 	defer safeclose(t, ablytest.FullRealtimeCloser(client), app)
+	off := rec.Listen(client)
+	defer off()
 
-	client.Connection.OnState(rec.Channel())
 	if err := ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected).Wait(); err != nil {
 		t.Fatalf("Connect()=%v", err)
 	}
@@ -70,37 +58,37 @@ func TestRealtimeConn_NoConnect(t *testing.T) {
 	if err := ablytest.FullRealtimeCloser(client).Close(); err != nil {
 		t.Fatalf("ablytest.FullRealtimeCloser(client).Close()=%v", err)
 	}
-	rec.Stop()
-	if err := rec.WaitFor(connTransitions); err != nil {
-		t.Error(err)
+	if expected, got := connTransitions, rec.States(); !reflect.DeepEqual(expected, got) {
+		t.Fatalf("expected %+v, got %+v", expected, got)
 	}
 }
 
-var connCloseTransitions = []ably.StateEnum{
-	ably.StateConnConnecting,
-	ably.StateConnConnected,
-	ably.StateConnClosing,
-	ably.StateConnClosed,
+var connCloseTransitions = []ably.ConnectionState{
+	ably.ConnectionStateConnecting,
+	ably.ConnectionStateConnected,
+	ably.ConnectionStateClosing,
+	ably.ConnectionStateClosed,
 }
 
 func TestRealtimeConn_ConnectClose(t *testing.T) {
 	t.Parallel()
-	rec := ablytest.NewStateRecorder(4)
-	app, client := ablytest.NewRealtime(ably.ClientOptions{}.Listener(rec.Channel()))
+	var rec ablytest.ConnStatesRecorder
+	app, client := ablytest.NewRealtime(ably.ClientOptions{})
 	defer safeclose(t, ablytest.FullRealtimeCloser(client), app)
+	off := rec.Listen(client)
+	defer off()
 
-	if err := await(client.Connection.StateEnum, ably.StateConnConnected); err != nil {
+	if err := ablytest.ConnWaiter(client, nil, ably.ConnectionEventConnected).Wait(); err != nil {
 		t.Fatal(err)
 	}
 	if err := ablytest.FullRealtimeCloser(client).Close(); err != nil {
 		t.Fatalf("ablytest.FullRealtimeCloser(client).Close()=%v", err)
 	}
-	if err := await(client.Connection.StateEnum, ably.StateConnClosed); err != nil {
+	if err := ablytest.ConnWaiter(client, nil, ably.ConnectionEventClosed).Wait(); err != nil {
 		t.Fatal(err)
 	}
-	rec.Stop()
-	if err := rec.WaitFor(connCloseTransitions); err != nil {
-		t.Error(err)
+	if expected, got := connTransitions, rec.States(); !reflect.DeepEqual(expected, got) {
+		t.Fatalf("expected %+v, got %+v", expected, got)
 	}
 }
 
@@ -135,7 +123,7 @@ func TestRealtimeConn_AuthError(t *testing.T) {
 		t.Fatal("Connect(): want err != nil")
 	}
 	if state := client.Connection.State(); state != ably.ConnectionStateFailed {
-		t.Fatalf("want state=%s; got %s", ably.StateConnFailed, state)
+		t.Fatalf("want state=%s; got %s", ably.ConnectionStateFailed, state)
 	}
 }
 
@@ -163,12 +151,19 @@ func TestRealtimeConn_ReceiveTimeout(t *testing.T) {
 		AutoConnect(false))
 	defer safeclose(t, app)
 
-	states := make(chan ably.State, 10)
-	client.Connection.OnState(states, ably.StateConnConnected, ably.StateConnDisconnected)
+	states := make(ably.ConnStateChanges, 10)
+	{
+		off := client.Connection.On(ably.ConnectionEventConnected, states.Receive)
+		defer off()
+	}
+	{
+		off := client.Connection.On(ably.ConnectionEventDisconnected, states.Receive)
+		defer off()
+	}
 
 	client.Connection.Connect()
 
-	var state ably.State
+	var state ably.ConnectionStateChange
 
 	select {
 	case state = <-states:
@@ -176,7 +171,7 @@ func TestRealtimeConn_ReceiveTimeout(t *testing.T) {
 		t.Fatal("didn't receive state change event")
 	}
 
-	if expected, got := ably.StateConnConnected, state.State; expected != got {
+	if expected, got := ably.ConnectionStateConnected, state.Current; expected != got {
 		t.Fatalf("expected %v, got %v", expected, got)
 	}
 
@@ -187,7 +182,7 @@ func TestRealtimeConn_ReceiveTimeout(t *testing.T) {
 		t.Fatal("didn't receive state change event")
 	}
 
-	if expected, got := ably.StateConnDisconnected, state.State; expected != got {
+	if expected, got := ably.ConnectionStateDisconnected, state.Current; expected != got {
 		t.Fatalf("expected %v, got %v", expected, got)
 	}
 }

--- a/ably/realtime_presence.go
+++ b/ably/realtime_presence.go
@@ -48,7 +48,7 @@ func newRealtimePresence(channel *RealtimeChannel) *RealtimePresence {
 
 func (pres *RealtimePresence) verifyChanState() error {
 	switch state := pres.channel.State(); state {
-	case StateChanDetached, StateChanDetaching, StateChanFailed:
+	case ChannelStateDetached, ChannelStateDetaching, ChannelStateFailed:
 		return newError(91001, fmt.Errorf("unable to enter presence channel (invalid channel state: %s)", state.String()))
 	default:
 		return nil

--- a/ably/realtime_presence.go
+++ b/ably/realtime_presence.go
@@ -64,7 +64,7 @@ func (pres *RealtimePresence) send(msg *proto.PresenceMessage) (Result, error) {
 	}
 	protomsg := &proto.ProtocolMessage{
 		Action:   proto.ActionPresence,
-		Channel:  pres.channel.state.channel,
+		Channel:  pres.channel.Name,
 		Presence: []*proto.PresenceMessage{msg},
 	}
 	return pres.channel.send(protomsg)

--- a/ably/realtime_presence.go
+++ b/ably/realtime_presence.go
@@ -48,7 +48,7 @@ func newRealtimePresence(channel *RealtimeChannel) *RealtimePresence {
 
 func (pres *RealtimePresence) verifyChanState() error {
 	switch state := pres.channel.State(); state {
-	case StateChanDetached, StateChanDetaching, StateChanClosing, StateChanClosed, StateChanFailed:
+	case StateChanDetached, StateChanDetaching, StateChanFailed:
 		return newError(91001, fmt.Errorf("unable to enter presence channel (invalid channel state: %s)", state.String()))
 	default:
 		return nil

--- a/ably/realtime_presence_test.go
+++ b/ably/realtime_presence_test.go
@@ -106,6 +106,7 @@ func TestRealtimePresence_Sync250(t *testing.T) {
 func TestRealtimePresence_EnsureChannelIsAttached(t *testing.T) {
 	t.Parallel()
 	presTransitions := []ably.ChannelState{
+		ably.ChannelStateInitialized,
 		ably.ChannelStateAttaching,
 		ably.ChannelStateAttached,
 	}

--- a/ably/state.go
+++ b/ably/state.go
@@ -68,8 +68,6 @@ const (
 	StateChanAttached
 	StateChanDetaching
 	StateChanDetached
-	StateChanClosing
-	StateChanClosed
 	StateChanFailed
 )
 
@@ -102,8 +100,6 @@ var stateText = map[StateEnum]string{
 	StateChanAttached:     "ably.StateChanAttached",
 	StateChanDetaching:    "ably.StateChanDetaching",
 	StateChanDetached:     "ably.StateChanDetached",
-	StateChanClosing:      "ably.StateChanClosing",
-	StateChanClosed:       "ably.StateChanClosed",
 	StateChanFailed:       "ably.StateChanFailed",
 }
 
@@ -124,7 +120,6 @@ var stateAll = map[StateType][]StateEnum{
 		StateChanAttaching,
 		StateChanAttached,
 		StateChanDetaching,
-		StateChanClosed,
 		StateChanDetached,
 		StateChanFailed,
 	},
@@ -136,8 +131,7 @@ var stateMasks = map[StateType]StateEnum{
 		StateConnDisconnected | StateConnSuspended | StateConnClosing | StateConnClosed |
 		StateConnFailed,
 	StateChan: StateChanInitialized | StateChanAttaching | StateChanAttached |
-		StateChanDetaching | StateChanDetached | StateChanClosing | StateChanClosed |
-		StateChanFailed,
+		StateChanDetaching | StateChanDetached | StateChanFailed,
 }
 
 var (

--- a/ably/state.go
+++ b/ably/state.go
@@ -8,69 +8,6 @@ import (
 	"github.com/ably/ably-go/ably/proto"
 )
 
-// StateType specifies which group of states is relevant in given context;
-// either:
-//
-//   - StateConn* group describing Conn states
-//   - StateChan* group describing RealtimeChannel states
-//
-type StateType int
-
-const (
-	StateConn StateType = 1 + iota
-	StateChan
-)
-
-// Strings implements the fmt.Stringer interface.
-func (st StateType) String() string {
-	switch st {
-	case StateConn:
-		return "connection"
-	case StateChan:
-		return "channel"
-	default:
-		return "invalid"
-	}
-}
-
-// Contains returns true when the state belongs to the given type.
-func (st StateType) Contains(state StateEnum) bool {
-	return stateMasks[st]&state == state
-}
-
-// StateEnum is an enumeration type for connection and channel states.
-type StateEnum int
-
-// String implements the fmt.Stringer interface.
-func (sc StateEnum) String() string {
-	if s, ok := stateText[sc]; ok {
-		return s
-	}
-	return "invalid"
-}
-
-// StateConn describes states of realtime connection.
-const (
-	StateConnInitialized StateEnum = 1 << iota
-	StateConnConnecting
-	StateConnConnected
-	StateConnDisconnected
-	StateConnSuspended
-	StateConnClosing
-	StateConnClosed
-	StateConnFailed
-)
-
-// StateChan describes states of realtime channel.
-const (
-	StateChanInitialized StateEnum = 1 << (iota + 8)
-	StateChanAttaching
-	StateChanAttached
-	StateChanDetaching
-	StateChanDetached
-	StateChanFailed
-)
-
 // Result awaits completion of asynchronous operation.
 type Result interface {
 	// Wait blocks until asynchronous operation is completed. Upon its completion,
@@ -86,54 +23,6 @@ func wait(res Result, err error) error {
 	return res.Wait()
 }
 
-var stateText = map[StateEnum]string{
-	StateConnInitialized:  "ably.StateConnInitialized",
-	StateConnConnecting:   "ably.StateConnConnecting",
-	StateConnConnected:    "ably.StateConnConnected",
-	StateConnDisconnected: "ably.StateConnDisconnected",
-	StateConnSuspended:    "ably.StateConnSuspended",
-	StateConnClosing:      "ably.StateConnClosing",
-	StateConnClosed:       "ably.StateConnClosed",
-	StateConnFailed:       "ably.StateConnFailed",
-	StateChanInitialized:  "ably.StateChanInitialized",
-	StateChanAttaching:    "ably.StateChanAttaching",
-	StateChanAttached:     "ably.StateChanAttached",
-	StateChanDetaching:    "ably.StateChanDetaching",
-	StateChanDetached:     "ably.StateChanDetached",
-	StateChanFailed:       "ably.StateChanFailed",
-}
-
-// stateAll lists all valid connection and channel state values.
-var stateAll = map[StateType][]StateEnum{
-	StateConn: {
-		StateConnInitialized,
-		StateConnConnecting,
-		StateConnConnected,
-		StateConnDisconnected,
-		StateConnSuspended,
-		StateConnClosing,
-		StateConnClosed,
-		StateConnFailed,
-	},
-	StateChan: {
-		StateChanInitialized,
-		StateChanAttaching,
-		StateChanAttached,
-		StateChanDetaching,
-		StateChanDetached,
-		StateChanFailed,
-	},
-}
-
-// stateMasks is used for testing connection and channel state values.
-var stateMasks = map[StateType]StateEnum{
-	StateConn: StateConnInitialized | StateConnConnecting | StateConnConnected |
-		StateConnDisconnected | StateConnSuspended | StateConnClosing | StateConnClosed |
-		StateConnFailed,
-	StateChan: StateChanInitialized | StateChanAttaching | StateChanAttached |
-		StateChanDetaching | StateChanDetached | StateChanFailed,
-}
-
 var (
 	errDisconnected   = newErrorf(80003, "Connection temporarily unavailable")
 	errSuspended      = newErrorf(80002, "Connection unavailable")
@@ -141,21 +30,20 @@ var (
 	errNeverConnected = newErrorf(80002, "Unable to establish connection")
 )
 
-var stateErrors = map[StateEnum]ErrorInfo{
-	StateConnInitialized:  *errNeverConnected,
-	StateConnDisconnected: *errDisconnected,
-	StateConnFailed:       *errFailed,
-	StateConnSuspended:    *errSuspended,
-	StateChanFailed:       *errFailed,
+var connStateErrors = map[ConnectionState]ErrorInfo{
+	ConnectionStateInitialized:  *errNeverConnected,
+	ConnectionStateDisconnected: *errDisconnected,
+	ConnectionStateFailed:       *errFailed,
+	ConnectionStateSuspended:    *errSuspended,
 }
 
-func stateError(state StateEnum, err error) *ErrorInfo {
+func connStateError(state ConnectionState, err error) *ErrorInfo {
 	// Set default error information associated with the target state.
 	e, ok := err.(*ErrorInfo)
 	if ok {
 		return e
 	}
-	if e, ok := stateErrors[state]; ok {
+	if e, ok := connStateErrors[state]; ok {
 		if err != nil {
 			e.err = err
 		}
@@ -164,179 +52,23 @@ func stateError(state StateEnum, err error) *ErrorInfo {
 	return newError(0, err)
 }
 
-// State describes a single state transition of either realtime connection or channel
-// that occurred due to some external condition (dropped connection, retried etc.).
-//
-// Each realtime connection and channel maintains its state to ensure high availability
-// and resilience, which is inherently asynchronous. In order to listen to transition
-// between states for both realtime connection and realtime channel user may provide
-// a channel, which will get notified with single State value for each transition
-// than takes place.
-type State struct {
-	Channel string     // channel name or empty if Type is StateConn
-	Err     *ErrorInfo // eventual error value associated with transition
-	State   StateEnum  // state which connection or channel has transitioned to
-	Type    StateType  // whether transition happened on connection or channel
+var channelStateErrors = map[ChannelState]ErrorInfo{
+	ChannelStateFailed: *errFailed,
 }
 
-type stateEmitter struct {
-	sync.Mutex
-	channel   string
-	listeners map[StateEnum]map[chan<- State]struct{}
-	onetime   map[StateEnum]map[chan<- State]struct{}
-	err       *ErrorInfo
-	current   StateEnum
-	typ       StateType
-	logger    *LoggerOptions
-
-	eventEmitter *eventEmitter
-}
-
-func newStateEmitter(typ StateType, startState StateEnum, channel string, log *LoggerOptions) *stateEmitter {
-	if !typ.Contains(startState) {
-		panic(`invalid start state: "` + startState.String() + `"`)
+func channelStateError(state ChannelState, err error) *ErrorInfo {
+	// Set default error information associated with the target state.
+	e, ok := err.(*ErrorInfo)
+	if ok {
+		return e
 	}
-	return &stateEmitter{
-		channel:   channel,
-		listeners: make(map[StateEnum]map[chan<- State]struct{}),
-		onetime:   make(map[StateEnum]map[chan<- State]struct{}),
-		current:   startState,
-		typ:       typ,
-		logger:    log,
-
-		eventEmitter: newEventEmitter(log),
-	}
-}
-
-func (s *stateEmitter) set(state StateEnum, err error) error {
-	previous := s.current
-	changed := s.current != state
-	s.current = state
-	s.err = stateError(state, err)
-	if changed || err != nil {
-		s.emit(State{
-			Channel: s.channel,
-			Err:     s.err,
-			State:   s.current,
-			Type:    s.typ,
-		})
-	}
-
-	if StateConn.Contains(state) {
-		previous := mapOldToNewConnState(previous)
-		change := ConnectionStateChange{
-			Current:  mapOldToNewConnState(s.current),
-			Previous: previous,
-			Reason:   s.err,
+	if e, ok := channelStateErrors[state]; ok {
+		if err != nil {
+			e.err = err
 		}
-		if !changed {
-			change.Event = ConnectionEventUpdated
-		} else {
-			change.Event = ConnectionEvent(change.Current)
-		}
-		s.eventEmitter.Emit(change.Event, change)
-	} else if StateChan.Contains(state) {
-		previous := mapOldToNewChanState(previous)
-		change := ChannelStateChange{
-			Current:  mapOldToNewChanState(s.current),
-			Previous: previous,
-			Reason:   s.err,
-		}
-		if !changed {
-			change.Event = ChannelEventUpdated
-		} else {
-			change.Event = ChannelEvent(change.Current)
-		}
-		s.eventEmitter.Emit(change.Event, change)
+		err = &e
 	}
-
-	return s.err
-}
-
-func (s *stateEmitter) emit(st State) {
-	for ch := range s.listeners[st.State] {
-		select {
-		case ch <- st:
-		default:
-			s.logger.Printf(LogWarning, "dropping %s due to slow receiver", st)
-		}
-	}
-	onetime := s.onetime[st.State]
-	if len(onetime) != 0 {
-		delete(s.onetime, st.State)
-		for ch := range onetime {
-			select {
-			case ch <- st:
-			default:
-				s.logger.Printf(LogWarning, "dropping %s due to slow receiver", st)
-			}
-			for _, l := range s.onetime {
-				delete(l, ch)
-			}
-		}
-	}
-}
-
-func (s *stateEmitter) syncSet(state StateEnum, err error) error {
-	s.Lock()
-	defer s.Unlock()
-	return s.set(state, err)
-}
-
-func (s *stateEmitter) once(ch chan<- State, states ...StateEnum) {
-	if len(states) == 0 {
-		states = stateAll[s.typ]
-	}
-	for _, state := range states {
-		l, ok := s.onetime[state]
-		if !ok {
-			l = make(map[chan<- State]struct{})
-			s.onetime[state] = l
-		}
-		l[ch] = struct{}{}
-	}
-}
-
-func (s *stateEmitter) on(ch chan<- State, states ...StateEnum) {
-	if ch == nil {
-		panic(fmt.Sprintf("ably: %s On using nil channel", s.typ))
-	}
-	if len(states) == 0 {
-		states = stateAll[s.typ]
-	}
-	s.Lock()
-	for _, state := range states {
-		if !s.typ.Contains(state) {
-			panic(fmt.Sprintf("ably: %s On using invalid state value: %s", s.typ, state.String()))
-		}
-		l, ok := s.listeners[state]
-		if !ok {
-			l = make(map[chan<- State]struct{})
-			s.listeners[state] = l
-		}
-		l[ch] = struct{}{}
-	}
-	s.Unlock()
-}
-
-func (s *stateEmitter) off(ch chan<- State, states ...StateEnum) {
-	if ch == nil {
-		panic(fmt.Sprintf("ably: %s Off using nil channel", s.typ))
-	}
-	if len(states) == 0 {
-		states = stateAll[s.typ]
-	}
-	s.Lock()
-	for _, state := range states {
-		if !s.typ.Contains(state) {
-			panic(fmt.Sprintf("ably: %s Off using invalid state value: %s", s.typ, state.String()))
-		}
-		delete(s.listeners[state], ch)
-		if len(s.listeners[state]) == 0 {
-			delete(s.listeners, state)
-		}
-	}
-	s.Unlock()
+	return newError(0, err)
 }
 
 // queuedEmitter emits confirmation events triggered by ACK or NACK messages.
@@ -514,44 +246,67 @@ func (res *errResult) Wait() error {
 	return res.err
 }
 
-type stateResult struct {
-	err      error
-	listen   <-chan State
-	expected StateEnum
+type resultFunc func() error
+
+func (f resultFunc) Wait() error {
+	return f()
 }
 
-func newResult(expected StateEnum) (Result, chan<- State) {
-	listen := make(chan State, 1)
-	res := &stateResult{listen: listen, expected: expected}
-	return res, listen
-}
+func (e ChannelEventEmitter) listenResult(expected ChannelState, failed ...ChannelState) Result {
+	changes := make(channelStateChanges, 1)
 
-func (s *stateEmitter) listenResult(states ...StateEnum) Result {
-	res, listen := newResult(states[0])
-	s.once(listen, states...)
-	return res
-}
-
-// Wait implements the Result interface.
-func (res *stateResult) Wait() error {
-	if res == nil {
-		return nil
+	var offs []func()
+	offs = append(offs, e.Once(ChannelEvent(expected), changes.Receive))
+	for _, ev := range failed {
+		offs = append(offs, e.Once(ChannelEvent(ev), changes.Receive))
 	}
-	if res.listen != nil {
-		switch state := <-res.listen; {
-		case state.State == res.expected:
-		case state.Err != nil:
-			res.err = state.Err
-		default:
-			code := 50001
-			if state.Type == StateConn {
-				code = 50002
+
+	return resultFunc(func() error {
+		defer func() {
+			for _, off := range offs {
+				off()
 			}
-			res.err = newError(code, fmt.Errorf("failed %s state: %s", state.Type, state.State))
+		}()
+
+		switch change := <-changes; {
+		case change.Current == expected:
+		case change.Reason != nil:
+			return change.Reason
+		default:
+			code := ErrInternalChannelError
+			return newError(code, fmt.Errorf("failed channel change: %s", change.Current))
 		}
-		res.listen = nil
+
+		return nil
+	})
+}
+func (e ConnectionEventEmitter) listenResult(expected ConnectionState, failed ...ConnectionState) Result {
+	changes := make(connStateChanges, 1)
+
+	var offs []func()
+	offs = append(offs, e.Once(ConnectionEvent(expected), changes.Receive))
+	for _, ev := range failed {
+		offs = append(offs, e.Once(ConnectionEvent(ev), changes.Receive))
 	}
-	return res.err
+
+	return resultFunc(func() error {
+		defer func() {
+			for _, off := range offs {
+				off()
+			}
+		}()
+
+		switch change := <-changes; {
+		case change.Current == expected:
+		case change.Reason != nil:
+			return change.Reason
+		default:
+			code := ErrInternalConnectionError
+			return newError(code, fmt.Errorf("failed connection change: %s", change.Current))
+		}
+
+		return nil
+	})
 }
 
 // A ConnectionState identifies the state of an Ably realtime connection.
@@ -613,29 +368,6 @@ type ConnectionStateChange struct {
 
 func (ConnectionStateChange) isEmitterData() {}
 
-func mapOldToNewConnState(old StateEnum) ConnectionState {
-	switch old {
-	case StateConnInitialized:
-		return ConnectionStateInitialized
-	case StateConnConnecting:
-		return ConnectionStateConnecting
-	case StateConnConnected:
-		return ConnectionStateConnected
-	case StateConnDisconnected:
-		return ConnectionStateDisconnected
-	case StateConnSuspended:
-		return ConnectionStateSuspended
-	case StateConnClosing:
-		return ConnectionStateClosing
-	case StateConnClosed:
-		return ConnectionStateClosed
-	case StateConnFailed:
-		return ConnectionStateFailed
-	default:
-		panic(fmt.Errorf("unexpected StateEnum: %v", old))
-	}
-}
-
 // A ChannelState identifies the state of an Ably realtime channel.
 type ChannelState struct {
 	name string
@@ -696,22 +428,3 @@ type ChannelStateChange struct {
 }
 
 func (ChannelStateChange) isEmitterData() {}
-
-func mapOldToNewChanState(old StateEnum) ChannelState {
-	switch old {
-	case StateChanInitialized:
-		return ChannelStateInitialized
-	case StateChanAttaching:
-		return ChannelStateAttaching
-	case StateChanAttached:
-		return ChannelStateAttached
-	case StateChanDetaching:
-		return ChannelStateDetaching
-	case StateChanDetached:
-		return ChannelStateDetached
-	case StateChanFailed:
-		return ChannelStateFailed
-	default:
-		panic(fmt.Errorf("unexpected StateEnum: %v", old))
-	}
-}


### PR DESCRIPTION
[RTL2](https://docs.ably.io/client-lib-development-guide/features/#RTL2). This also removes the old State machinery, including the temporary workarounds for bridging the two.