### PR TITLE
Explicitly annotate enum vars so that godoc places them with the type

### DIFF
--- a/ably/state.go
+++ b/ably/state.go
@@ -326,14 +326,14 @@ type ConnectionState struct {
 }
 
 var (
-	ConnectionStateInitialized  = ConnectionState{name: "INITIALIZED"}
-	ConnectionStateConnecting   = ConnectionState{name: "CONNECTING"}
-	ConnectionStateConnected    = ConnectionState{name: "CONNECTED"}
-	ConnectionStateDisconnected = ConnectionState{name: "DISCONNECTED"}
-	ConnectionStateSuspended    = ConnectionState{name: "SUSPENDED"}
-	ConnectionStateClosing      = ConnectionState{name: "CLOSING"}
-	ConnectionStateClosed       = ConnectionState{name: "CLOSED"}
-	ConnectionStateFailed       = ConnectionState{name: "FAILED"}
+	ConnectionStateInitialized  ConnectionState = ConnectionState{name: "INITIALIZED"}
+	ConnectionStateConnecting   ConnectionState = ConnectionState{name: "CONNECTING"}
+	ConnectionStateConnected    ConnectionState = ConnectionState{name: "CONNECTED"}
+	ConnectionStateDisconnected ConnectionState = ConnectionState{name: "DISCONNECTED"}
+	ConnectionStateSuspended    ConnectionState = ConnectionState{name: "SUSPENDED"}
+	ConnectionStateClosing      ConnectionState = ConnectionState{name: "CLOSING"}
+	ConnectionStateClosed       ConnectionState = ConnectionState{name: "CLOSED"}
+	ConnectionStateFailed       ConnectionState = ConnectionState{name: "FAILED"}
 )
 
 func (e ConnectionState) String() string {
@@ -349,15 +349,15 @@ type ConnectionEvent struct {
 func (ConnectionEvent) isEmitterEvent() {}
 
 var (
-	ConnectionEventInitialized  = ConnectionEvent(ConnectionStateInitialized)
-	ConnectionEventConnecting   = ConnectionEvent(ConnectionStateConnecting)
-	ConnectionEventConnected    = ConnectionEvent(ConnectionStateConnected)
-	ConnectionEventDisconnected = ConnectionEvent(ConnectionStateDisconnected)
-	ConnectionEventSuspended    = ConnectionEvent(ConnectionStateSuspended)
-	ConnectionEventClosing      = ConnectionEvent(ConnectionStateClosing)
-	ConnectionEventClosed       = ConnectionEvent(ConnectionStateClosed)
-	ConnectionEventFailed       = ConnectionEvent(ConnectionStateFailed)
-	ConnectionEventUpdated      = ConnectionEvent{name: "UPDATED"}
+	ConnectionEventInitialized  ConnectionEvent = ConnectionEvent(ConnectionStateInitialized)
+	ConnectionEventConnecting   ConnectionEvent = ConnectionEvent(ConnectionStateConnecting)
+	ConnectionEventConnected    ConnectionEvent = ConnectionEvent(ConnectionStateConnected)
+	ConnectionEventDisconnected ConnectionEvent = ConnectionEvent(ConnectionStateDisconnected)
+	ConnectionEventSuspended    ConnectionEvent = ConnectionEvent(ConnectionStateSuspended)
+	ConnectionEventClosing      ConnectionEvent = ConnectionEvent(ConnectionStateClosing)
+	ConnectionEventClosed       ConnectionEvent = ConnectionEvent(ConnectionStateClosed)
+	ConnectionEventFailed       ConnectionEvent = ConnectionEvent(ConnectionStateFailed)
+	ConnectionEventUpdated      ConnectionEvent = ConnectionEvent{name: "UPDATED"}
 )
 
 func (e ConnectionEvent) String() string {
@@ -385,13 +385,13 @@ type ChannelState struct {
 }
 
 var (
-	ChannelStateInitialized = ChannelState{name: "INITIALIZED"}
-	ChannelStateAttaching   = ChannelState{name: "ATTACHING"}
-	ChannelStateAttached    = ChannelState{name: "ATTACHED"}
-	ChannelStateDetaching   = ChannelState{name: "DETACHING"}
-	ChannelStateDetached    = ChannelState{name: "DETACHED"}
-	ChannelStateSuspended   = ChannelState{name: "SUSPENDED"}
-	ChannelStateFailed      = ChannelState{name: "FAILED"}
+	ChannelStateInitialized ChannelState = ChannelState{name: "INITIALIZED"}
+	ChannelStateAttaching   ChannelState = ChannelState{name: "ATTACHING"}
+	ChannelStateAttached    ChannelState = ChannelState{name: "ATTACHED"}
+	ChannelStateDetaching   ChannelState = ChannelState{name: "DETACHING"}
+	ChannelStateDetached    ChannelState = ChannelState{name: "DETACHED"}
+	ChannelStateSuspended   ChannelState = ChannelState{name: "SUSPENDED"}
+	ChannelStateFailed      ChannelState = ChannelState{name: "FAILED"}
 )
 
 func (e ChannelState) String() string {
@@ -407,14 +407,14 @@ type ChannelEvent struct {
 func (ChannelEvent) isEmitterEvent() {}
 
 var (
-	ChannelEventInitialized = ChannelEvent(ChannelStateInitialized)
-	ChannelEventAttaching   = ChannelEvent(ChannelStateAttaching)
-	ChannelEventAttached    = ChannelEvent(ChannelStateAttached)
-	ChannelEventDetaching   = ChannelEvent(ChannelStateDetaching)
-	ChannelEventDetached    = ChannelEvent(ChannelStateDetached)
-	ChannelEventSuspended   = ChannelEvent(ChannelStateSuspended)
-	ChannelEventFailed      = ChannelEvent(ChannelStateFailed)
-	ChannelEventUpdated     = ChannelEvent{name: "UPDATED"}
+	ChannelEventInitialized ChannelEvent = ChannelEvent(ChannelStateInitialized)
+	ChannelEventAttaching   ChannelEvent = ChannelEvent(ChannelStateAttaching)
+	ChannelEventAttached    ChannelEvent = ChannelEvent(ChannelStateAttached)
+	ChannelEventDetaching   ChannelEvent = ChannelEvent(ChannelStateDetaching)
+	ChannelEventDetached    ChannelEvent = ChannelEvent(ChannelStateDetached)
+	ChannelEventSuspended   ChannelEvent = ChannelEvent(ChannelStateSuspended)
+	ChannelEventFailed      ChannelEvent = ChannelEvent(ChannelStateFailed)
+	ChannelEventUpdated     ChannelEvent = ChannelEvent{name: "UPDATED"}
 )
 
 func (e ChannelEvent) String() string {


### PR DESCRIPTION
Turns out, if you left a top-level variable implicitly typed, it goes to the generic "Variables" section instead of to its type's section.

We go from this:

<img width="638" alt="Screenshot 2020-10-07 at 12 02 35" src="https://user-images.githubusercontent.com/727422/95317193-217e3280-0895-11eb-8112-45906d7557b8.png">

To this:

<img width="668" alt="Screenshot 2020-10-07 at 12 03 21" src="https://user-images.githubusercontent.com/727422/95317209-2642e680-0895-11eb-946c-ffbe614c3dc8.png">

<img width="579" alt="Screenshot 2020-10-07 at 12 03 07" src="https://user-images.githubusercontent.com/727422/95317227-2a6f0400-0895-11eb-9796-49c45c0ebcb8.png">
