### PR TITLE
Propagate contexts everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,8 +244,8 @@ if err != nil {
 ### Querying the History
 
 ```go
-page, err := channel.History(nil)
-for ; err == nil && page != nil; page, err = page.Next() {
+page, err := channel.History(ctx, nil)
+for ; err == nil && page != nil; page, err = page.Next(ctx) {
 	for _, message := range page.Messages() {
 		fmt.Println(message)
 	}
@@ -258,8 +258,8 @@ if err != nil {
 ### Presence on a channel
 
 ```go
-page, err = channel.Presence.Get(nil)
-for ; err == nil && page != nil; page, err = page.Next() {
+page, err = channel.Presence.Get(ctx, nil)
+for ; err == nil && page != nil; page, err = page.Next(ctx) {
 	for _, presence := range page.PresenceMessages() {
 		fmt.Println(presence)
 	}
@@ -272,8 +272,8 @@ if err != nil {
 ### Querying the Presence History
 
 ```go
-page, err = channel.Presence.History(nil)
-for ; err == nil && page != nil; page, err = page.Next() {
+page, err = channel.Presence.History(ctx, nil)
+for ; err == nil && page != nil; page, err = page.Next(ctx) {
 	for _, presence := range page.PresenceMessages() {
 		fmt.Println(presence)
 	}
@@ -286,8 +286,8 @@ if err != nil {
 ### Fetching your application's stats
 
 ```go
-page, err = client.Stats(&ably.PaginateParams{})
-for ; err == nil && page != nil; page, err = page.Next() {
+page, err = client.Stats(ctx, &ably.PaginateParams{})
+for ; err == nil && page != nil; page, err = page.Next(ctx) {
 	for _, stat := range page.Stats() {
 		fmt.Println(stat)
 	}

--- a/ably/auth.go
+++ b/ably/auth.go
@@ -338,11 +338,7 @@ func (a *Auth) setDefaults(opts *authOptions, req *TokenRequest) error {
 		req.ClientID = a.opts().ClientID
 	}
 	if req.Timestamp == 0 {
-		var ctx context.Context
-		if opts.UseQueryTime {
-			ctx = context.Background()
-		}
-		ts, err := a.timestamp(ctx)
+		ts, err := a.timestamp(context.Background(), opts.UseQueryTime)
 		if err != nil {
 			return err
 		}
@@ -352,9 +348,9 @@ func (a *Auth) setDefaults(opts *authOptions, req *TokenRequest) error {
 }
 
 //Timestamp returns the timestamp to be used in authorization request.
-func (a *Auth) timestamp(queryCtx context.Context) (time.Time, error) {
+func (a *Auth) timestamp(ctx context.Context, query bool) (time.Time, error) {
 	now := a.client.opts.Now()
-	if queryCtx == nil {
+	if !query {
 		return now, nil
 	}
 	if a.serverTimeOffset != 0 {
@@ -372,7 +368,7 @@ func (a *Auth) timestamp(queryCtx context.Context) (time.Time, error) {
 		}
 		serverTime = t
 	} else {
-		t, err := a.client.Time(queryCtx)
+		t, err := a.client.Time(ctx)
 		if err != nil {
 			return time.Time{}, newError(ErrUnauthorized, err)
 		}

--- a/ably/auth.go
+++ b/ably/auth.go
@@ -168,18 +168,18 @@ func (a *Auth) createTokenRequest(params *TokenParams, opts *authOptions) (*Toke
 }
 
 // RequestToken
-func (a *Auth) RequestToken(params *TokenParams, opts ...AuthOption) (*TokenDetails, error) {
+func (a *Auth) RequestToken(ctx context.Context, params *TokenParams, opts ...AuthOption) (*TokenDetails, error) {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
 	var o *authOptions
 	if opts != nil {
 		o = applyAuthOptionsWithDefaults(opts...)
 	}
-	tok, _, err := a.requestToken(params, o)
+	tok, _, err := a.requestToken(ctx, params, o)
 	return tok, err
 }
 
-func (a *Auth) requestToken(params *TokenParams, opts *authOptions) (tok *TokenDetails, tokReqClientID string, err error) {
+func (a *Auth) requestToken(ctx context.Context, params *TokenParams, opts *authOptions) (tok *TokenDetails, tokReqClientID string, err error) {
 	log := a.logger().sugar()
 	switch {
 	case opts != nil && opts.Token != "":
@@ -224,7 +224,7 @@ func (a *Auth) requestToken(params *TokenParams, opts *authOptions) (tok *TokenD
 		}
 	case opts.AuthURL != "":
 		log.Verbose("Auth: found AuthURL in []AuthOption")
-		res, err := a.requestAuthURL(params, opts)
+		res, err := a.requestAuthURL(ctx, params, opts)
 		if err != nil {
 			log.Error("Auth: failed calling requesting token with AuthURL ", err)
 			return nil, "", err
@@ -253,39 +253,27 @@ func (a *Auth) requestToken(params *TokenParams, opts *authOptions) (tok *TokenD
 		Out:    tok,
 		NoAuth: true,
 	}
-	if _, err := a.client.do(r); err != nil {
+	if _, err := a.client.do(ctx, r); err != nil {
 		return nil, "", err
 	}
 	return tok, tokReqClientID, nil
-}
-
-// Authorise performs authorization with ably service and returns the
-// authorization token details.
-//
-// This method is an alias to Auth.Authorize and it is DEPRECATED use
-// Auth.Authorize instead.
-//
-// Refers to RSA10l
-func (a *Auth) Authorise(params *TokenParams, opts ...AuthOption) (*TokenDetails, error) {
-	a.logger().Print(LogWarning, "Auth.Authorise is deprecated please use Auth.Authorize \n")
-	return a.Authorize(params, opts...)
 }
 
 // Authorize performs authorization with ably service and returns the
 // authorization token details.
 //
 // Refers to RSA10
-func (a *Auth) Authorize(params *TokenParams, setOpts ...AuthOption) (*TokenDetails, error) {
+func (a *Auth) Authorize(ctx context.Context, params *TokenParams, setOpts ...AuthOption) (*TokenDetails, error) {
 	var opts *authOptions
 	if setOpts != nil {
 		opts = applyAuthOptionsWithDefaults(setOpts...)
 	}
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
-	return a.authorize(params, opts, true)
+	return a.authorize(ctx, params, opts, true)
 }
 
-func (a *Auth) authorize(params *TokenParams, opts *authOptions, force bool) (*TokenDetails, error) {
+func (a *Auth) authorize(ctx context.Context, params *TokenParams, opts *authOptions, force bool) (*TokenDetails, error) {
 	log := a.logger().sugar()
 	switch tok := a.token(); {
 	case tok != nil && !force && (tok.Expires == 0 || !tok.expired(a.opts().Now())):
@@ -296,7 +284,7 @@ func (a *Auth) authorize(params *TokenParams, opts *authOptions, force bool) (*T
 		params = &TokenParams{ClientID: a.clientID}
 	}
 	log.Info("Auth: sending  token request")
-	tok, tokReqClientID, err := a.requestToken(params, opts)
+	tok, tokReqClientID, err := a.requestToken(ctx, params, opts)
 	if err != nil {
 		log.Error("Auth: failed to get token", err)
 		return nil, err
@@ -320,11 +308,11 @@ func (a *Auth) authorize(params *TokenParams, opts *authOptions, force bool) (*T
 	return tok, nil
 }
 
-func (a *Auth) reauthorize() (*TokenDetails, error) {
+func (a *Auth) reauthorize(ctx context.Context) (*TokenDetails, error) {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
 	a.logger().sugar().Info("Auth: reauthorize")
-	return a.authorize(a.params, nil, true)
+	return a.authorize(ctx, a.params, nil, true)
 }
 
 func (a *Auth) mergeOpts(opts *authOptions) *authOptions {
@@ -350,7 +338,11 @@ func (a *Auth) setDefaults(opts *authOptions, req *TokenRequest) error {
 		req.ClientID = a.opts().ClientID
 	}
 	if req.Timestamp == 0 {
-		ts, err := a.timestamp(opts.UseQueryTime)
+		var ctx context.Context
+		if opts.UseQueryTime {
+			ctx = context.Background()
+		}
+		ts, err := a.timestamp(ctx)
 		if err != nil {
 			return err
 		}
@@ -360,9 +352,9 @@ func (a *Auth) setDefaults(opts *authOptions, req *TokenRequest) error {
 }
 
 //Timestamp returns the timestamp to be used in authorization request.
-func (a *Auth) timestamp(query bool) (time.Time, error) {
+func (a *Auth) timestamp(queryCtx context.Context) (time.Time, error) {
 	now := a.client.opts.Now()
-	if !query {
+	if queryCtx == nil {
 		return now, nil
 	}
 	if a.serverTimeOffset != 0 {
@@ -380,7 +372,7 @@ func (a *Auth) timestamp(query bool) (time.Time, error) {
 		}
 		serverTime = t
 	} else {
-		t, err := a.client.Time()
+		t, err := a.client.Time(queryCtx)
 		if err != nil {
 			return time.Time{}, newError(ErrUnauthorized, err)
 		}
@@ -390,8 +382,8 @@ func (a *Auth) timestamp(query bool) (time.Time, error) {
 	return serverTime, nil
 }
 
-func (a *Auth) requestAuthURL(params *TokenParams, opts *authOptions) (interface{}, error) {
-	req, err := http.NewRequest(opts.authMethod(), opts.AuthURL, nil)
+func (a *Auth) requestAuthURL(ctx context.Context, params *TokenParams, opts *authOptions) (interface{}, error) {
+	req, err := http.NewRequestWithContext(ctx, opts.authMethod(), opts.AuthURL, nil)
 	if err != nil {
 		return nil, a.newError(40000, err)
 	}
@@ -458,7 +450,7 @@ func (a *Auth) authReq(req *http.Request) error {
 	case authBasic:
 		req.SetBasicAuth(a.opts().KeyName(), a.opts().KeySecret())
 	case authToken:
-		if _, err := a.authorize(a.params, nil, false); err != nil {
+		if _, err := a.authorize(req.Context(), a.params, nil, false); err != nil {
 			return err
 		}
 		encToken := base64.StdEncoding.EncodeToString([]byte(a.token().Token))
@@ -467,14 +459,14 @@ func (a *Auth) authReq(req *http.Request) error {
 	return nil
 }
 
-func (a *Auth) authQuery(query url.Values) error {
+func (a *Auth) authQuery(ctx context.Context, query url.Values) error {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
 	switch a.method {
 	case authBasic:
 		query.Set("key", a.opts().Key)
 	case authToken:
-		if _, err := a.authorize(a.params, nil, false); err != nil {
+		if _, err := a.authorize(ctx, a.params, nil, false); err != nil {
 			return err
 		}
 		query.Set("access_token", a.token().Token)

--- a/ably/auth_test.go
+++ b/ably/auth_test.go
@@ -178,7 +178,7 @@ func TestAuth_TimestampRSA10k(t *testing.T) {
 		a.SetServerTimeFunc(func() (time.Time, error) {
 			return now.Add(time.Minute), nil
 		})
-		stamp, err := a.Timestamp(nil)
+		stamp, err := a.Timestamp(context.Background(), false)
 		if err != nil {
 			ts.Fatal(err)
 		}

--- a/ably/auth_test.go
+++ b/ably/auth_test.go
@@ -52,10 +52,10 @@ func TestAuth_BasicAuth(t *testing.T) {
 	app, client := ablytest.NewREST(append(opts, extraOpt...)...)
 	defer safeclose(t, app)
 
-	if _, err := client.Time(); err != nil {
+	if _, err := client.Time(context.Background()); err != nil {
 		t.Fatalf("client.Time()=%v", err)
 	}
-	if _, err := client.Stats(single()); err != nil {
+	if _, err := client.Stats(context.Background(), single()); err != nil {
 		t.Fatalf("client.Stats()=%v", err)
 	}
 	if n := rec.Len(); n != 2 {
@@ -104,10 +104,10 @@ func TestAuth_TokenAuth(t *testing.T) {
 	defer safeclose(t, app)
 
 	beforeAuth := time.Now().Add(-time.Second)
-	if _, err := client.Time(); err != nil {
+	if _, err := client.Time(context.Background()); err != nil {
 		t.Fatalf("client.Time()=%v", err)
 	}
-	if _, err := client.Stats(single()); err != nil {
+	if _, err := client.Stats(context.Background(), single()); err != nil {
 		t.Fatalf("client.Stats()=%v", err)
 	}
 	// At this points there should be two requests recorded:
@@ -128,7 +128,7 @@ func TestAuth_TokenAuth(t *testing.T) {
 		t.Fatalf("want url.Scheme=http; got %s", url.Scheme)
 	}
 	rec.Reset()
-	tok, err := client.Auth.Authorize(nil)
+	tok, err := client.Auth.Authorize(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Authorize()=%v", err)
 	}
@@ -161,36 +161,6 @@ func (b *bufferLogger) Print(level ably.LogLevel, v ...interface{}) {
 }
 func (b *bufferLogger) Printf(level ably.LogLevel, str string, v ...interface{}) {}
 
-func TestAuth_Authorise(t *testing.T) {
-	t.Parallel()
-	rec, extraOpt := recorder()
-	defer rec.Stop()
-	log := &bufferLogger{}
-	opts := []ably.ClientOption{
-		ably.WithUseTokenAuth(true),
-		ably.WithLogHandler(log),
-		ably.WithLogLevel(ably.LogWarning),
-	}
-	app, client := ablytest.NewREST(append(opts, extraOpt...)...)
-	defer safeclose(t, app)
-
-	params := &ably.TokenParams{
-		TTL: time.Second.Milliseconds(),
-	}
-	_, err := client.Auth.Authorise(params)
-	if err != nil {
-		t.Fatal(err)
-	}
-	msg := "Auth.Authorise is deprecated"
-	txt := log.buf.String()
-
-	// make sure deprecation warning is logged
-	//
-	// Refers to RSA10L
-	if !strings.Contains(txt, msg) {
-		t.Errorf("expected %s to contain %s", txt, msg)
-	}
-}
 func TestAuth_TimestampRSA10k(t *testing.T) {
 	t.Parallel()
 	now, err := time.Parse(time.RFC822, time.RFC822)
@@ -208,7 +178,7 @@ func TestAuth_TimestampRSA10k(t *testing.T) {
 		a.SetServerTimeFunc(func() (time.Time, error) {
 			return now.Add(time.Minute), nil
 		})
-		stamp, err := a.Timestamp(false)
+		stamp, err := a.Timestamp(nil)
 		if err != nil {
 			ts.Fatal(err)
 		}
@@ -226,7 +196,7 @@ func TestAuth_TimestampRSA10k(t *testing.T) {
 		a.SetServerTimeFunc(func() (time.Time, error) {
 			return now.Add(time.Minute), nil
 		})
-		stamp, err := a.Timestamp(true)
+		stamp, err := rest.Timestamp(true)
 		if err != nil {
 			ts.Fatal(err)
 		}
@@ -246,7 +216,7 @@ func TestAuth_TimestampRSA10k(t *testing.T) {
 		a.SetServerTimeFunc(func() (time.Time, error) {
 			return now.Add(time.Minute), nil
 		})
-		stamp, err := a.Timestamp(true)
+		stamp, err := rest.Timestamp(true)
 		if err != nil {
 			ts.Fatal(err)
 		}
@@ -259,7 +229,7 @@ func TestAuth_TimestampRSA10k(t *testing.T) {
 		a.SetServerTimeFunc(func() (time.Time, error) {
 			return time.Time{}, errors.New("must not be called")
 		})
-		stamp, err = a.Timestamp(true)
+		stamp, err = rest.Timestamp(true)
 		if err != nil {
 			ts.Fatal(err)
 		}
@@ -281,7 +251,7 @@ func TestAuth_TokenAuth_Renew(t *testing.T) {
 	params := &ably.TokenParams{
 		TTL: time.Second.Milliseconds(),
 	}
-	tok, err := client.Auth.Authorize(params)
+	tok, err := client.Auth.Authorize(context.Background(), params)
 	if err != nil {
 		t.Fatalf("Authorize()=%v", err)
 	}
@@ -292,7 +262,7 @@ func TestAuth_TokenAuth_Renew(t *testing.T) {
 		t.Fatalf("want ttl=1s; got %v", ttl)
 	}
 	time.Sleep(2 * time.Second) // wait till expires
-	_, err = client.Stats(single())
+	_, err = client.Stats(context.Background(), single())
 	if err != nil {
 		t.Fatalf("Stats()=%v", err)
 	}
@@ -326,7 +296,7 @@ func TestAuth_TokenAuth_Renew(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewREST()=%v", err)
 	}
-	if _, err := client.Stats(single()); err == nil {
+	if _, err := client.Stats(context.Background(), single()); err == nil {
 		t.Fatal("want err!=nil")
 	}
 	// Ensure no requests were made to Ably servers.
@@ -351,7 +321,7 @@ func TestAuth_RequestToken(t *testing.T) {
 	if n := rec.Len(); n != 0 {
 		t.Fatalf("want rec.Len()=0; got %d", n)
 	}
-	token, err := client.Auth.RequestToken(nil)
+	token, err := client.Auth.RequestToken(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("RequestToken()=%v", err)
 	}
@@ -364,7 +334,7 @@ func TestAuth_RequestToken(t *testing.T) {
 	authOpts := []ably.AuthOption{
 		ably.AuthWithURL(server.URL("details")),
 	}
-	token2, err := client.Auth.RequestToken(nil, authOpts...)
+	token2, err := client.Auth.RequestToken(context.Background(), nil, authOpts...)
 	if err != nil {
 		t.Fatalf("RequestToken()=%v", err)
 	}
@@ -386,7 +356,7 @@ func TestAuth_RequestToken(t *testing.T) {
 		authOpts := []ably.AuthOption{
 			ably.AuthWithCallback(server.Callback(callback)),
 		}
-		tokCallback, err := client.Auth.RequestToken(nil, authOpts...)
+		tokCallback, err := client.Auth.RequestToken(context.Background(), nil, authOpts...)
 		if err != nil {
 			t.Fatalf("RequestToken()=%v (callback=%s)", err, callback)
 		}
@@ -409,7 +379,7 @@ func TestAuth_RequestToken(t *testing.T) {
 	authOpts = []ably.AuthOption{
 		ably.AuthWithCallback(server.Callback("request")),
 	}
-	tokCallback, err := client.Auth.RequestToken(nil, authOpts...)
+	tokCallback, err := client.Auth.RequestToken(context.Background(), nil, authOpts...)
 	if err != nil {
 		t.Fatalf("RequestToken()=%v", err)
 	}
@@ -445,7 +415,7 @@ func TestAuth_RequestToken(t *testing.T) {
 			ClientID: "test",
 		}
 
-		tokURL, err := client.Auth.RequestToken(params, authOpts...)
+		tokURL, err := client.Auth.RequestToken(context.Background(), params, authOpts...)
 		if err != nil {
 			t.Fatalf("RequestToken()=%v (method=%s)", err, method)
 		}
@@ -490,7 +460,7 @@ func TestAuth_RequestToken(t *testing.T) {
 			t.Errorf("NewRealtime()=%v", err)
 			continue
 		}
-		if _, err = c.Stats(single()); err != nil {
+		if _, err = c.Stats(context.Background(), single()); err != nil {
 			t.Errorf("c.Stats()=%v (method=%s)", err, method)
 		}
 	}
@@ -518,7 +488,7 @@ func TestAuth_ReuseClientID(t *testing.T) {
 	params := &ably.TokenParams{
 		ClientID: "reuse-me",
 	}
-	tok, err := client.Auth.Authorize(params)
+	tok, err := client.Auth.Authorize(context.Background(), params)
 	if err != nil {
 		t.Fatalf("Authorize()=%v", err)
 	}
@@ -528,7 +498,7 @@ func TestAuth_ReuseClientID(t *testing.T) {
 	if clientID := client.Auth.ClientID(); clientID != params.ClientID {
 		t.Fatalf("want ClientID=%q; got %q", params.ClientID, tok.ClientID)
 	}
-	tok2, err := client.Auth.Authorize(nil)
+	tok2, err := client.Auth.Authorize(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Authorize()=%v", err)
 	}
@@ -562,7 +532,7 @@ func TestAuth_RequestToken_PublishClientID(t *testing.T) {
 		params := &ably.TokenParams{
 			ClientID: cas.authAs,
 		}
-		tok, err := rclient.Auth.RequestToken(params)
+		tok, err := rclient.Auth.RequestToken(context.Background(), params)
 		if err != nil {
 			t.Errorf("%d: CreateTokenRequest()=%v", i, err)
 			continue
@@ -642,13 +612,13 @@ func TestAuth_ClientID(t *testing.T) {
 	}
 	client := app.NewRealtime(opts...) // no client.Close as the connection is mocked
 
-	tok, err := client.Auth.RequestToken(params)
+	tok, err := client.Auth.RequestToken(context.Background(), params)
 	if err != nil {
 		t.Fatalf("RequestToken()=%v", err)
 	}
 	proxy.TokenQueue = append(proxy.TokenQueue, tok)
 
-	tok, err = client.Auth.Authorize(nil)
+	tok, err = client.Auth.Authorize(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Authorize()=%v", err)
 	}
@@ -675,7 +645,7 @@ func TestAuth_ClientID(t *testing.T) {
 	tok.ClientID = "non-matching"
 	proxy.TokenQueue = append(proxy.TokenQueue, tok)
 
-	_, err = client.Auth.Authorize(nil)
+	_, err = client.Auth.Authorize(context.Background(), nil)
 	if err := checkError(40012, err); err != nil {
 		t.Fatal(err)
 	}

--- a/ably/error_test.go
+++ b/ably/error_test.go
@@ -1,6 +1,7 @@
 package ably_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -54,7 +55,7 @@ func TestIssue127ErrorResponse(t *testing.T) {
 	client, e := ably.NewREST(opts...)
 	assert.Nil(t, e)
 
-	_, err = client.Time()
+	_, err = client.Time(context.Background())
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), errMsg)
 }
@@ -145,7 +146,7 @@ func TestIssue_154(t *testing.T) {
 	client, e := ably.NewREST(opts...)
 	assert.Nil(t, e)
 
-	_, err = client.Time()
+	_, err = client.Time(context.Background())
 	assert.NotNil(t, err)
 	et := err.(*ably.ErrorInfo)
 	if et.StatusCode != http.StatusMethodNotAllowed {

--- a/ably/export_test.go
+++ b/ably/export_test.go
@@ -40,16 +40,12 @@ func UnwrapErrorCode(err error) ErrorCode {
 	return code(err)
 }
 
-func (a *Auth) Timestamp(queryCtx context.Context) (time.Time, error) {
-	return a.timestamp(queryCtx)
+func (a *Auth) Timestamp(ctx context.Context, query bool) (time.Time, error) {
+	return a.timestamp(ctx, query)
 }
 
 func (c *REST) Timestamp(query bool) (time.Time, error) {
-	var ctx context.Context
-	if query {
-		ctx = c.opts.BaseCtx
-	}
-	return c.Auth.timestamp(ctx)
+	return c.Auth.timestamp(c.opts.BaseCtx, query)
 }
 
 func (a *Auth) SetServerTimeFunc(st func() (time.Time, error)) {

--- a/ably/export_test.go
+++ b/ably/export_test.go
@@ -45,7 +45,7 @@ func (a *Auth) Timestamp(ctx context.Context, query bool) (time.Time, error) {
 }
 
 func (c *REST) Timestamp(query bool) (time.Time, error) {
-	return c.Auth.timestamp(c.opts.BaseCtx, query)
+	return c.Auth.timestamp(context.Background(), query)
 }
 
 func (a *Auth) SetServerTimeFunc(st func() (time.Time, error)) {

--- a/ably/export_test.go
+++ b/ably/export_test.go
@@ -19,8 +19,8 @@ func (opts *clientOptions) RealtimeURL() string {
 	return opts.realtimeURL()
 }
 
-func (c *REST) Post(path string, in, out interface{}) (*http.Response, error) {
-	return c.post(path, in, out)
+func (c *REST) Post(ctx context.Context, path string, in, out interface{}) (*http.Response, error) {
+	return c.post(ctx, path, in, out)
 }
 
 const (
@@ -40,8 +40,16 @@ func UnwrapErrorCode(err error) ErrorCode {
 	return code(err)
 }
 
-func (a *Auth) Timestamp(query bool) (time.Time, error) {
-	return a.timestamp(query)
+func (a *Auth) Timestamp(queryCtx context.Context) (time.Time, error) {
+	return a.timestamp(queryCtx)
+}
+
+func (c *REST) Timestamp(query bool) (time.Time, error) {
+	var ctx context.Context
+	if query {
+		ctx = c.opts.BaseCtx
+	}
+	return c.Auth.timestamp(ctx)
 }
 
 func (a *Auth) SetServerTimeFunc(st func() (time.Time, error)) {

--- a/ably/http_paginated_response.go
+++ b/ably/http_paginated_response.go
@@ -1,6 +1,7 @@
 package ably
 
 import (
+	"context"
 	"net/http"
 	"reflect"
 
@@ -26,9 +27,9 @@ func decodeHTTPPaginatedResult(opts *proto.ChannelOptions, typ reflect.Type, res
 	return o, nil
 }
 
-func newHTTPPaginatedResult(path string, params *PaginateParams,
+func newHTTPPaginatedResult(ctx context.Context, path string, params *PaginateParams,
 	query queryFunc, log *LoggerOptions) (*HTTPPaginatedResponse, error) {
-	p, err := newPaginatedResult(nil, paginatedRequest{typ: arrayTyp, path: path, params: params, query: query, logger: log, respCheck: func(_ *http.Response) error {
+	p, err := newPaginatedResult(ctx, nil, paginatedRequest{typ: arrayTyp, path: path, params: params, query: query, logger: log, respCheck: func(_ *http.Response) error {
 		return nil
 	}, decoder: decodeHTTPPaginatedResult})
 	if err != nil {
@@ -49,8 +50,8 @@ func newHTTPPaginatedResultFromPaginatedResult(p *PaginatedResult) *HTTPPaginate
 
 // Next overrides PaginatedResult.Next
 // spec HP2
-func (h *HTTPPaginatedResponse) Next() (*HTTPPaginatedResponse, error) {
-	p, err := h.PaginatedResult.Next()
+func (h *HTTPPaginatedResponse) Next(ctx context.Context) (*HTTPPaginatedResponse, error) {
+	p, err := h.PaginatedResult.Next(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/ably/http_paginated_response_test.go
+++ b/ably/http_paginated_response_test.go
@@ -1,6 +1,7 @@
 package ably_test
 
 import (
+	"context"
 	"net/http"
 	"reflect"
 	"sort"
@@ -25,7 +26,7 @@ func TestHTTPPaginatedResponse(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Run("request_time", func(ts *testing.T) {
-		res, err := client.Request("get", "/time", nil, nil, nil)
+		res, err := client.Request(context.Background(), "get", "/time", nil, nil, nil)
 		if err != nil {
 			ts.Fatal(err)
 		}
@@ -42,7 +43,7 @@ func TestHTTPPaginatedResponse(t *testing.T) {
 	})
 
 	t.Run("request_404", func(ts *testing.T) {
-		res, err := client.Request("get", "/keys/ablyjs.test/requestToken", nil, nil, nil)
+		res, err := client.Request(context.Background(), "get", "/keys/ablyjs.test/requestToken", nil, nil, nil)
 		if err != nil {
 			ts.Fatal(err)
 		}
@@ -70,7 +71,7 @@ func TestHTTPPaginatedResponse(t *testing.T) {
 
 		ts.Run("post", func(ts *testing.T) {
 			for _, message := range msgs {
-				res, err := client.Request("POST", channelPath, nil, message, nil)
+				res, err := client.Request(context.Background(), "POST", channelPath, nil, message, nil)
 				if err != nil {
 					ts.Fatal(err)
 				}
@@ -88,7 +89,7 @@ func TestHTTPPaginatedResponse(t *testing.T) {
 		})
 
 		ts.Run("get", func(ts *testing.T) {
-			res, err := client.Request("get", channelPath, &ably.PaginateParams{
+			res, err := client.Request(context.Background(), "get", channelPath, &ably.PaginateParams{
 				Limit:     1,
 				Direction: "forwards",
 			}, nil, nil)
@@ -112,7 +113,7 @@ func TestHTTPPaginatedResponse(t *testing.T) {
 				ts.Errorf("expected %v got %s", msgs[0].Data, data)
 			}
 
-			res, err = res.Next()
+			res, err = res.Next(context.Background())
 			if err != nil {
 				ts.Fatal(err)
 			}
@@ -132,7 +133,7 @@ func TestHTTPPaginatedResponse(t *testing.T) {
 
 		})
 
-		res, err := client.Channels.Get(channelName).History(nil)
+		res, err := client.Channels.Get(channelName).History(context.Background(), nil)
 		if err != nil {
 			ts.Fatal(err)
 		}

--- a/ably/options.go
+++ b/ably/options.go
@@ -41,7 +41,6 @@ var defaultOptions = clientOptions{
 	TLSPort:                  443,
 	Now:                      time.Now,
 	After:                    ablyutil.After,
-	BaseCtx:                  context.Background(),
 }
 
 func defaultFallbackHosts() []string {
@@ -236,8 +235,6 @@ type clientOptions struct {
 	// Now returns the time the library should take as current.
 	Now   func() time.Time
 	After func(context.Context, time.Duration) <-chan time.Time
-
-	BaseCtx context.Context
 }
 
 func (opts *clientOptions) timeoutConnect() time.Duration {
@@ -699,15 +696,6 @@ func WithHTTPClient(client *http.Client) ClientOption {
 func WithDial(dial func(protocol string, u *url.URL, timeout time.Duration) (proto.Conn, error)) ClientOption {
 	return func(os *clientOptions) {
 		os.Dial = dial
-	}
-}
-
-// WithBaseContext establishes a context to use for operations initiated by the
-// the library, such as establishing realtime connections and requesting
-// implicit authorizations.
-func WithBaseContext(ctx context.Context) ClientOption {
-	return func(os *clientOptions) {
-		os.BaseCtx = ctx
 	}
 }
 

--- a/ably/options.go
+++ b/ably/options.go
@@ -41,6 +41,7 @@ var defaultOptions = clientOptions{
 	TLSPort:                  443,
 	Now:                      time.Now,
 	After:                    ablyutil.After,
+	BaseCtx:                  context.Background(),
 }
 
 func defaultFallbackHosts() []string {
@@ -235,6 +236,8 @@ type clientOptions struct {
 	// Now returns the time the library should take as current.
 	Now   func() time.Time
 	After func(context.Context, time.Duration) <-chan time.Time
+
+	BaseCtx context.Context
 }
 
 func (opts *clientOptions) timeoutConnect() time.Duration {
@@ -696,6 +699,15 @@ func WithHTTPClient(client *http.Client) ClientOption {
 func WithDial(dial func(protocol string, u *url.URL, timeout time.Duration) (proto.Conn, error)) ClientOption {
 	return func(os *clientOptions) {
 		os.Dial = dial
+	}
+}
+
+// WithBaseContext establishes a context to use for operations initiated by the
+// the library, such as establishing realtime connections and requesting
+// implicit authorizations.
+func WithBaseContext(ctx context.Context) ClientOption {
+	return func(os *clientOptions) {
+		os.BaseCtx = ctx
 	}
 }
 

--- a/ably/paginated_result_test.go
+++ b/ably/paginated_result_test.go
@@ -1,6 +1,7 @@
 package ably_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -42,7 +43,7 @@ func TestMalformedPaginatedResult(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resp, err := client.Request("POST", "/foo", nil, nil, nil)
+	resp, err := client.Request(context.Background(), "POST", "/foo", nil, nil, nil)
 	if resp != nil {
 		t.Errorf("expected no HTTPPaginatedResult; got %+v", resp)
 	}

--- a/ably/readme_examples_test.go
+++ b/ably/readme_examples_test.go
@@ -170,8 +170,8 @@ func TestReadmeExamples(t *testing.T) {
 			/* README.md:240 */ panic(err)
 			/* README.md:241 */
 		}
-		/* README.md:247 */ page, err := channel.History(nil)
-		/* README.md:248 */ for ; err == nil && page != nil; page, err = page.Next() {
+		/* README.md:247 */ page, err := channel.History(ctx, nil)
+		/* README.md:248 */ for ; err == nil && page != nil; page, err = page.Next(ctx) {
 			/* README.md:249 */ for _, message := range page.Messages() {
 				/* README.md:250 */ fmt.Println(message)
 				/* README.md:251 */
@@ -182,8 +182,8 @@ func TestReadmeExamples(t *testing.T) {
 			/* README.md:254 */ panic(err)
 			/* README.md:255 */
 		}
-		/* README.md:261 */ page, err = channel.Presence.Get(nil)
-		/* README.md:262 */ for ; err == nil && page != nil; page, err = page.Next() {
+		/* README.md:261 */ page, err = channel.Presence.Get(ctx, nil)
+		/* README.md:262 */ for ; err == nil && page != nil; page, err = page.Next(ctx) {
 			/* README.md:263 */ for _, presence := range page.PresenceMessages() {
 				/* README.md:264 */ fmt.Println(presence)
 				/* README.md:265 */
@@ -194,8 +194,8 @@ func TestReadmeExamples(t *testing.T) {
 			/* README.md:268 */ panic(err)
 			/* README.md:269 */
 		}
-		/* README.md:275 */ page, err = channel.Presence.History(nil)
-		/* README.md:276 */ for ; err == nil && page != nil; page, err = page.Next() {
+		/* README.md:275 */ page, err = channel.Presence.History(ctx, nil)
+		/* README.md:276 */ for ; err == nil && page != nil; page, err = page.Next(ctx) {
 			/* README.md:277 */ for _, presence := range page.PresenceMessages() {
 				/* README.md:278 */ fmt.Println(presence)
 				/* README.md:279 */
@@ -206,8 +206,8 @@ func TestReadmeExamples(t *testing.T) {
 			/* README.md:282 */ panic(err)
 			/* README.md:283 */
 		}
-		/* README.md:289 */ page, err = client.Stats(&ably.PaginateParams{})
-		/* README.md:290 */ for ; err == nil && page != nil; page, err = page.Next() {
+		/* README.md:289 */ page, err = client.Stats(ctx, &ably.PaginateParams{})
+		/* README.md:290 */ for ; err == nil && page != nil; page, err = page.Next(ctx) {
 			/* README.md:291 */ for _, stat := range page.Stats() {
 				/* README.md:292 */ fmt.Println(stat)
 				/* README.md:293 */

--- a/ably/realtime_channel.go
+++ b/ably/realtime_channel.go
@@ -434,8 +434,8 @@ func (c *RealtimeChannel) PublishBatch(ctx context.Context, messages []*Message)
 // History gives the channel's message history according to the given parameters.
 // The returned result can be inspected for the messages via the Messages()
 // method.
-func (c *RealtimeChannel) History(params *PaginateParams) (*PaginatedResult, error) {
-	return c.client.rest.Channels.Get(c.Name).History(params)
+func (c *RealtimeChannel) History(ctx context.Context, params *PaginateParams) (*PaginatedResult, error) {
+	return c.client.rest.Channels.Get(c.Name).History(ctx, params)
 }
 
 func (c *RealtimeChannel) send(msg *proto.ProtocolMessage) (result, error) {

--- a/ably/realtime_client.go
+++ b/ably/realtime_client.go
@@ -1,6 +1,7 @@
 package ably
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -53,13 +54,13 @@ func (c *Realtime) Close() {
 // Stats gives the clients metrics according to the given parameters. The
 // returned result can be inspected for the statistics via the Stats()
 // method.
-func (c *Realtime) Stats(params *PaginateParams) (*PaginatedResult, error) {
-	return c.rest.Stats(params)
+func (c *Realtime) Stats(ctx context.Context, params *PaginateParams) (*PaginatedResult, error) {
+	return c.rest.Stats(ctx, params)
 }
 
 // Time
-func (c *Realtime) Time() (time.Time, error) {
-	return c.rest.Time()
+func (c *Realtime) Time(ctx context.Context) (time.Time, error) {
+	return c.rest.Time(ctx)
 }
 
 func (c *Realtime) onChannelMsg(msg *proto.ProtocolMessage) {

--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -116,7 +116,6 @@ func (c *Connection) dial(proto string, u *url.URL) (conn proto.Conn, err error)
 	query.Add("heartbeats", "true")
 	u.RawQuery = query.Encode()
 	timeout := c.opts.realtimeRequestTimeout()
-	// TODO: Use c.opts.baseCtx to dial.
 	if c.opts.Dial != nil {
 		conn, err = c.opts.Dial(proto, u, timeout)
 	} else {
@@ -268,7 +267,7 @@ func (c *Connection) params(mode connectionMode) (url.Values, error) {
 	for k, v := range c.opts.TransportParams {
 		query[k] = v
 	}
-	if err := c.auth.authQuery(c.opts.BaseCtx, query); err != nil {
+	if err := c.auth.authQuery(context.Background(), query); err != nil {
 		return nil, err
 	}
 	switch mode {
@@ -876,7 +875,7 @@ func (c *Connection) failedConnSideEffects(err *proto.ErrorInfo) {
 
 func (c *Connection) reauthorize(arg connArgs) {
 	c.mtx.Lock()
-	_, err := c.auth.reauthorize(c.opts.BaseCtx)
+	_, err := c.auth.reauthorize(context.Background())
 
 	if err != nil {
 		c.lockedReauthorizationFailed(err)

--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -116,6 +116,7 @@ func (c *Connection) dial(proto string, u *url.URL) (conn proto.Conn, err error)
 	query.Add("heartbeats", "true")
 	u.RawQuery = query.Encode()
 	timeout := c.opts.realtimeRequestTimeout()
+	// TODO: Use c.opts.baseCtx to dial.
 	if c.opts.Dial != nil {
 		conn, err = c.opts.Dial(proto, u, timeout)
 	} else {
@@ -267,7 +268,7 @@ func (c *Connection) params(mode connectionMode) (url.Values, error) {
 	for k, v := range c.opts.TransportParams {
 		query[k] = v
 	}
-	if err := c.auth.authQuery(query); err != nil {
+	if err := c.auth.authQuery(c.opts.BaseCtx, query); err != nil {
 		return nil, err
 	}
 	switch mode {
@@ -875,7 +876,7 @@ func (c *Connection) failedConnSideEffects(err *proto.ErrorInfo) {
 
 func (c *Connection) reauthorize(arg connArgs) {
 	c.mtx.Lock()
-	_, err := c.auth.reauthorize()
+	_, err := c.auth.reauthorize(c.opts.BaseCtx)
 
 	if err != nil {
 		c.lockedReauthorizationFailed(err)

--- a/ably/rest_channel.go
+++ b/ably/rest_channel.go
@@ -134,7 +134,7 @@ func (c *RESTChannel) PublishBatchWithOptions(ctx context.Context, messages []*M
 		}
 		query = "?" + queryParams.Encode()
 	}
-	res, err := c.client.post(c.baseURL+"/messages"+query, messages, nil)
+	res, err := c.client.post(ctx, c.baseURL+"/messages"+query, messages, nil)
 	if err != nil {
 		return err
 	}
@@ -144,9 +144,9 @@ func (c *RESTChannel) PublishBatchWithOptions(ctx context.Context, messages []*M
 // History gives the channel's message history according to the given parameters.
 // The returned result can be inspected for the messages via the Messages()
 // method.
-func (c *RESTChannel) History(params *PaginateParams) (*PaginatedResult, error) {
+func (c *RESTChannel) History(ctx context.Context, params *PaginateParams) (*PaginatedResult, error) {
 	path := c.baseURL + "/history"
-	rst, err := newPaginatedResult(c.options, paginatedRequest{typ: msgType, path: path, params: params, query: query(c.client.get), logger: c.logger(), respCheck: checkValidHTTPResponse})
+	rst, err := newPaginatedResult(ctx, c.options, paginatedRequest{typ: msgType, path: path, params: params, query: query(c.client.get), logger: c.logger(), respCheck: checkValidHTTPResponse})
 	if err != nil {
 		return nil, err
 	}

--- a/ably/rest_channel_test.go
+++ b/ably/rest_channel_test.go
@@ -77,7 +77,7 @@ func TestRESTChannel(t *testing.T) {
 			}
 		}
 		ts.Run("is available in the history", func(ts *testing.T) {
-			page, err := channel.History(nil)
+			page, err := channel.History(context.Background(), nil)
 			if err != nil {
 				ts.Fatal(err)
 			}
@@ -100,7 +100,7 @@ func TestRESTChannel(t *testing.T) {
 			historyRESTChannel.Publish(context.Background(), "breakingnews", "Another Shark attack!!")
 		}
 
-		page1, err := historyRESTChannel.History(&ably.PaginateParams{Limit: 1})
+		page1, err := historyRESTChannel.History(context.Background(), &ably.PaginateParams{Limit: 1})
 		if err != nil {
 			ts.Fatal(err)
 		}
@@ -111,7 +111,7 @@ func TestRESTChannel(t *testing.T) {
 			ts.Errorf("expected 1 item got %d", len(page1.Items()))
 		}
 
-		page2, err := page1.Next()
+		page2, err := page1.Next(context.Background())
 		if err != nil {
 			ts.Fatal(err)
 		}
@@ -133,7 +133,7 @@ func TestRESTChannel(t *testing.T) {
 		if err != nil {
 			ts.Fatal(err)
 		}
-		page, err := encodingRESTChannel.History(&ably.PaginateParams{Limit: 2})
+		page, err := encodingRESTChannel.History(context.Background(), &ably.PaginateParams{Limit: 2})
 		if err != nil {
 			ts.Fatal(err)
 		}
@@ -175,7 +175,7 @@ func TestRESTChannel(t *testing.T) {
 			}
 		}
 
-		rst, err := channel.History(nil)
+		rst, err := channel.History(context.Background(), nil)
 		if err != nil {
 			ts.Fatal(err)
 		}
@@ -223,7 +223,7 @@ func TestIdempotentPublishing(t *testing.T) {
 				ts.Fatal(err)
 			}
 		}
-		res, err := channel.History(nil)
+		res, err := channel.History(context.Background(), nil)
 		if err != nil {
 			ts.Fatal(err)
 		}
@@ -246,7 +246,7 @@ func TestIdempotentPublishing(t *testing.T) {
 				ts.Fatal(err)
 			}
 		}
-		res, err := channel.History(nil)
+		res, err := channel.History(context.Background(), nil)
 		if err != nil {
 			ts.Fatal(err)
 		}
@@ -298,7 +298,7 @@ func TestIdempotentPublishing(t *testing.T) {
 		if err != nil {
 			ts.Fatal(err)
 		}
-		res, err := channel.History(nil)
+		res, err := channel.History(context.Background(), nil)
 		if err != nil {
 			ts.Fatal(err)
 		}
@@ -340,7 +340,7 @@ func TestIdempotentPublishing(t *testing.T) {
 		if err != nil {
 			ts.Fatal(err)
 		}
-		res, err := channel.History(nil)
+		res, err := channel.History(context.Background(), nil)
 		if err != nil {
 			ts.Fatal(err)
 		}
@@ -378,7 +378,7 @@ func TestIdempotentPublishing(t *testing.T) {
 		if err != nil {
 			ts.Fatal(err)
 		}
-		res, err := channel.History(nil)
+		res, err := channel.History(context.Background(), nil)
 		if err != nil {
 			ts.Fatal(err)
 		}
@@ -477,7 +477,7 @@ func TestIdempotent_retry(t *testing.T) {
 			if retryCount != 2 {
 				ts.Errorf("expected %d retry attempts got %d", 2, retryCount)
 			}
-			res, err := channel.History(nil)
+			res, err := channel.History(context.Background(), nil)
 			if err != nil {
 				ts.Fatal(err)
 			}
@@ -497,7 +497,7 @@ func TestIdempotent_retry(t *testing.T) {
 			for range msgs {
 				channel.PublishBatch(context.Background(), msgs)
 			}
-			res, err := channel.History(nil)
+			res, err := channel.History(context.Background(), nil)
 			if err != nil {
 				ts.Fatal(err)
 			}
@@ -537,7 +537,7 @@ func TestRSL1f1(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := channel.History(nil)
+	res, err := channel.History(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -579,7 +579,7 @@ func TestRSL1g(t *testing.T) {
 		if err != nil {
 			ts.Fatal(err)
 		}
-		pages, err := channel.History(nil)
+		pages, err := channel.History(context.Background(), nil)
 		if err != nil {
 			ts.Fatal(err)
 		}
@@ -603,7 +603,7 @@ func TestRSL1g(t *testing.T) {
 		if err != nil {
 			ts.Fatal(err)
 		}
-		pages, err := channel.History(nil)
+		pages, err := channel.History(context.Background(), nil)
 		if err != nil {
 			ts.Fatal(err)
 		}

--- a/ably/rest_client.go
+++ b/ably/rest_client.go
@@ -164,11 +164,10 @@ func (c *REST) Stats(ctx context.Context, params *PaginateParams) (*PaginatedRes
 // request this contains fields necessary to compose http request that will be
 // sent ably endpoints.
 type request struct {
-	Context context.Context
-	Method  string
-	Path    string
-	In      interface{} // value to be encoded and sent with request body
-	Out     interface{} // value to store decoded response body
+	Method string
+	Path   string
+	In     interface{} // value to be encoded and sent with request body
+	Out    interface{} // value to store decoded response body
 
 	// NoAuth when set to true, makes the request not being authenticated.
 	NoAuth bool

--- a/ably/rest_client_test.go
+++ b/ably/rest_client_test.go
@@ -126,7 +126,7 @@ func TestRestClient(t *testing.T) {
 		if err != nil {
 			ts.Fatal(err)
 		}
-		t, err := client.Time()
+		t, err := client.Time(context.Background())
 		if err != nil {
 			ts.Fatal(err)
 		}
@@ -178,7 +178,7 @@ func TestRestClient(t *testing.T) {
 		stats[1].IntervalID = proto.IntervalFormatFor(lastInterval.Add(-60*time.Minute), proto.StatGranularityMinute)
 		stats[2].IntervalID = proto.IntervalFormatFor(lastInterval.Add(-1*time.Minute), proto.StatGranularityMinute)
 
-		res, err := client.Post("/stats", &stats, nil)
+		res, err := client.Post(context.Background(), "/stats", &stats, nil)
 		if err != nil {
 			ts.Error(err)
 		}
@@ -200,7 +200,7 @@ func TestRestClient(t *testing.T) {
 					errCh <- errors.New("timeout waiting for client.Stats to return nonempty value")
 					return
 				case <-tick:
-					page, err := client.Stats(&ably.PaginateParams{
+					page, err := client.Stats(context.Background(), &ably.PaginateParams{
 						Limit: 1,
 						ScopeParams: ably.ScopeParams{
 							Start: longAgo,
@@ -256,7 +256,7 @@ func TestRSC7(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, _ = c.Request("POST", "/foo", nil, nil, nil)
+	_, _ = c.Request(context.Background(), "POST", "/foo", nil, nil, nil)
 
 	var req *http.Request
 	ablytest.Instantly.Recv(t, &req, requests, t.Fatalf)

--- a/ably/rest_presence.go
+++ b/ably/rest_presence.go
@@ -1,5 +1,7 @@
 package ably
 
+import "context"
+
 type RESTPresence struct {
 	client  *REST
 	channel *RESTChannel
@@ -8,17 +10,17 @@ type RESTPresence struct {
 // Get gives the channel's presence messages according to the given parameters.
 // The returned result can be inspected for the presence messages via
 // the PresenceMessages() method.
-func (p *RESTPresence) Get(params *PaginateParams) (*PaginatedResult, error) {
+func (p *RESTPresence) Get(ctx context.Context, params *PaginateParams) (*PaginatedResult, error) {
 	path := p.channel.baseURL + "/presence"
-	return newPaginatedResult(nil, paginatedRequest{typ: presMsgType, path: path, params: params, query: query(p.client.get), logger: p.logger(), respCheck: checkValidHTTPResponse})
+	return newPaginatedResult(ctx, nil, paginatedRequest{typ: presMsgType, path: path, params: params, query: query(p.client.get), logger: p.logger(), respCheck: checkValidHTTPResponse})
 }
 
 // History gives the channel's presence messages history according to the given
 // parameters. The returned result can be inspected for the presence messages
 // via the PresenceMessages() method.
-func (p *RESTPresence) History(params *PaginateParams) (*PaginatedResult, error) {
+func (p *RESTPresence) History(ctx context.Context, params *PaginateParams) (*PaginatedResult, error) {
 	path := p.channel.baseURL + "/presence/history"
-	return newPaginatedResult(nil, paginatedRequest{typ: presMsgType, path: path, params: params, query: query(p.client.get), logger: p.logger(), respCheck: checkValidHTTPResponse})
+	return newPaginatedResult(ctx, nil, paginatedRequest{typ: presMsgType, path: path, params: params, query: query(p.client.get), logger: p.logger(), respCheck: checkValidHTTPResponse})
 }
 
 func (p *RESTPresence) logger() *LoggerOptions {

--- a/ably/rest_presence_test.go
+++ b/ably/rest_presence_test.go
@@ -1,6 +1,7 @@
 package ably_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -23,7 +24,7 @@ func TestChannel_Presence(t *testing.T) {
 	presence := channel.Presence
 
 	t.Run("Get", func(ts *testing.T) {
-		page, err := presence.Get(nil)
+		page, err := presence.Get(context.Background(), nil)
 		if err != nil {
 			ts.Fatal(err)
 		}
@@ -35,7 +36,7 @@ func TestChannel_Presence(t *testing.T) {
 
 		ts.Run("With limit option", func(ts *testing.T) {
 			limit := 2
-			page1, err := presence.Get(&ably.PaginateParams{Limit: limit})
+			page1, err := presence.Get(context.Background(), &ably.PaginateParams{Limit: limit})
 			if err != nil {
 				ts.Fatal(err)
 			}
@@ -48,7 +49,7 @@ func TestChannel_Presence(t *testing.T) {
 				ts.Errorf("expected %d items got %d", limit, n)
 			}
 
-			page2, err := page1.Next()
+			page2, err := page1.Next(context.Background())
 			if err != nil {
 				ts.Fatal(err)
 			}
@@ -61,7 +62,7 @@ func TestChannel_Presence(t *testing.T) {
 				ts.Errorf("expected %d items got %d", limit, n)
 			}
 
-			noPage, err := page2.Next()
+			noPage, err := page2.Next(context.Background())
 			if err != nil {
 				ts.Fatal(err)
 			}
@@ -72,7 +73,7 @@ func TestChannel_Presence(t *testing.T) {
 	})
 
 	t.Run("History", func(ts *testing.T) {
-		page, err := presence.History(nil)
+		page, err := presence.History(context.Background(), nil)
 		if err != nil {
 			ts.Fatal(err)
 		}
@@ -89,7 +90,7 @@ func TestChannel_Presence(t *testing.T) {
 					End:   time.Now(),
 				},
 			}
-			page, err := presence.History(params)
+			page, err := presence.History(context.Background(), params)
 			if err != nil {
 				ts.Fatal(err)
 			}


### PR DESCRIPTION
Now HTTP requests require contexts. Since lots of things end up making
HTTP requests, contexts need to be propagated everywhere. Huge change,
but not one that can be easily or usefully split.

For where we don't have a context passed as a parameter because it's the
library itself who initiates the operation, a base context can be set
with a new ClientOption.

Fixes #275.