### PR TITLE
RTL6c: Publish while not connected

### DIFF
--- a/ably/ably_test.go
+++ b/ably/ably_test.go
@@ -56,6 +56,12 @@ func safeclose(t *testing.T, closers ...io.Closer) {
 	}
 }
 
+type closeFunc func() error
+
+func (f closeFunc) Close() error {
+	return f()
+}
+
 func checkError(code ably.ErrorCode, err error) error {
 	switch e, ok := err.(*ably.ErrorInfo); {
 	case !ok:
@@ -74,4 +80,10 @@ func init() {
 	ablytest.ClientOptionsInspector.HTTPClient = func(o []ably.ClientOption) *http.Client {
 		return ably.ApplyOptionsWithDefaults(o...).HTTPClient
 	}
+}
+
+type messages chan *ably.Message
+
+func (ms messages) Receive(m *ably.Message) {
+	ms <- m
 }

--- a/ably/ablytest/ablytest.go
+++ b/ably/ablytest/ablytest.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/ably/ably-go/ably"
@@ -124,4 +125,54 @@ func ReceivePresenceMessages(channel *ably.RealtimeChannel, action *ably.Presenc
 		unsubscribe, err = channel.Presence.Subscribe(context.Background(), *action, ch.Receive)
 	}
 	return ch, unsubscribe, err
+}
+
+type AfterCall struct {
+	Ctx  context.Context
+	D    time.Duration
+	Time chan<- time.Time
+}
+
+// TimeFuncs returns time functions to be passed as options.
+//
+// Now returns a stable time that is only updated with the times that the
+// returned After produces.
+//
+// After forwards calls to the given channel. The receiver is in charge of
+// sending the resulting time to the AfterCall.Time channel.
+func TimeFuncs(afterCalls chan<- AfterCall) (
+	now func() time.Time,
+	after func(context.Context, time.Duration) <-chan time.Time,
+) {
+	var mtx sync.Mutex
+	currentTime := time.Now()
+	now = func() time.Time {
+		mtx.Lock()
+		defer mtx.Unlock()
+		return currentTime
+	}
+
+	after = func(ctx context.Context, d time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+
+		timeUpdates := make(chan time.Time, 1)
+		go func() {
+			t, ok := <-timeUpdates
+			if !ok {
+				close(ch)
+				return
+
+			}
+			mtx.Lock()
+			currentTime = t
+			mtx.Unlock()
+			ch <- t
+		}()
+
+		afterCalls <- AfterCall{Ctx: ctx, D: d, Time: timeUpdates}
+
+		return ch
+	}
+
+	return now, after
 }

--- a/ably/ablytest/recorders.go
+++ b/ably/ablytest/recorders.go
@@ -578,10 +578,6 @@ func (c realtimeIOCloser) Close() error {
 		ably.ConnectionStateClosed,
 		ably.ConnectionStateFailed:
 
-		err := c.c.Connection.ErrorReason()
-		if err != nil {
-			return err
-		}
 		return nil
 	}
 

--- a/ably/auth_test.go
+++ b/ably/auth_test.go
@@ -576,7 +576,7 @@ func TestAuth_RequestToken_PublishClientID(t *testing.T) {
 		}
 		client := app.NewRealtime(opts...)
 		defer safeclose(t, ablytest.FullRealtimeCloser(client))
-		if err = ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected).Wait(); err != nil {
+		if err = ablytest.Wait(ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected), nil); err != nil {
 			t.Fatalf("Connect(): want err == nil got err=%v", err)
 		}
 		if id := client.Auth.ClientID(); id != cas.clientID {
@@ -664,7 +664,7 @@ func TestAuth_ClientID(t *testing.T) {
 	if id := client.Auth.ClientID(); id != "" {
 		t.Fatalf("want clientID to be empty; got %q", id)
 	}
-	if err := ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected).Wait(); err != nil {
+	if err := ablytest.Wait(ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected), nil); err != nil {
 		t.Fatalf("Connect()=%v", err)
 	}
 	if id := client.Auth.ClientID(); id != connected.ConnectionDetails.ClientID {
@@ -802,7 +802,7 @@ func TestAuth_RealtimeAccessToken(t *testing.T) {
 	app, client := ablytest.NewRealtime(opts...)
 	defer safeclose(t, app)
 
-	if err := ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected).Wait(); err != nil {
+	if err := ablytest.Wait(ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected), nil); err != nil {
 		t.Fatalf("Connect()=%v", err)
 	}
 	if err := client.Channels.Get("test").Publish(context.Background(), "name", "value"); err != nil {

--- a/ably/internal/ablyutil/time.go
+++ b/ably/internal/ablyutil/time.go
@@ -37,7 +37,7 @@ func NewTicker(after TimerFunc) TimerFunc {
 
 		go func() {
 			for {
-				t, ok := <-After(ctx, d)
+				t, ok := <-after(ctx, d)
 				if !ok {
 					close(ch)
 					return

--- a/ably/internal/ablyutil/time.go
+++ b/ably/internal/ablyutil/time.go
@@ -11,7 +11,7 @@ import (
 func After(ctx context.Context, d time.Duration) <-chan time.Time {
 	timer := time.NewTimer(d)
 
-	ch := make(chan time.Time)
+	ch := make(chan time.Time, 1)
 
 	go func() {
 		defer timer.Stop()
@@ -24,4 +24,28 @@ func After(ctx context.Context, d time.Duration) <-chan time.Time {
 	}()
 
 	return ch
+}
+
+type TimerFunc func(context.Context, time.Duration) <-chan time.Time
+
+// NewTicker repeatedly calls the given TimerFunc, which should behave like
+// After, until the context it cancelled. It returns a channel to which it sends
+// every value produced by the TimerFunc.
+func NewTicker(after TimerFunc) TimerFunc {
+	return func(ctx context.Context, d time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+
+		go func() {
+			for {
+				t, ok := <-After(ctx, d)
+				if !ok {
+					close(ch)
+					return
+				}
+				ch <- t
+			}
+		}()
+
+		return ch
+	}
 }

--- a/ably/realtime_channel.go
+++ b/ably/realtime_channel.go
@@ -191,7 +191,10 @@ func (c *RealtimeChannel) mayAttach(result, checkActive bool) (Result, error) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 	if checkActive {
-		if c.isActive() {
+		switch c.state {
+		case ChannelStateAttaching:
+			return c.listenResult(ChannelStateAttached, ChannelStateFailed), nil
+		case ChannelStateAttached:
 			return nopResult, nil
 		}
 	}

--- a/ably/realtime_channel.go
+++ b/ably/realtime_channel.go
@@ -162,6 +162,8 @@ func (c *RealtimeChannel) onConnStateChange(change ConnectionStateChange) {
 	active := c.isActive()
 	c.mtx.Unlock()
 	switch change.Current {
+	case ConnectionStateConnected:
+		c.queue.Flush()
 	case ConnectionStateFailed:
 		if active {
 			c.setState(ChannelStateFailed, change.Reason)

--- a/ably/realtime_channel_spec_test.go
+++ b/ably/realtime_channel_spec_test.go
@@ -226,11 +226,25 @@ func TestRealtimeChannel_RTL6c2_PublishEnqueue(t *testing.T) {
 
 	var cases []transitionsCase
 
-	// When connection is INITIALIZED or first CONNECTING, channel can only be
-	// INITIALIZED or ATTACHING.
+	// When connection is INITIALIZED, channel can only be INITIALIZED.
 
 	for _, connBefore := range [][]ably.ConnectionState{
 		{initialized},
+	} {
+		for _, channel := range [][]ably.ChannelState{
+			{chInitialized},
+		} {
+			cases = append(cases, transitionsCase{
+				connBefore: connBefore,
+				channel:    channel,
+			})
+		}
+	}
+
+	// When connection is first CONNECTING, channel can only be INITIALIZED or
+	// ATTACHING.
+
+	for _, connBefore := range [][]ably.ConnectionState{
 		{connecting},
 		{connecting, disconnected},
 	} {
@@ -432,18 +446,6 @@ func TestRealtimeChannel_RTL6c4_PublishFail(t *testing.T) {
 			}
 		})
 	}
-}
-
-func expectActions(t *testing.T, protoMsgs <-chan *proto.ProtocolMessage, actions ...proto.Action) {
-	t.Helper()
-	for _, a := range actions {
-		var msg *proto.ProtocolMessage
-		ablytest.Instantly.Recv(t, &msg, protoMsgs, t.Fatalf)
-		if expected, got := a, msg.Action; expected != got {
-			t.Fatalf("expected message with action %v, got %#v", expected, msg)
-		}
-	}
-	ablytest.Instantly.NoRecv(t, nil, protoMsgs, t.Fatalf)
 }
 
 func TestRealtimeChannel_RTL13_HandleDetached(t *testing.T) {

--- a/ably/realtime_channel_spec_test.go
+++ b/ably/realtime_channel_spec_test.go
@@ -448,6 +448,27 @@ func TestRealtimeChannel_RTL6c4_PublishFail(t *testing.T) {
 	}
 }
 
+func TestRealtimeChannel_RTL6c5_NoImplicitAttach(t *testing.T) {
+	t.Parallel()
+
+	app, c := ablytest.NewRealtime()
+	defer safeclose(t, app, ablytest.FullRealtimeCloser(c))
+
+	if err := ablytest.Wait(ablytest.ConnWaiter(c, c.Connect, ably.ConnectionEventConnected), nil); err != nil {
+		t.Fatal(err)
+	}
+
+	channel := c.Channels.Get("test")
+	err := channel.Publish(context.Background(), "test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if channel.State() == chAttached {
+		t.Fatal("channel implicitly attached")
+	}
+}
+
 func TestRealtimeChannel_RTL13_HandleDetached(t *testing.T) {
 	t.Parallel()
 

--- a/ably/realtime_channel_spec_test.go
+++ b/ably/realtime_channel_spec_test.go
@@ -187,7 +187,7 @@ func TestRealtimeChannel_RTL13_HandleDetached(t *testing.T) {
 			ConnectionDetails: &proto.ConnectionDetails{},
 		}
 
-		err := ablytest.ConnWaiter(c, c.Connect, ably.ConnectionEventConnected).Wait()
+		err := ablytest.Wait(ablytest.ConnWaiter(c, c.Connect, ably.ConnectionEventConnected), nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -379,9 +379,9 @@ func TestRealtimeChannel_RTL13_HandleDetached(t *testing.T) {
 
 		// Get the connection to a non-CONNECTED state by closing in.
 
-		err := ablytest.ConnWaiter(c, func() {
+		err := ablytest.Wait(ablytest.ConnWaiter(c, func() {
 			close(in)
-		}, ably.ConnectionEventDisconnected).Wait()
+		}, ably.ConnectionEventDisconnected), nil)
 		if !errors.Is(err, io.EOF) {
 			t.Fatal(err)
 		}

--- a/ably/realtime_channel_test.go
+++ b/ably/realtime_channel_test.go
@@ -40,7 +40,7 @@ func TestRealtimeChannel_Publish(t *testing.T) {
 	t.Parallel()
 	app, client := ablytest.NewRealtime(nil...)
 	defer safeclose(t, ablytest.FullRealtimeCloser(client), app)
-	if err := ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected).Wait(); err != nil {
+	if err := ablytest.Wait(ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected), nil); err != nil {
 		t.Fatal(err)
 	}
 	channel := client.Channels.Get("test")
@@ -55,10 +55,10 @@ func TestRealtimeChannel_Subscribe(t *testing.T) {
 	defer safeclose(t, ablytest.FullRealtimeCloser(client1), app)
 	client2 := app.NewRealtime(ably.WithEchoMessages(false))
 	defer safeclose(t, ablytest.FullRealtimeCloser(client2))
-	if err := ablytest.ConnWaiter(client1, client1.Connect, ably.ConnectionEventConnected).Wait(); err != nil {
+	if err := ablytest.Wait(ablytest.ConnWaiter(client1, client1.Connect, ably.ConnectionEventConnected), nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := ablytest.ConnWaiter(client2, client2.Connect, ably.ConnectionEventConnected).Wait(); err != nil {
+	if err := ablytest.Wait(ablytest.ConnWaiter(client2, client2.Connect, ably.ConnectionEventConnected), nil); err != nil {
 		t.Fatal(err)
 	}
 	channel1 := client1.Channels.Get("test")
@@ -110,7 +110,7 @@ func TestRealtimeChannel_Detach(t *testing.T) {
 	t.Parallel()
 	app, client := ablytest.NewRealtime()
 	defer safeclose(t, ablytest.FullRealtimeCloser(client), app)
-	if err := ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected).Wait(); err != nil {
+	if err := ablytest.Wait(ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected), nil); err != nil {
 		t.Fatal(err)
 	}
 	channel := client.Channels.Get("test")
@@ -188,7 +188,7 @@ func TestRealtimeChannel_AttachWhileDisconnected(t *testing.T) {
 
 	res := make(chan ably.Result)
 	go func() {
-		res <- ablytest.ResultFunc.Go(func() error { return channel.Attach(context.Background()) })
+		res <- ablytest.ResultFunc.Go(func(ctx context.Context) error { return channel.Attach(ctx) })
 	}()
 	ablytest.Before(1*time.Second).NoRecv(t, nil, attached, t.Fatalf)
 

--- a/ably/realtime_client.go
+++ b/ably/realtime_client.go
@@ -75,7 +75,7 @@ func (c *Realtime) onReconnected(err *proto.ErrorInfo, isNewID bool) {
 		switch ch.State() {
 		// TODO: SUSPENDED
 		case ChannelStateAttaching, ChannelStateAttached:
-			ch.mayAttach(false, false)
+			ch.mayAttach(false)
 		}
 	}
 }

--- a/ably/realtime_client.go
+++ b/ably/realtime_client.go
@@ -66,8 +66,8 @@ func (c *Realtime) onChannelMsg(msg *proto.ProtocolMessage) {
 	c.Channels.Get(msg.Channel).notify(msg)
 }
 
-func (c *Realtime) onReconnected(err *proto.ErrorInfo, isNewID bool) {
-	if err == nil /* RTN15c3 */ && !isNewID /* RTN15g3 */ {
+func (c *Realtime) onReconnected(isNewID bool) {
+	if !isNewID /* RTN15c3, RTN15g3 */ {
 		// No need to reattach: state is preserved. We just need to flush the
 		// queue of pending messages.
 		for _, ch := range c.Channels.All() {

--- a/ably/realtime_client.go
+++ b/ably/realtime_client.go
@@ -68,6 +68,11 @@ func (c *Realtime) onChannelMsg(msg *proto.ProtocolMessage) {
 
 func (c *Realtime) onReconnected(err *proto.ErrorInfo, isNewID bool) {
 	if err == nil /* RTN15c3 */ && !isNewID /* RTN15g3 */ {
+		// No need to reattach: state is preserved. We just need to flush the
+		// queue of pending messages.
+		for _, ch := range c.Channels.All() {
+			ch.queue.Flush()
+		}
 		return
 	}
 

--- a/ably/realtime_client_test.go
+++ b/ably/realtime_client_test.go
@@ -118,11 +118,14 @@ func TestRealtime_multiple(t *testing.T) {
 			for j := 0; j < 10; j++ {
 				channel := c.Channels.Get(fmt.Sprintf("client/%d/channel/%d", i, j))
 				rg.GoAdd(func(ctx context.Context) error { return channel.Presence.Leave(ctx, "") })
-				rg.GoAdd(func(ctx context.Context) error { return channel.Detach(ctx) })
-				rg.GoAdd(func(ctx context.Context) error { return channel.Detach(ctx) })
 			}
 			if err := rg.Wait(); err != nil {
 				all.Add(nil, err)
+			}
+			for j := 0; j < 10; j++ {
+				channel := c.Channels.Get(fmt.Sprintf("client/%d/channel/%d", i, j))
+				rg.GoAdd(func(ctx context.Context) error { return channel.Detach(ctx) })
+				rg.GoAdd(func(ctx context.Context) error { return channel.Detach(ctx) })
 			}
 			idch <- c.Connection.ID()
 			keych <- c.Connection.Key()

--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -75,7 +75,7 @@ type connCallbacks struct {
 	// move this up because some implementation details for (RTN15c) requires
 	// access to Channels and we dont have it here so we let RealtimeClient do the
 	// work.
-	onReconnected func(_ *proto.ErrorInfo, isNewID bool)
+	onReconnected func(isNewID bool)
 	// onReconnectionFailed is called when we get a FAILED response from a
 	// reconnection request.
 	onReconnectionFailed func(*proto.ErrorInfo)
@@ -784,7 +784,7 @@ func (c *Connection) eventloop() {
 				// we are calling this outside of locks to avoid deadlock because in the
 				// RealtimeClient client where this callback is implemented we do some ops
 				// with this Conn where we re acquire Conn.Lock again.
-				c.callbacks.onReconnected(msg.Error, previousID != msg.ConnectionID)
+				c.callbacks.onReconnected(previousID != msg.ConnectionID)
 			} else {
 				// preserve old behavior.
 				c.mtx.Lock()

--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -663,14 +663,13 @@ func (c *Connection) eventloop() {
 	var lastActivityAt time.Time
 	var connDetails *proto.ConnectionDetails
 	for c.lockCanReceiveMessages() {
-		var deadline time.Time
+		receiveTimeout := c.opts.realtimeRequestTimeout()
 		if connDetails != nil {
 			maxIdleInterval := time.Duration(connDetails.MaxIdleInterval)
-			receiveTimeout := c.opts.realtimeRequestTimeout() + maxIdleInterval // RTN23a
-			deadline = c.opts.Now().Add(receiveTimeout)                         // RTNf23a
+			receiveTimeout += maxIdleInterval // RTN23a
 		}
 		c.connMtx.Lock()
-		msg, err := c.conn.Receive(deadline)
+		msg, err := c.conn.Receive(c.opts.Now().Add(receiveTimeout))
 		c.connMtx.Unlock()
 		if err != nil {
 			c.mtx.Lock()

--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -95,6 +95,7 @@ func newConn(opts *clientOptions, auth *Auth, callbacks connCallbacks) *Connecti
 	}
 	c.queue = newMsgQueue(c)
 	if !opts.NoConnect {
+		c.setState(ConnectionStateConnecting, nil, 0)
 		go func() {
 			lg := opts.Logger.sugar()
 			lg.Info("Trying to establish a connection asynchronously")

--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -738,13 +738,11 @@ func (c *Connection) eventloop() {
 				c.mtx.Lock()
 				c.lockSetState(ConnectionStateConnected, newErrorFromProto(msg.Error), 0)
 				c.mtx.Unlock()
-				if previousID != msg.ConnectionID {
-					// (RTN15c3)
-					// we are calling this outside of locks to avoid deadlock because in the
-					// RealtimeClient client where this callback is implemented we do some ops
-					// with this Conn where we re acquire Conn.Lock again.
-					c.callbacks.onReconnected(msg.Error, true)
-				}
+				// (RTN15c3)
+				// we are calling this outside of locks to avoid deadlock because in the
+				// RealtimeClient client where this callback is implemented we do some ops
+				// with this Conn where we re acquire Conn.Lock again.
+				c.callbacks.onReconnected(msg.Error, previousID != msg.ConnectionID)
 			} else {
 				// preserve old behavior.
 				c.mtx.Lock()

--- a/ably/realtime_conn_spec_test.go
+++ b/ably/realtime_conn_spec_test.go
@@ -196,7 +196,7 @@ func TestRealtimeConn_RTN15a_ReconnectOnEOF(t *testing.T) {
 		}))
 	defer safeclose(t, ablytest.FullRealtimeCloser(client), app)
 
-	if err := ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected).Wait(); err != nil {
+	if err := ablytest.Wait(ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected), nil); err != nil {
 		t.Fatalf("Connect=%s", err)
 	}
 
@@ -333,7 +333,7 @@ func TestRealtimeConn_RTN15b(t *testing.T) {
 		}))
 	defer safeclose(t, ablytest.FullRealtimeCloser(client), app)
 
-	if err := ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected).Wait(); err != nil {
+	if err := ablytest.Wait(ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected), nil); err != nil {
 		t.Fatalf("Connect=%s", err)
 	}
 
@@ -463,7 +463,7 @@ func TestRealtimeConn_RTN15c1(t *testing.T) {
 		}))
 	defer safeclose(t, ablytest.FullRealtimeCloser(client), app)
 
-	if err := ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected).Wait(); err != nil {
+	if err := ablytest.Wait(ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected), nil); err != nil {
 		t.Fatalf("Connect=%s", err)
 	}
 
@@ -582,7 +582,7 @@ func TestRealtimeConn_RTN15c2(t *testing.T) {
 		}))
 	defer safeclose(t, ablytest.FullRealtimeCloser(client), app)
 
-	if err := ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected).Wait(); err != nil {
+	if err := ablytest.Wait(ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected), nil); err != nil {
 		t.Fatalf("Connect=%s", err)
 	}
 
@@ -711,7 +711,7 @@ func TestRealtimeConn_RTN15c3_attached(t *testing.T) {
 		}))
 	defer safeclose(t, ablytest.FullRealtimeCloser(client), app)
 
-	if err := ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected).Wait(); err != nil {
+	if err := ablytest.Wait(ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected), nil); err != nil {
 		t.Fatalf("Connect=%s", err)
 	}
 
@@ -822,7 +822,7 @@ func TestRealtimeConn_RTN15c3_attaching(t *testing.T) {
 		}))
 	defer safeclose(t, ablytest.FullRealtimeCloser(client), app)
 
-	if err := ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected).Wait(); err != nil {
+	if err := ablytest.Wait(ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected), nil); err != nil {
 		t.Fatalf("Connect=%s", err)
 	}
 
@@ -928,7 +928,7 @@ func TestRealtimeConn_RTN15c4(t *testing.T) {
 		}))
 	defer safeclose(t, &closeClient{Closer: ablytest.FullRealtimeCloser(client), skip: []int{http.StatusBadRequest}}, app)
 
-	if err := ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected).Wait(); err != nil {
+	if err := ablytest.Wait(ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected), nil); err != nil {
 		t.Fatalf("Connect=%s", err)
 	}
 
@@ -1016,7 +1016,7 @@ func TestRealtimeConn_RTN15d_MessageRecovery(t *testing.T) {
 		}))
 	defer safeclose(t, ablytest.FullRealtimeCloser(client), app)
 
-	if err := ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected).Wait(); err != nil {
+	if err := ablytest.Wait(ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected), nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1032,9 +1032,9 @@ func TestRealtimeConn_RTN15d_MessageRecovery(t *testing.T) {
 	}
 	defer unsub()
 
-	if err := ablytest.ConnWaiter(client, func() {
+	if err := ablytest.Wait(ablytest.ConnWaiter(client, func() {
 		doEOF <- struct{}{}
-	}, ably.ConnectionEventDisconnected).Wait(); !errors.Is(err, io.EOF) {
+	}, ably.ConnectionEventDisconnected), nil); !errors.Is(err, io.EOF) {
 		t.Fatal(err)
 	}
 
@@ -1055,9 +1055,9 @@ func TestRealtimeConn_RTN15d_MessageRecovery(t *testing.T) {
 
 	// Now let the connection reconnect.
 
-	if err := ablytest.ConnWaiter(client, func() {
+	if err := ablytest.Wait(ablytest.ConnWaiter(client, func() {
 		allowDial <- struct{}{}
-	}, ably.ConnectionEventConnected).Wait(); err != nil {
+	}, ably.ConnectionEventConnected), nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1087,7 +1087,7 @@ func TestRealtimeConn_RTN15e_ConnKeyUpdatedOnReconnect(t *testing.T) {
 		}))
 	defer safeclose(t, ablytest.FullRealtimeCloser(client), app)
 
-	if err := ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected).Wait(); err != nil {
+	if err := ablytest.Wait(ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected), nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1164,7 +1164,7 @@ func TestRealtimeConn_RTN15g_NewConnectionOnStateLost(t *testing.T) {
 		}))
 
 	connIDs <- "conn-1"
-	err := ablytest.ConnWaiter(c, c.Connect, ably.ConnectionEventConnected).Wait()
+	err := ablytest.Wait(ablytest.ConnWaiter(c, c.Connect, ably.ConnectionEventConnected), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1174,13 +1174,13 @@ func TestRealtimeConn_RTN15g_NewConnectionOnStateLost(t *testing.T) {
 	// Get channels to ATTACHING, ATTACHED and DETACHED. (TODO: SUSPENDED)
 
 	attaching := c.Channels.Get("attaching")
-	_ = ablytest.ResultFunc.Go(func() error { return attaching.Attach(context.Background()) })
+	_ = ablytest.ResultFunc.Go(func(ctx context.Context) error { return attaching.Attach(ctx) })
 	if msg := <-out; msg.Action != proto.ActionAttach {
 		t.Fatalf("expected ATTACH, got %v", msg)
 	}
 
 	attached := c.Channels.Get("attached")
-	attachWaiter := ablytest.ResultFunc.Go(func() error { return attached.Attach(context.Background()) })
+	attachWaiter := ablytest.ResultFunc.Go(func(ctx context.Context) error { return attached.Attach(ctx) })
 	if msg := <-out; msg.Action != proto.ActionAttach {
 		t.Fatalf("expected ATTACH, got %v", msg)
 	}
@@ -1191,7 +1191,7 @@ func TestRealtimeConn_RTN15g_NewConnectionOnStateLost(t *testing.T) {
 	ablytest.Wait(attachWaiter, err)
 
 	detached := c.Channels.Get("detached")
-	attachWaiter = ablytest.ResultFunc.Go(func() error { return detached.Attach(context.Background()) })
+	attachWaiter = ablytest.ResultFunc.Go(func(ctx context.Context) error { return detached.Attach(ctx) })
 	if msg := <-out; msg.Action != proto.ActionAttach {
 		t.Fatalf("expected ATTACH, got %v", msg)
 	}
@@ -1200,7 +1200,7 @@ func TestRealtimeConn_RTN15g_NewConnectionOnStateLost(t *testing.T) {
 		Channel: "detached",
 	}
 	ablytest.Wait(attachWaiter, err)
-	detachWaiter := ablytest.ResultFunc.Go(func() error { return detached.Detach(context.Background()) })
+	detachWaiter := ablytest.ResultFunc.Go(func(ctx context.Context) error { return detached.Detach(ctx) })
 	if msg := <-out; msg.Action != proto.ActionDetach {
 		t.Fatalf("expected DETACH, got %v", msg)
 	}
@@ -1285,7 +1285,7 @@ func TestRealtimeConn_RTN15h1_OnDisconnectedCannotRenewToken(t *testing.T) {
 		ConnectionDetails: &proto.ConnectionDetails{},
 	}
 
-	err := ablytest.ConnWaiter(c, c.Connect, ably.ConnectionEventConnected).Wait()
+	err := ablytest.Wait(ablytest.ConnWaiter(c, c.Connect, ably.ConnectionEventConnected), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1296,12 +1296,12 @@ func TestRealtimeConn_RTN15h1_OnDisconnectedCannotRenewToken(t *testing.T) {
 		Message:    "fake token error",
 	}
 
-	err = ablytest.ConnWaiter(c, func() {
+	err = ablytest.Wait(ablytest.ConnWaiter(c, func() {
 		in <- &proto.ProtocolMessage{
 			Action: proto.ActionDisconnected,
 			Error:  &tokenErr,
 		}
-	}, ably.ConnectionEventFailed).Wait()
+	}, ably.ConnectionEventFailed), nil)
 
 	var errInfo *ably.ErrorInfo
 	if !errors.As(err, &errInfo) {
@@ -1342,7 +1342,7 @@ func TestRealtimeConn_RTN15h2_ReauthFails(t *testing.T) {
 		ConnectionDetails: &proto.ConnectionDetails{},
 	}
 
-	err := ablytest.ConnWaiter(c, c.Connect, ably.ConnectionEventConnected).Wait()
+	err := ablytest.Wait(ablytest.ConnWaiter(c, c.Connect, ably.ConnectionEventConnected), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1353,12 +1353,12 @@ func TestRealtimeConn_RTN15h2_ReauthFails(t *testing.T) {
 		Message:    "fake token error",
 	}
 
-	err = ablytest.ConnWaiter(c, func() {
+	err = ablytest.Wait(ablytest.ConnWaiter(c, func() {
 		in <- &proto.ProtocolMessage{
 			Action: proto.ActionDisconnected,
 			Error:  &tokenErr,
 		}
-	}, ably.ConnectionEventDisconnected).Wait()
+	}, ably.ConnectionEventDisconnected), nil)
 
 	if !errors.Is(err, authErr) {
 		t.Fatalf("expected the auth error as DISCONNECTED state change reason; got: %s", err)
@@ -1390,7 +1390,7 @@ func TestRealtimeConn_RTN15h2_ReauthWithBadToken(t *testing.T) {
 		ConnectionDetails: &proto.ConnectionDetails{},
 	}
 
-	err := ablytest.ConnWaiter(c, c.Connect, ably.ConnectionEventConnected).Wait()
+	err := ablytest.Wait(ablytest.ConnWaiter(c, c.Connect, ably.ConnectionEventConnected), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1477,7 +1477,7 @@ func TestRealtimeConn_RTN15h2_Success(t *testing.T) {
 		ConnectionDetails: &proto.ConnectionDetails{},
 	}
 
-	err := ablytest.ConnWaiter(c, c.Connect, ably.ConnectionEventConnected).Wait()
+	err := ablytest.Wait(ablytest.ConnWaiter(c, c.Connect, ably.ConnectionEventConnected), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1551,7 +1551,7 @@ func TestRealtimeConn_RTN15i_OnErrorWhenConnected(t *testing.T) {
 		ConnectionDetails: &proto.ConnectionDetails{},
 	}
 
-	err := ablytest.ConnWaiter(c, c.Connect, ably.ConnectionEventConnected).Wait()
+	err := ablytest.Wait(ablytest.ConnWaiter(c, c.Connect, ably.ConnectionEventConnected), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1559,7 +1559,7 @@ func TestRealtimeConn_RTN15i_OnErrorWhenConnected(t *testing.T) {
 	// Get a channel to ATTACHED.
 
 	channel := c.Channels.Get("test")
-	attachWaiter := ablytest.ResultFunc.Go(func() error { return channel.Attach(context.Background()) })
+	attachWaiter := ablytest.ResultFunc.Go(func(ctx context.Context) error { return channel.Attach(ctx) })
 
 	_ = <-out // consume ATTACH
 
@@ -1578,7 +1578,7 @@ func TestRealtimeConn_RTN15i_OnErrorWhenConnected(t *testing.T) {
 	off := channel.On(ably.ChannelEventFailed, channelFailed.Receive)
 	defer off()
 
-	err = ablytest.ConnWaiter(c, func() {
+	err = ablytest.Wait(ablytest.ConnWaiter(c, func() {
 		in <- &proto.ProtocolMessage{
 			Action: proto.ActionError,
 			Error: &proto.ErrorInfo{
@@ -1587,7 +1587,7 @@ func TestRealtimeConn_RTN15i_OnErrorWhenConnected(t *testing.T) {
 				Message:    "fake error",
 			},
 		}
-	}, ably.ConnectionEventFailed).Wait()
+	}, ably.ConnectionEventFailed), nil)
 
 	var errorInfo *ably.ErrorInfo
 	if !errors.As(err, &errorInfo) {
@@ -1615,7 +1615,7 @@ func TestRealtimeConn_RTN16(t *testing.T) {
 	app, c := ablytest.NewRealtime()
 	defer safeclose(t, ablytest.FullRealtimeCloser(c), app)
 
-	err := ablytest.ConnWaiter(c, c.Connect, ably.ConnectionEventConnected).Wait()
+	err := ablytest.Wait(ablytest.ConnWaiter(c, c.Connect, ably.ConnectionEventConnected), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1633,7 +1633,7 @@ func TestRealtimeConn_RTN16(t *testing.T) {
 	)
 	defer safeclose(t, ablytest.FullRealtimeCloser(client))
 
-	err = ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected).Wait()
+	err = ablytest.Wait(ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1672,7 +1672,7 @@ func TestRealtimeConn_RTN16(t *testing.T) {
 				return ablyutil.DialWebsocket(protocol, u, timeout)
 			}))
 		defer safeclose(t, ablytest.FullRealtimeCloser(client2))
-		err = ablytest.ConnWaiter(client2, client2.Connect, ably.ConnectionEventConnected).Wait()
+		err = ablytest.Wait(ablytest.ConnWaiter(client2, client2.Connect, ably.ConnectionEventConnected), nil)
 		if err == nil {
 			t.Fatal("expected reason to be set")
 		}
@@ -1759,7 +1759,7 @@ func TestRealtimeConn_RTN23(t *testing.T) {
 	c.Connection.Once(ably.ConnectionEventDisconnected, func(e ably.ConnectionStateChange) {
 		disconnected <- e.Reason
 	})
-	err := ablytest.ConnWaiter(c, c.Connect, ably.ConnectionEventConnected).Wait()
+	err := ablytest.Wait(ablytest.ConnWaiter(c, c.Connect, ably.ConnectionEventConnected), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ably/realtime_conn_spec_test.go
+++ b/ably/realtime_conn_spec_test.go
@@ -1648,7 +1648,11 @@ func TestRealtimeConn_RTN16(t *testing.T) {
 	}
 
 	{ //(RTN16c)
-		client.Close()
+		err := ablytest.Wait(ablytest.ConnWaiter(client, client.Close, ably.ConnectionEventClosed), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		if key := client.Connection.Key(); key != "" {
 			t.Errorf("expected key to be empty got %q instead", key)
 		}

--- a/ably/realtime_conn_spec_test.go
+++ b/ably/realtime_conn_spec_test.go
@@ -1864,7 +1864,7 @@ func TestRealtimeConn_RTN14c(t *testing.T) {
 
 	// We can't be precise here so just an estimate. Manual tests ranges between 5ms -10ms
 	// TODO: Find a proper way to record Dial i/o timeouts duration.
-	if d < reqTimeout || d > reqTimeout+2 {
+	if d < reqTimeout || d > reqTimeout+(2*time.Millisecond) {
 		t.Errorf("expected i/o timeout to be %v got %v", reqTimeout, d)
 	}
 }

--- a/ably/realtime_conn_test.go
+++ b/ably/realtime_conn_test.go
@@ -24,7 +24,7 @@ func TestRealtimeConn_Connect(t *testing.T) {
 	off := rec.Listen(client)
 	defer off()
 
-	if err := ablytest.ConnWaiter(client, nil, ably.ConnectionEventConnected).Wait(); err != nil {
+	if err := ablytest.Wait(ablytest.ConnWaiter(client, nil, ably.ConnectionEventConnected), nil); err != nil {
 		t.Fatalf("Connect()=%v", err)
 	}
 	if serial := client.Connection.Serial(); serial != -1 {
@@ -51,7 +51,7 @@ func TestRealtimeConn_NoConnect(t *testing.T) {
 	off := rec.Listen(client)
 	defer off()
 
-	if err := ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected).Wait(); err != nil {
+	if err := ablytest.Wait(ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected), nil); err != nil {
 		t.Fatalf("Connect()=%v", err)
 	}
 	if serial := client.Connection.Serial(); serial != -1 {
@@ -75,13 +75,13 @@ func TestRealtimeConn_ConnectClose(t *testing.T) {
 	off := rec.Listen(client)
 	defer off()
 
-	if err := ablytest.ConnWaiter(client, nil, ably.ConnectionEventConnected).Wait(); err != nil {
+	if err := ablytest.Wait(ablytest.ConnWaiter(client, nil, ably.ConnectionEventConnected), nil); err != nil {
 		t.Fatal(err)
 	}
 	if err := ablytest.FullRealtimeCloser(client).Close(); err != nil {
 		t.Fatalf("ablytest.FullRealtimeCloser(client).Close()=%v", err)
 	}
-	if err := ablytest.ConnWaiter(client, nil, ably.ConnectionEventClosed).Wait(); err != nil {
+	if err := ablytest.Wait(ablytest.ConnWaiter(client, nil, ably.ConnectionEventClosed), nil); err != nil {
 		t.Fatal(err)
 	}
 	if !ablytest.Soon.IsTrue(func() bool {
@@ -96,7 +96,7 @@ func TestRealtimeConn_AlreadyConnected(t *testing.T) {
 	app, client := ablytest.NewRealtime(ably.WithAutoConnect(false))
 	defer safeclose(t, ablytest.FullRealtimeCloser(client), app)
 
-	if err := ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected).Wait(); err != nil {
+	if err := ablytest.Wait(ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected), nil); err != nil {
 		t.Fatalf("Connect=%s", err)
 	}
 
@@ -119,7 +119,7 @@ func TestRealtimeConn_AuthError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRealtime()=%v", err)
 	}
-	if err = ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected).Wait(); err == nil {
+	if err = ablytest.Wait(ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected), nil); err == nil {
 		t.Fatal("Connect(): want err != nil")
 	}
 }

--- a/ably/realtime_presence.go
+++ b/ably/realtime_presence.go
@@ -451,10 +451,6 @@ func (pres *RealtimePresence) UpdateClient(ctx context.Context, clientID string,
 // presence data may eventually be updated anyway.
 func (pres *RealtimePresence) LeaveClient(ctx context.Context, clientID string, data interface{}) error {
 	pres.mtx.Lock()
-	if pres.state != proto.PresenceEnter {
-		pres.mtx.Unlock()
-		return newError(91001, nil)
-	}
 	if pres.data == nil {
 		pres.data = data
 	}

--- a/ably/realtime_presence.go
+++ b/ably/realtime_presence.go
@@ -57,7 +57,7 @@ func (pres *RealtimePresence) verifyChanState() error {
 }
 
 func (pres *RealtimePresence) send(msg *proto.PresenceMessage) (Result, error) {
-	attached, err := pres.channel.attach(true)
+	attached, err := pres.channel.attach()
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +244,7 @@ func (pres *RealtimePresence) GetWithOptions(ctx context.Context, options ...Pre
 	var opts presenceGetOptions
 	opts.applyWithDefaults(options...)
 
-	res, err := pres.channel.attach(true)
+	res, err := pres.channel.attach()
 	if err != nil {
 		return nil, err
 	}
@@ -303,7 +303,7 @@ func (*subscriptionPresenceMessage) isEmitterData() {}
 // See package-level documentation on Event Emitter for details about
 // messages dispatch.
 func (pres *RealtimePresence) Subscribe(ctx context.Context, action PresenceAction, handle func(*PresenceMessage)) (unsubscribe func(), err error) {
-	res, err := pres.channel.attach(true)
+	res, err := pres.channel.attach()
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +327,7 @@ func (pres *RealtimePresence) Subscribe(ctx context.Context, action PresenceActi
 // See package-level documentation on Event Emitter for details about
 // messages dispatch.
 func (pres *RealtimePresence) SubscribeAll(ctx context.Context, handle func(*PresenceMessage)) (unsubscribe func(), err error) {
-	res, err := pres.channel.attach(true)
+	res, err := pres.channel.attach()
 	if err != nil {
 		return nil, err
 	}

--- a/ably/realtime_presence_test.go
+++ b/ably/realtime_presence_test.go
@@ -44,7 +44,7 @@ func TestRealtimePresence_Sync(t *testing.T) {
 	t.Parallel()
 	app, client := ablytest.NewRealtime(nil...)
 	defer safeclose(t, ablytest.FullRealtimeCloser(client), app)
-	err := ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected).Wait()
+	err := ablytest.Wait(ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected), nil)
 
 	members, err := client.Channels.Get("persisted:presence_fixtures").Presence.Get(context.Background())
 	if err != nil {
@@ -63,15 +63,15 @@ func TestRealtimePresence_Sync250(t *testing.T) {
 	client2 := app.NewRealtime(nil...)
 	client3 := app.NewRealtime(nil...)
 	defer safeclose(t, ablytest.FullRealtimeCloser(client2), ablytest.FullRealtimeCloser(client3))
-	err := ablytest.ConnWaiter(client1, client1.Connect, ably.ConnectionEventConnected).Wait()
+	err := ablytest.Wait(ablytest.ConnWaiter(client1, client1.Connect, ably.ConnectionEventConnected), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = ablytest.ConnWaiter(client2, client2.Connect, ably.ConnectionEventConnected).Wait()
+	err = ablytest.Wait(ablytest.ConnWaiter(client2, client2.Connect, ably.ConnectionEventConnected), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = ablytest.ConnWaiter(client3, client3.Connect, ably.ConnectionEventConnected).Wait()
+	err = ablytest.Wait(ablytest.ConnWaiter(client3, client3.Connect, ably.ConnectionEventConnected), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +94,7 @@ func TestRealtimePresence_Sync250(t *testing.T) {
 	var clients = generateClients(250)
 	for _, client := range clients {
 		client := client
-		rg.GoAdd(func() error { return channel1.Presence.EnterClient(context.Background(), client, "") })
+		rg.GoAdd(func(ctx context.Context) error { return channel1.Presence.EnterClient(ctx, client, "") })
 	}
 	if err := rg.Wait(); err != nil {
 		t.Fatalf("rg.Wait()=%v", err)
@@ -139,7 +139,7 @@ func TestRealtimePresence_EnsureChannelIsAttached(t *testing.T) {
 	channel := client.Channels.Get("persisted:presence_fixtures")
 	off := rec.Listen(channel)
 	defer off()
-	if err := ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected).Wait(); err != nil {
+	if err := ablytest.Wait(ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected), nil); err != nil {
 		t.Fatal(err)
 	}
 	members, err := channel.Presence.Get(context.Background())

--- a/ably/state.go
+++ b/ably/state.go
@@ -1,6 +1,7 @@
 package ably
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"sync"
@@ -14,24 +15,31 @@ type Result interface {
 	// Wait blocks until asynchronous operation is completed. Upon its completion,
 	// the method returns nil error if it was successful and non-nil error otherwise.
 	// It's allowed to call Wait multiple times.
-	Wait() error
+	Wait(context.Context) error
 }
 
-func wait(res Result, err error) error {
-	if err != nil {
-		return err
+func wait(ctx context.Context) func(Result, error) error {
+	return func(res Result, err error) error {
+		if err != nil {
+			return err
+		}
+		return res.Wait(ctx)
 	}
-	return res.Wait()
 }
 
-func goWaiter(f resultFunc) Result {
+func goWaiter(f func() error) Result {
 	err := make(chan error, 1)
 	go func() {
 		defer close(err)
 		err <- f()
 	}()
-	return resultFunc(func() error {
-		return <-err
+	return resultFunc(func(ctx context.Context) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-err:
+			return err
+		}
 	})
 }
 
@@ -254,21 +262,25 @@ func newErrResult() (Result, chan<- error) {
 }
 
 // Wait implements the Result interface.
-func (res *errResult) Wait() error {
+func (res *errResult) Wait(ctx context.Context) error {
 	if res == nil {
 		return nil
 	}
-	if res.listen != nil {
-		res.err = <-res.listen
+	if l := res.listen; l != nil {
 		res.listen = nil
+		select {
+		case res.err = <-l:
+		case <-ctx.Done():
+			res.err = ctx.Err()
+		}
 	}
 	return res.err
 }
 
-type resultFunc func() error
+type resultFunc func(context.Context) error
 
-func (f resultFunc) Wait() error {
-	return f()
+func (f resultFunc) Wait(ctx context.Context) error {
+	return f(ctx)
 }
 
 func (e ChannelEventEmitter) listenResult(expected ChannelState, failed ...ChannelState) Result {
@@ -280,14 +292,21 @@ func (e ChannelEventEmitter) listenResult(expected ChannelState, failed ...Chann
 		offs = append(offs, e.Once(ChannelEvent(ev), changes.Receive))
 	}
 
-	return resultFunc(func() error {
+	return resultFunc(func(ctx context.Context) error {
 		defer func() {
 			for _, off := range offs {
 				off()
 			}
 		}()
 
-		switch change := <-changes; {
+		var change ChannelStateChange
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case change = <-changes:
+		}
+
+		switch {
 		case change.Current == expected:
 		case change.Reason != nil:
 			return change.Reason
@@ -308,14 +327,21 @@ func (e ConnectionEventEmitter) listenResult(expected ConnectionState, failed ..
 		offs = append(offs, e.Once(ConnectionEvent(ev), changes.Receive))
 	}
 
-	return resultFunc(func() error {
+	return resultFunc(func(ctx context.Context) error {
 		defer func() {
 			for _, off := range offs {
 				off()
 			}
 		}()
 
-		switch change := <-changes; {
+		var change ConnectionStateChange
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case change = <-changes:
+		}
+
+		switch {
 		case change.Current == expected:
 		case change.Reason != nil:
 			return change.Reason

--- a/ably/transitioner_test.go
+++ b/ably/transitioner_test.go
@@ -1,0 +1,320 @@
+package ably_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/ably/ably-go/ably"
+	"github.com/ably/ably-go/ably/ablytest"
+	"github.com/ably/ably-go/ably/proto"
+)
+
+type ConnTransitioner struct {
+	Realtime *ably.Realtime
+
+	t          *testing.T
+	dialErr    chan<- error
+	disconnect func() error
+	intercept  func(context.Context, ...proto.Action) <-chan *proto.ProtocolMessage
+}
+
+func TransitionConn(t *testing.T, options ...ably.ClientOption) ConnTransitioner {
+	t.Helper()
+
+	c := ConnTransitioner{t: t}
+
+	dial, disconnect := ablytest.DialFakeDisconnect(nil)
+	c.disconnect = disconnect
+
+	dial, intercept := ablytest.DialIntercept(dial)
+	c.intercept = intercept
+
+	dialErr := make(chan error, 1)
+	prevDial := dial
+	dial = func(proto string, u *url.URL, timeout time.Duration) (proto.Conn, error) {
+		if err := <-dialErr; err != nil {
+			return nil, err
+		}
+		return prevDial(proto, u, timeout)
+	}
+	c.dialErr = dialErr
+
+	afterCalls := make(chan ablytest.AfterCall, 1)
+	now, after := ablytest.TimeFuncs(afterCalls)
+
+	realtime, err := ably.NewRealtime(append(options,
+		ably.WithAutoConnect(false),
+		ably.WithDial(dial),
+		ably.WithNow(now),
+		ably.WithAfter(after),
+	)...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Realtime = realtime
+
+	return c
+}
+
+func (c ConnTransitioner) Channel(name string) ChanTransitioner {
+	return ChanTransitioner{c, c.Realtime.Channels.Get(name)}
+}
+
+func (c ConnTransitioner) To(path ...ably.ConnectionState) (ConnTransitioner, io.Closer) {
+	c.t.Helper()
+
+	from := initialized
+	c.assertState(from)
+
+	next := connNextStates{
+		connecting: c.connect,
+		closed:     c.closeNow,
+	}
+	var cleanUp func()
+
+	for _, to := range path {
+		if from == to {
+			continue
+		}
+
+		transition, ok := next[to]
+		if !ok {
+			c.t.Fatalf("no transition from %v to %v", from, to)
+		}
+		next, cleanUp = transition()
+		from = to
+		c.assertState(from)
+	}
+
+	return c, closeFunc(func() error {
+		if cleanUp != nil {
+			cleanUp()
+		}
+		return ablytest.FullRealtimeCloser(c.Realtime).Close()
+	})
+}
+
+func (c ConnTransitioner) assertState(state ably.ConnectionState) {
+	c.t.Helper()
+	if expected, got := state, c.Realtime.Connection.State(); expected != got {
+		c.t.Fatalf("expected connection to be %v; is %v", expected, got)
+	}
+}
+
+func (c ConnTransitioner) connect() (connNextStates, func()) {
+	change := make(ably.ConnStateChanges, 1)
+	c.Realtime.Connection.Once(ably.ConnectionEventConnecting, change.Receive)
+
+	c.Realtime.Connect()
+
+	ablytest.Soon.Recv(c.t, nil, change, c.t.Fatalf)
+
+	return connNextStates{
+			connected:    c.finishConnecting(nil),
+			disconnected: c.finishConnecting(errors.New("fake connection error")),
+		}, func() {
+			c.Realtime.Close() // don't reconnect
+			c.finishConnecting(errors.New("test done"))
+		}
+}
+
+func (c ConnTransitioner) finishConnecting(err error) connTransitionFunc {
+	return func() (connNextStates, func()) {
+		change := make(ably.ConnStateChanges, 1)
+		c.Realtime.Connection.OnceAll(change.Receive)
+
+		c.dialErr <- err
+
+		ablytest.Soon.Recv(c.t, nil, change, c.t.Fatalf)
+
+		if err != nil {
+			// Should be DISCONNECTED.
+			return connNextStates{
+				connecting: c.connect,
+			}, nil
+		}
+
+		// Should be CONNECTED.
+		return connNextStates{}, nil
+	}
+}
+
+func (c ConnTransitioner) closeNow() (connNextStates, func()) {
+	c.Realtime.Close()
+	return nil, nil
+}
+
+type connTransitionFunc func() (next connNextStates, cleanUp func())
+
+type connNextStates map[ably.ConnectionState]connTransitionFunc
+
+type ChanTransitioner struct {
+	ConnTransitioner
+	Channel *ably.RealtimeChannel
+}
+
+func (c ChanTransitioner) To(path ...ably.ChannelState) (*ably.RealtimeChannel, io.Closer) {
+	c.t.Helper()
+
+	from := chInitialized
+	c.assertState(from)
+
+	next := chanNextStates{
+		chAttaching: c.attach,
+	}
+	var cleanUp func()
+
+	for _, to := range path {
+		if from == to {
+			continue
+		}
+
+		transition, ok := next[to]
+		if !ok {
+			c.t.Fatalf("no transition from %v to %v", from, to)
+		}
+		next, cleanUp = transition()
+		from = to
+		c.assertState(from)
+	}
+
+	return c.Channel, closeFunc(func() error {
+		if cleanUp != nil {
+			cleanUp()
+		}
+		return nil
+	})
+}
+
+func (c ChanTransitioner) assertState(state ably.ChannelState) {
+	c.t.Helper()
+	if expected, got := state, c.Channel.State(); expected != got {
+		c.t.Fatalf("expected channel to be %v; is %v", expected, got)
+	}
+}
+
+func (c ChanTransitioner) attach() (chanNextStates, func()) {
+	c.t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), ablytest.Timeout)
+	msg := c.intercept(ctx, proto.ActionAttached)
+
+	change := make(ably.ChannelStateChanges, 1)
+	c.Channel.Once(ably.ChannelEventAttaching, change.Receive)
+
+	asyncAttach(c.Channel)
+
+	ablytest.Soon.Recv(c.t, nil, change, c.t.Fatalf)
+
+	return chanNextStates{
+		chAttached: c.finishAttach(msg, cancel, nil),
+		chFailed:   c.finishAttach(msg, cancel, &proto.ErrorInfo{Message: "fake error"}),
+	}, cancel
+}
+
+func (c ChanTransitioner) finishAttach(msg <-chan *proto.ProtocolMessage, cancelIntercept func(), err *proto.ErrorInfo) chanTransitionFunc {
+	return func() (chanNextStates, func()) {
+		var attachMsg *proto.ProtocolMessage
+		ablytest.Soon.Recv(c.t, &attachMsg, msg, c.t.Fatalf)
+
+		var next chanNextStates
+		if err != nil {
+			// Ideally, for moving to FAILED, we'd arrange a real capabilities error
+			// to keep things real. But it's too much hassle for now.
+			attachMsg.Action = proto.ActionError
+			attachMsg.Error = err
+		} else {
+			next = chanNextStates{
+				chDetaching: c.detach,
+			}
+		}
+
+		change := make(ably.ChannelStateChanges, 1)
+		c.Channel.Once(ably.ChannelEventAttached, change.Receive)
+
+		cancelIntercept()
+
+		ablytest.Instantly.Recv(c.t, nil, change, c.t.Fatalf)
+
+		return next, nil
+	}
+}
+
+func (c ChanTransitioner) detach() (chanNextStates, func()) {
+	c.t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), ablytest.Timeout)
+	c.intercept(ctx, proto.ActionDetached)
+
+	change := make(ably.ChannelStateChanges, 1)
+	c.Channel.Once(ably.ChannelEventDetaching, change.Receive)
+
+	asyncDetach(c.Channel)
+
+	ablytest.Soon.Recv(c.t, nil, change, c.t.Fatalf)
+
+	return chanNextStates{
+		chDetached: c.finishDetach(cancel),
+	}, cancel
+}
+
+func (c ChanTransitioner) finishDetach(cancelIntercept func()) chanTransitionFunc {
+	return func() (chanNextStates, func()) {
+		change := make(ably.ChannelStateChanges, 1)
+		c.Channel.Once(ably.ChannelEventDetached, change.Receive)
+
+		cancelIntercept()
+
+		ablytest.Soon.Recv(c.t, nil, change, c.t.Fatalf)
+
+		return nil, nil
+	}
+}
+
+type chanTransitionFunc func() (next chanNextStates, cleanUp func())
+
+type chanNextStates map[ably.ChannelState]chanTransitionFunc
+
+// This file is full of those. Avoid "ably.ConnectionState" noise.
+var (
+	initialized  = ably.ConnectionStateInitialized
+	connecting   = ably.ConnectionStateConnecting
+	connected    = ably.ConnectionStateConnected
+	disconnected = ably.ConnectionStateDisconnected
+	suspended    = ably.ConnectionStateSuspended
+	closing      = ably.ConnectionStateClosing
+	closed       = ably.ConnectionStateClosed
+	failed       = ably.ConnectionStateFailed
+
+	chInitialized = ably.ChannelStateInitialized
+	chAttaching   = ably.ChannelStateAttaching
+	chAttached    = ably.ChannelStateAttached
+	chDetaching   = ably.ChannelStateDetaching
+	chDetached    = ably.ChannelStateDetached
+	chSuspended   = ably.ChannelStateSuspended
+	chFailed      = ably.ChannelStateFailed
+)
+
+func asyncAttach(c *ably.RealtimeChannel) <-chan error {
+	return async(func() error { return c.Attach(context.Background()) })
+}
+
+func asyncDetach(c *ably.RealtimeChannel) <-chan error {
+	return async(func() error { return c.Detach(context.Background()) })
+}
+
+func asyncPublish(c *ably.RealtimeChannel) <-chan error {
+	return async(func() error { return c.Publish(context.Background(), "event", nil) })
+}
+
+func async(f func() error) <-chan error {
+	done := make(chan error, 1)
+	go func() {
+		done <- f()
+	}()
+	return done
+}

--- a/ably/transitioner_test.go
+++ b/ably/transitioner_test.go
@@ -26,6 +26,10 @@ type ConnTransitioner struct {
 	next connNextStates
 }
 
+// TransitionConn makes a connection with external events (requests, protocol
+// messages, timers) mocked, so that state transitions can be controlled by the
+// tests. The returned ConnTransitioner's To method moves the connection to the
+// desired state, and keeps it there.
 func TransitionConn(t *testing.T, dial ablytest.DialFunc, options ...ably.ClientOption) (ConnTransitioner, io.Closer) {
 	t.Helper()
 

--- a/ably/transitioner_test.go
+++ b/ably/transitioner_test.go
@@ -316,8 +316,6 @@ func (c ChanTransitioner) assertState(state ably.ChannelState) {
 }
 
 func (c ChanTransitioner) attach() (chanNextStates, func()) {
-	c.t.Helper()
-
 	ctx, cancel := context.WithTimeout(context.Background(), ablytest.Timeout)
 	msg := c.intercept(ctx, proto.ActionAttached)
 
@@ -363,8 +361,6 @@ func (c ChanTransitioner) finishAttach(msg <-chan *proto.ProtocolMessage, cancel
 }
 
 func (c ChanTransitioner) detach() (chanNextStates, func()) {
-	c.t.Helper()
-
 	ctx, cancel := context.WithTimeout(context.Background(), ablytest.Timeout)
 	c.intercept(ctx, proto.ActionDetached)
 


### PR DESCRIPTION
- [x] [RTL6c1](https://docs.ably.io/client-lib-development-guide/features/#RTL6c1)
- [x] [RTL6c2](https://docs.ably.io/client-lib-development-guide/features/#RTL6c2)
- [x] [RTL6c4](https://docs.ably.io/client-lib-development-guide/features/#RTL6c4)
- [x] [RTL6c5](https://docs.ably.io/client-lib-development-guide/features/#RTL6c5)

This PR also includes random fixes that came up during testing, including the culprit of #172's CI failure.