### PR TITLE
Ad-hoc fix for enqueuing attach attempt when DISCONNECTED.

### DIFF
--- a/ably/ablytest/timeout.go
+++ b/ably/ablytest/timeout.go
@@ -1,0 +1,65 @@
+package ablytest
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+var Instantly = Before(10 * time.Millisecond)
+
+var Soon = Before(Timeout)
+
+// Before returns a WithTimeout with the given timeout duration.
+func Before(d time.Duration) WithTimeout {
+	return WithTimeout{before: d}
+}
+
+// WithTimeout configures test helpers with a timeout.
+type WithTimeout struct {
+	before time.Duration
+}
+
+// Recv asserts that a value is received through channel from before the
+// timeout. If it isn't, the fail function is called.
+//
+// If into is non-nil, it must be a pointer to a variable of the same type as
+// from's element type and it will be set to the received value, if any.
+//
+// It returns the second, boolean value returned by the receive operation,
+// or false if the operation times out.
+func (wt WithTimeout) Recv(t *testing.T, into interface{}, from interface{}, fail func(fmt string, args ...interface{})) (ok bool) {
+	t.Helper()
+	ok, timeout := wt.recv(into, from)
+	if timeout {
+		fail("timed out waiting for channel receive")
+	}
+	return ok
+}
+
+// NoRecv is like Recv, except it asserts no value is received.
+func (wt WithTimeout) NoRecv(t *testing.T, into interface{}, from interface{}, fail func(fmt string, args ...interface{})) (ok bool) {
+	t.Helper()
+	if into == nil {
+		into = &into
+	}
+	ok, timeout := wt.recv(into, from)
+	if !timeout {
+		fail("unexpectedly received in channel: %v", into)
+	}
+	return ok
+}
+
+func (wt WithTimeout) recv(into interface{}, from interface{}) (ok, timeout bool) {
+	chosen, recv, ok := reflect.Select([]reflect.SelectCase{{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(from),
+	}, {
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(time.After(time.Duration(wt.before))),
+	}})
+	if chosen == 0 && ok && into != nil {
+		reflect.ValueOf(into).Elem().Set(recv)
+	}
+	return ok, chosen == 1
+}

--- a/ably/realtime_channel.go
+++ b/ably/realtime_channel.go
@@ -170,14 +170,14 @@ func (c *RealtimeChannel) mayAttach(result, checkActive bool) (Result, error) {
 
 	switch c.client.Connection.State() {
 	// RTL4b
-	case StateConnClosed,
+	case StateConnInitialized,
+		StateConnClosed,
 		StateConnClosing,
 		StateConnFailed:
 		return nil, newError(80000, errAttach)
 
 	// RTL4i
-	case StateConnInitialized,
-		StateConnConnecting,
+	case StateConnConnecting,
 		StateConnDisconnected:
 
 		return goWaiter(func() error {

--- a/ably/realtime_channel.go
+++ b/ably/realtime_channel.go
@@ -191,7 +191,10 @@ func (c *RealtimeChannel) mayAttach(result, checkActive bool) (Result, error) {
 				return err
 			}
 
-			return res.Wait()
+			if result {
+				return res.Wait()
+			}
+			return nil
 		}), nil
 	}
 

--- a/ably/realtime_channel.go
+++ b/ably/realtime_channel.go
@@ -182,9 +182,12 @@ func (c *RealtimeChannel) mayAttach(result, checkActive bool) (Result, error) {
 
 		return goWaiter(func() error {
 			connected := make(chan State, 1)
-			c.client.Connection.On(connected, StateConnConnected)
-			<-connected
+			c.client.Connection.On(connected, StateConnConnected, StateConnClosed, StateConnFailed)
+			state := <-connected
 			c.client.Connection.Off(connected)
+			if state.State != StateConnConnected {
+				return state.Err
+			}
 
 			res, err := c.mayAttach(result, checkActive)
 			if err != nil {

--- a/ably/realtime_channel.go
+++ b/ably/realtime_channel.go
@@ -173,7 +173,7 @@ func (c *RealtimeChannel) mayAttach(result, checkActive bool) (Result, error) {
 	case StateConnClosed,
 		StateConnClosing,
 		StateConnFailed:
-		return nil, errAttach
+		return nil, newError(80000, errAttach)
 
 	// RTL4i
 	case StateConnInitialized,

--- a/ably/realtime_channel_test.go
+++ b/ably/realtime_channel_test.go
@@ -46,47 +46,6 @@ func TestRealtimeChannel_Publish(t *testing.T) {
 	}
 }
 
-func TestRealtimeChannel_Failed(t *testing.T) {
-	t.Parallel()
-	rec := ablytest.NewStateChanRecorder(5)
-	opts := &ably.ClientOptions{
-		NoConnect:  true,
-		NoQueueing: true,
-		Listener:   rec.Channel(),
-	}
-	app, client := ablytest.NewRealtimeClient(opts)
-	defer safeclose(t, client, app)
-
-	if err := ablytest.Wait(client.Connection.Connect()); err != nil {
-		t.Fatalf("Connect()=%v", err)
-	}
-	channel := client.Channels.GetAndAttach("test")
-	if err := client.Close(); err != nil {
-		t.Fatalf("Close()=%v", err)
-	}
-	want := []ably.StateEnum{
-		ably.StateChanAttaching,
-		ably.StateChanAttached,
-		ably.StateChanClosed,
-		ably.StateChanFailed,
-	}
-	if err := rec.WaitFor(want[:3]); err != nil {
-		t.Fatal(err)
-	}
-	if err := checkError(80000, ablytest.Wait(channel.Publish("im", "closed"))); err != nil {
-		t.Fatal(err)
-	}
-	if err := rec.WaitFor(want); err != nil {
-		t.Fatal(err)
-	}
-	if err := checkError(80000, ablytest.Wait(channel.Detach())); err != nil {
-		t.Fatal(err)
-	}
-	if len(rec.Errors()) == 0 {
-		t.Fatal("want len(errors) != 0")
-	}
-}
-
 func TestRealtimeChannel_Subscribe(t *testing.T) {
 	t.Parallel()
 	app, client1 := ablytest.NewRealtimeClient(nil)

--- a/ably/realtime_channel_test.go
+++ b/ably/realtime_channel_test.go
@@ -3,12 +3,14 @@ package ably_test
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/ably/ably-go/ably"
 	"github.com/ably/ably-go/ably/ablytest"
+	"github.com/ably/ably-go/ably/internal/ablyutil"
 	"github.com/ably/ably-go/ably/proto"
 )
 
@@ -210,4 +212,57 @@ func TestRealtimeChannel_Close(t *testing.T) {
 		}
 	}
 	t.Error(err)
+}
+
+func TestRealtimeChannel_AttachWhileDisconnected(t *testing.T) {
+	t.Parallel()
+
+	doEOF := make(chan struct{}, 1)
+	allowDial := make(chan struct{}, 1)
+	allowDial <- struct{}{}
+
+	app, client := ablytest.NewRealtimeClient(&ably.ClientOptions{
+		NoConnect: true,
+		Dial: func(protocol string, u *url.URL) (proto.Conn, error) {
+			<-allowDial
+			c, err := ablyutil.DialWebsocket(protocol, u)
+			return protoConnWithFakeEOF{Conn: c, doEOF: doEOF}, err
+		},
+	})
+	defer safeclose(t, client, app)
+
+	channel := client.Channels.Get("test")
+
+	if err := ablytest.Wait(client.Connection.Connect()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Move to DISCONNECTED.
+
+	disconnected := make(chan ably.State, 1)
+	client.Connection.On(disconnected, ably.StateConnDisconnected)
+	doEOF <- struct{}{}
+	client.Connection.Off(disconnected, ably.StateConnDisconnected)
+
+	// Attempt ATTACH. It should be blocked until we're CONNECTED again.
+
+	attached := make(chan ably.State, 1)
+	channel.On(attached, ably.StateChanAttached)
+
+	res, err := channel.Attach()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ablytest.Before(1*time.Second).NoRecv(t, nil, attached, t.Fatalf)
+
+	// Allow another dial, which should eventually move the connection to
+	// CONNECTED, thus allowing the attachment to complete.
+
+	allowDial <- struct{}{}
+
+	ablytest.Soon.Recv(t, nil, attached, t.Fatalf)
+
+	if err := ablytest.Wait(res, nil); err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
To be converted to a proper spec-oriented test when ported to the 1.2 branch.

Fixes #189.