### PR TITLE
Add RTN2g

### DIFF
--- a/ably/proto/http.go
+++ b/ably/proto/http.go
@@ -7,7 +7,7 @@ const (
 	AblyErrorCodeHeader    = "X-Ably-Errorcode"
 	AblyErrormessageHeader = "X-Ably-Errormessage"
 	LibraryVersion         = "1.1.5"
-	LibraryName            = "ably-go"
+	LibraryName            = "go"
 	LibraryString          = LibraryName + "-" + LibraryVersion
 	AblyVersion            = "1.0"
 	AblyClientIDHeader     = "X-Ably-ClientId"

--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -248,6 +248,7 @@ func (c *Connection) params(mode connectionMode) (url.Values, error) {
 		"timestamp": []string{strconv.FormatInt(unixMilli(c.opts.Now()), 10)},
 		"echo":      []string{"true"},
 		"format":    []string{"msgpack"},
+		"lib":       []string{proto.LibraryString},
 	}
 	if c.opts.NoEcho {
 		query.Set("echo", "false")

--- a/ably/realtime_conn_spec_test.go
+++ b/ably/realtime_conn_spec_test.go
@@ -2123,3 +2123,24 @@ func TestRealtimeConn_RTN14e(t *testing.T) {
 		t.Fatalf("expected transitioning from %v got %v", expect, got)
 	}
 }
+
+func TestRealtimeConn_RTN2g(t *testing.T) {
+	t.Parallel()
+	uri := make(chan url.URL, 1)
+	_, err := ably.NewRealtime(
+		ably.WithKey("xxx:xxx"),
+		ably.WithDial(func(protocol string, u *url.URL, timeout time.Duration) (proto.Conn, error) {
+			uri <- *u
+			return nil, io.EOF
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var connURL url.URL
+	ablytest.Soon.Recv(t, &connURL, uri, t.Fatalf)
+	lib := connURL.Query().Get("lib")
+	if lib != proto.LibraryString {
+		t.Errorf("expected %q got %q", proto.LibraryString, lib)
+	}
+}


### PR DESCRIPTION
@SimonWoolf the library name is `ably-go` and not just `go` so the `lib` query param will contain something like  `ably-go-1.1.5` instead of `go-1.1.5`
