### PR TITLE
Always include serial values in encoded protocol messages

### DIFF
--- a/ably/proto/protocol_message.go
+++ b/ably/proto/protocol_message.go
@@ -85,8 +85,8 @@ type ProtocolMessage struct {
 	ChannelSerial     string             `json:"channelSerial,omitempty" codec:"channelSerial,omitempty"`
 	ConnectionDetails *ConnectionDetails `json:"connectionDetails,omitempty" codec:"connectionDetails,omitempty"`
 	Error             *ErrorInfo         `json:"error,omitempty" codec:"error,omitempty"`
-	MsgSerial         int64              `json:"msgSerial,omitempty" codec:"msgSerial,omitempty"`
-	ConnectionSerial  int64              `json:"connectionSerial,omitempty" codec:"connectionSerial,omitempty"`
+	MsgSerial         int64              `json:"msgSerial" codec:"msgSerial"`
+	ConnectionSerial  int64              `json:"connectionSerial" codec:"connectionSerial"`
 	Timestamp         int64              `json:"timestamp,omitempty" codec:"timestamp,omitempty"`
 	Count             int                `json:"count,omitempty" codec:"count,omitempty"`
 	Action            Action             `json:"action,omitempty" codec:"action,omitempty"`

--- a/ably/proto/protocol_message_test.go
+++ b/ably/proto/protocol_message_test.go
@@ -1,0 +1,28 @@
+package proto_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ably/ably-go/ably/internal/ablyutil"
+	"github.com/ably/ably-go/ably/proto"
+)
+
+// TestProtocolMessageEncodeZeroSerials tests that zero-valued serials are
+// explicitly encoded into msgpack (as required by the realtime API)
+func TestProtocolMessageEncodeZeroSerials(t *testing.T) {
+	msg := proto.ProtocolMessage{
+		ID:               "test",
+		MsgSerial:        0,
+		ConnectionSerial: 0,
+	}
+	encoded, err := ablyutil.Marshal(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// expect a 3-element map with both the serial fields set to zero
+	expected := []byte("\x83\xB0connectionSerial\x00\xA2id\xA4test\xA9msgSerial\x00")
+	if !bytes.Equal(encoded, expected) {
+		t.Fatalf("unexpected msgpack encoding\nexpected: %x\nactual:   %x", expected, encoded)
+	}
+}


### PR DESCRIPTION
Both `msgSerial` and `connectionSerial` are zero-based, but realtime does not treat the absence of these values as the same as zero, which when done for a realtime message triggers the following error:

```
Fatal protocol error: message published without msgSerial
```

This commit removes the `omitempty` tag from the serial fields so that their values are always included when they are encoded.

This behaviour was witnessed in our load testing environment where the client was setting the `msgSerial` back to zero after establishing a connection [here](https://github.com/ably/ably-go/blob/main/ably/realtime_conn.go#L473), assigning a zero `msgSerial` to the next message that was sent, and receiving a publish error.