### PR TITLE
TestFixConnLeak_ISSUE89: Change the way it detects closed conns

### DIFF
--- a/ably/ablytest/timeout.go
+++ b/ably/ablytest/timeout.go
@@ -91,11 +91,11 @@ func (wt WithTimeout) IsTrue(pred func() bool) bool {
 	timeout := time.NewTimer(wt.before)
 	defer timeout.Stop()
 	for {
+		if pred() {
+			return true
+		}
 		select {
 		case <-ticker.C:
-			if pred() {
-				return true
-			}
 		case <-timeout.C:
 			return pred()
 		}

--- a/ably/rest_client_test.go
+++ b/ably/rest_client_test.go
@@ -549,7 +549,7 @@ func TestFixConnLeak_ISSUE89(t *testing.T) {
 	}
 	defer app.Close()
 
-	var conns []*connTrackingClose
+	var conns []*connCloseTracker
 
 	httpClient := ablytest.NewHTTPClientNoKeepAlive()
 	transport := httpClient.Transport.(*http.Transport)
@@ -559,7 +559,7 @@ func TestFixConnLeak_ISSUE89(t *testing.T) {
 		if err != nil {
 			return nil, err
 		}
-		tracked := &connTrackingClose{Conn: c}
+		tracked := &connCloseTracker{Conn: c}
 		conns = append(conns, tracked)
 		return tracked, nil
 	}
@@ -586,12 +586,12 @@ func TestFixConnLeak_ISSUE89(t *testing.T) {
 	}
 }
 
-type connTrackingClose struct {
+type connCloseTracker struct {
 	net.Conn
 	closed uintptr
 }
 
-func (c *connTrackingClose) Close() error {
+func (c *connCloseTracker) Close() error {
 	atomic.StoreUintptr(&c.closed, 1)
 	return c.Conn.Close()
 }

--- a/ably/rest_client_test.go
+++ b/ably/rest_client_test.go
@@ -7,12 +7,13 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/http/httptest"
-	"net/http/httptrace"
 	"net/url"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -542,19 +543,28 @@ func TestRESTChannels_RSN1(t *testing.T) {
 }
 
 func TestFixConnLeak_ISSUE89(t *testing.T) {
-	var trackRecord []httptrace.GotConnInfo
-	trace := &httptrace.ClientTrace{
-		GotConn: func(c httptrace.GotConnInfo) {
-			trackRecord = append(trackRecord, c)
-		},
-	}
 	app, err := ablytest.NewSandbox(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer app.Close()
-	opts := app.Options(ably.WithHTTPClient(ablytest.NewHTTPClientNoKeepAlive()))
-	opts = append(opts, ably.WithTrace(trace))
+
+	var conns []*connTrackingClose
+
+	httpClient := ablytest.NewHTTPClientNoKeepAlive()
+	transport := httpClient.Transport.(*http.Transport)
+	dial := transport.Dial
+	transport.Dial = func(network, address string) (net.Conn, error) {
+		c, err := dial(network, address)
+		if err != nil {
+			return nil, err
+		}
+		tracked := &connTrackingClose{Conn: c}
+		conns = append(conns, tracked)
+		return tracked, nil
+	}
+
+	opts := app.Options(ably.WithHTTPClient(httpClient))
 	client, err := ably.NewREST(opts...)
 	if err != nil {
 		t.Fatal(err)
@@ -567,16 +577,21 @@ func TestFixConnLeak_ISSUE89(t *testing.T) {
 		}
 	}
 
-	for _, v := range trackRecord {
-		v.Conn.SetReadDeadline(time.Now())
-		if _, err := v.Conn.Read(make([]byte, 1)); err != nil {
-			if !connIsClosed(err) {
-				t.Errorf("expected conn %s to be closed", v.Conn.LocalAddr())
-			}
+	for _, c := range conns {
+		if !ablytest.Before(1 * time.Second).IsTrue(func() bool {
+			return atomic.LoadUintptr(&c.closed) != 0
+		}) {
+			t.Errorf("conn to %v wasn't closed", c.RemoteAddr())
 		}
 	}
 }
 
-func connIsClosed(err error) bool {
-	return strings.Contains(err.Error(), "use of closed network connection")
+type connTrackingClose struct {
+	net.Conn
+	closed uintptr
+}
+
+func (c *connTrackingClose) Close() error {
+	atomic.StoreUintptr(&c.closed, 1)
+	return c.Close()
 }

--- a/ably/rest_client_test.go
+++ b/ably/rest_client_test.go
@@ -593,5 +593,5 @@ type connTrackingClose struct {
 
 func (c *connTrackingClose) Close() error {
 	atomic.StoreUintptr(&c.closed, 1)
-	return c.Close()
+	return c.Conn.Close()
 }


### PR DESCRIPTION
In the new CI, we often see this:

```
--- FAIL: TestFixConnLeak_ISSUE89 (6.87s)
    rest_client_test.go:574: expected conn 10.1.0.4:47296 to be closed
    rest_client_test.go:574: expected conn 10.1.0.4:47308 to be closed
    rest_client_test.go:574: expected conn 10.1.0.4:47312 to be closed
```

It's probably just a race condition, so, fix that by waiting a bit.

Also, the way it was checking that conns were closed was by trying to
reuse them, seeing if that failed with a particular error message.
That's too implementation-dependent. Now it checks that the Close()
method is called on the connections.