### PR TITLE
Adapt Stats to follow new paginated result design

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,10 @@ if err != nil {
 
 ### Querying the History
 
+<!-- GO EXAMPLE
+{
+-->
+
 ```go
 page, err := channel.History(ctx, nil)
 for ; err == nil && page != nil; page, err = page.Next(ctx) {
@@ -255,10 +259,18 @@ if err != nil {
 }
 ```
 
+<!-- GO EXAMPLE
+}
+-->
+
 ### Presence on a channel
 
+<!-- GO EXAMPLE
+{
+-->
+
 ```go
-page, err = channel.Presence.Get(ctx, nil)
+page, err := channel.Presence.Get(ctx, nil)
 for ; err == nil && page != nil; page, err = page.Next(ctx) {
 	for _, presence := range page.PresenceMessages() {
 		fmt.Println(presence)
@@ -268,11 +280,19 @@ if err != nil {
 	panic(err)
 }
 ```
+
+<!-- GO EXAMPLE
+}
+-->
 
 ### Querying the Presence History
 
+<!-- GO EXAMPLE
+{
+-->
+
 ```go
-page, err = channel.Presence.History(ctx, nil)
+page, err := channel.Presence.History(ctx, nil)
 for ; err == nil && page != nil; page, err = page.Next(ctx) {
 	for _, presence := range page.PresenceMessages() {
 		fmt.Println(presence)
@@ -283,19 +303,34 @@ if err != nil {
 }
 ```
 
+<!-- GO EXAMPLE
+}
+-->
+
 ### Fetching your application's stats
 
+<!-- GO EXAMPLE
+{
+-->
+
 ```go
-page, err = client.Stats(ctx, &ably.PaginateParams{})
-for ; err == nil && page != nil; page, err = page.Next(ctx) {
-	for _, stat := range page.Stats() {
-		fmt.Println(stat)
-	}
-}
+pages, err := client.Stats().Pages(ctx)
 if err != nil {
 	panic(err)
 }
+for pages.Next(ctx) {
+	for _, stat := range pages.Items() {
+		fmt.Println(stat)
+	}
+}
+if err := pages.Err(); err != nil {
+	panic(err)
+}
 ```
+
+<!-- GO EXAMPLE
+}
+-->
 
 <!-- GO EXAMPLE
 }

--- a/ably/ablytest/pagination.go
+++ b/ably/ablytest/pagination.go
@@ -1,0 +1,150 @@
+package ablytest
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+)
+
+func TestPagination(expected, request interface{}, perPage int) error {
+	var items []interface{}
+	rexpected := reflect.ValueOf(expected)
+	for i := 0; i < reflect.ValueOf(expected).Len(); i++ {
+		items = append(items, rexpected.Index(i).Interface())
+	}
+	return testPagination(reflect.ValueOf(request), items, perPage)
+}
+
+func testPagination(request reflect.Value, expectedItems []interface{}, perPage int) error {
+	getPages, getItems := generalizePagination(request)
+
+	var expectedPages [][]interface{}
+	var page []interface{}
+	for _, item := range expectedItems {
+		page = append(page, item)
+		if len(page) == perPage {
+			expectedPages = append(expectedPages, page)
+			page = nil
+		}
+	}
+	if len(page) > 0 {
+		expectedPages = append(expectedPages, page)
+	}
+
+	for i := 0; i < 2; i++ {
+		pages, err := getPages()
+		if err != nil {
+			return fmt.Errorf("calling Pages: %w", err)
+		}
+		var gotPages [][]interface{}
+		for pages.next() {
+			gotPages = append(gotPages, pages.items())
+		}
+		if err := pages.err(); err != nil {
+			return fmt.Errorf("iterating pages: %w", err)
+		}
+
+		if !reflect.DeepEqual(expectedPages, gotPages) {
+			return fmt.Errorf("expected pages: %+v, got: %+v", expectedPages, gotPages)
+		}
+
+		if err := pages.first(); err != nil {
+			return fmt.Errorf("going back to first page: %w", err)
+		}
+	}
+
+	for i := 0; i < 2; i++ {
+		items, err := getItems()
+		if err != nil {
+			return fmt.Errorf("calling Items: %w", err)
+		}
+		var gotItems []interface{}
+		for items.next() {
+			gotItems = append(gotItems, items.item())
+		}
+		if err := items.err(); err != nil {
+			return fmt.Errorf("iterating items: %w", err)
+		}
+
+		if !reflect.DeepEqual(expectedItems, gotItems) {
+			return fmt.Errorf("expected items: %+v, got: %+v", expectedItems, gotItems)
+		}
+
+		if err := items.first(); err != nil {
+			return fmt.Errorf("going back to first page: %w", err)
+		}
+	}
+
+	return nil
+}
+
+type paginated struct {
+	next  func() bool
+	first func() error
+	err   func() error
+}
+
+type paginatedResult struct {
+	paginated
+	items func() []interface{}
+}
+
+type paginatedItems struct {
+	paginated
+	item func() interface{}
+}
+
+func generalizePagination(request reflect.Value) (func() (paginatedResult, error), func() (paginatedItems, error)) {
+	ctx := reflect.ValueOf(context.Background())
+
+	generalizeCommon := func(r reflect.Value) paginated {
+		return paginated{
+			next: func() bool {
+				return r.MethodByName("Next").Call([]reflect.Value{ctx})[0].Bool()
+			},
+			first: func() error {
+				err, _ := r.MethodByName("First").Call([]reflect.Value{ctx})[0].Interface().(error)
+				return err
+			},
+			err: func() error {
+				err, _ := r.MethodByName("Err").Call(nil)[0].Interface().(error)
+				return err
+			},
+		}
+	}
+
+	pages := func() (paginatedResult, error) {
+		ret := request.MethodByName("Pages").Call([]reflect.Value{ctx})
+		if err, ok := ret[1].Interface().(error); ok && err != nil {
+			return paginatedResult{}, err
+		}
+		r := ret[0]
+		return paginatedResult{
+			paginated: generalizeCommon(r),
+			items: func() []interface{} {
+				ritems := r.MethodByName("Items").Call(nil)[0]
+				var items []interface{}
+				for i := 0; i < ritems.Len(); i++ {
+					items = append(items, ritems.Index(i).Interface())
+				}
+				return items
+			},
+		}, nil
+	}
+
+	items := func() (paginatedItems, error) {
+		ret := request.MethodByName("Items").Call([]reflect.Value{ctx})
+		if err, ok := ret[1].Interface().(error); ok && err != nil {
+			return paginatedItems{}, err
+		}
+		r := ret[0]
+		return paginatedItems{
+			paginated: generalizeCommon(r),
+			item: func() interface{} {
+				return r.MethodByName("Item").Call(nil)[0].Interface()
+			},
+		}, nil
+	}
+
+	return pages, items
+}

--- a/ably/auth_test.go
+++ b/ably/auth_test.go
@@ -55,7 +55,7 @@ func TestAuth_BasicAuth(t *testing.T) {
 	if _, err := client.Time(context.Background()); err != nil {
 		t.Fatalf("client.Time()=%v", err)
 	}
-	if _, err := client.Stats(context.Background(), single()); err != nil {
+	if _, err := client.Stats().Pages(context.Background()); err != nil {
 		t.Fatalf("client.Stats()=%v", err)
 	}
 	if n := rec.Len(); n != 2 {
@@ -107,7 +107,7 @@ func TestAuth_TokenAuth(t *testing.T) {
 	if _, err := client.Time(context.Background()); err != nil {
 		t.Fatalf("client.Time()=%v", err)
 	}
-	if _, err := client.Stats(context.Background(), single()); err != nil {
+	if _, err := client.Stats().Pages(context.Background()); err != nil {
 		t.Fatalf("client.Stats()=%v", err)
 	}
 	// At this points there should be two requests recorded:
@@ -262,7 +262,7 @@ func TestAuth_TokenAuth_Renew(t *testing.T) {
 		t.Fatalf("want ttl=1s; got %v", ttl)
 	}
 	time.Sleep(2 * time.Second) // wait till expires
-	_, err = client.Stats(context.Background(), single())
+	_, err = client.Stats().Pages(context.Background())
 	if err != nil {
 		t.Fatalf("Stats()=%v", err)
 	}
@@ -296,7 +296,7 @@ func TestAuth_TokenAuth_Renew(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewREST()=%v", err)
 	}
-	if _, err := client.Stats(context.Background(), single()); err == nil {
+	if _, err := client.Stats().Pages(context.Background()); err == nil {
 		t.Fatal("want err!=nil")
 	}
 	// Ensure no requests were made to Ably servers.
@@ -460,7 +460,7 @@ func TestAuth_RequestToken(t *testing.T) {
 			t.Errorf("NewRealtime()=%v", err)
 			continue
 		}
-		if _, err = c.Stats(context.Background(), single()); err != nil {
+		if _, err = c.Stats().Pages(context.Background()); err != nil {
 			t.Errorf("c.Stats()=%v (method=%s)", err, method)
 		}
 	}

--- a/ably/doc.go
+++ b/ably/doc.go
@@ -33,4 +33,28 @@
 //
 // For messages and presence messages, "on" is called "subscribe" and "off" is
 // called "unsubscribe".
+//
+// Paginated results
+//
+// Most requests to the Ably REST API return a single page of results, with
+// hyperlinks to the first and next pages in the whole collection of results.
+// To facilitate navigating through these pages, the library provides access to
+// such paginated results though a common pattern.
+//
+// A method that prepares a paginated request returns a Request object with two
+// methods: Pages and Items. Pages returns a PaginatedResult, an iterator that,
+// on each iteration, yields a whole page of results. Items is simply a
+// convenience wrapper that yields single results insteads.
+//
+// In both cases, calling the method validates the request and may return an
+// error.
+//
+// Then, for accessing the results, the Next method from the resulting
+// iterator object must be called repeatedly; each time it returns true, the
+// result that has been retrieved can be inspected with the Items or Item method
+// from the iterator object. Finally, once it returns false, the Err method must
+// be called to check if the iterator stopped due to some error, or else, it
+// just finished going through all pages.
+//
+// See the PaginatedResults example.
 package ably

--- a/ably/doc_test.go
+++ b/ably/doc_test.go
@@ -1,0 +1,8 @@
+package ably_test
+
+import "fmt"
+
+func Example_paginatedResults() {
+	fmt.Println("TODO once the Requests method is adapted")
+	// Output: TODO once the Requests method is adapted
+}

--- a/ably/paginated_result.go
+++ b/ably/paginated_result.go
@@ -57,7 +57,7 @@ type PaginatedResultNew struct {
 // load loads the first page of results. Must be called from the type-specific
 // wrapper Pages method that creates the PaginatedResult object.
 func (p *PaginatedResultNew) load(ctx context.Context, r paginatedRequestNew) error {
-	p.basePath = r.path
+	p.basePath = path.Dir(r.path)
 	p.firstLink = (&url.URL{
 		Path:     r.path,
 		RawQuery: r.params.Encode(),
@@ -99,12 +99,11 @@ func (p *PaginatedResultNew) loadItems(
 		if nextItem == 0 {
 			var getLen func() int
 			page, getLen = pageDecoder()
-			pageLen = getLen()
-
 			hasNext := p.next(ctx, &page)
 			if !hasNext {
 				return 0, false
 			}
+			pageLen = getLen()
 		}
 
 		idx := nextItem
@@ -119,6 +118,7 @@ func (p *PaginatedResultNew) goTo(ctx context.Context, link string) error {
 	if err != nil {
 		return err
 	}
+	p.nextLink = ""
 	for _, rawLink := range p.res.Header["Link"] {
 		m := relLinkRegexp.FindStringSubmatch(rawLink)
 		if len(m) == 0 {
@@ -387,6 +387,7 @@ func (p *PaginatedResult) PresenceMessages() []*PresenceMessage {
 
 type Stats = proto.Stats
 type StatsMessageTypes = proto.MessageTypes
+type StatsMessageCount = proto.MessageCount
 type StatsMessageTraffic = proto.MessageTraffic
 type StatsConnectionTypes = proto.ConnectionTypes
 type StatsResourceCount = proto.ResourceCount

--- a/ably/paginated_result.go
+++ b/ably/paginated_result.go
@@ -41,6 +41,8 @@ func (r *REST) newPaginatedRequest(path string, params url.Values) paginatedRequ
 
 // PaginatedResultNew is a generic iterator for PaginatedResult pagination.
 // Items decoding is delegated to type-specific wrappers.
+//
+// See "Paginated results" section in the package-level documentation.
 type PaginatedResultNew struct {
 	basePath  string
 	nextLink  string
@@ -52,6 +54,8 @@ type PaginatedResultNew struct {
 	first bool
 }
 
+// load loads the first page of results. Must be called from the type-specific
+// wrapper Pages method that creates the PaginatedResult object.
 func (p *PaginatedResultNew) load(ctx context.Context, r paginatedRequestNew) error {
 	p.basePath = r.path
 	p.firstLink = (&url.URL{
@@ -90,6 +94,8 @@ func (p *PaginatedResultNew) goTo(ctx context.Context, link string) error {
 // called to check for any errors.
 //
 // Items can then be inspected with the type-specific Items method.
+//
+// For items iterators, use the next function returned by loadItems instead.
 func (p *PaginatedResultNew) next(ctx context.Context, into interface{}) bool {
 	if !p.first {
 		if p.nextLink == "" {

--- a/ably/proto/stat.go
+++ b/ably/proto/stat.go
@@ -1,6 +1,9 @@
 package proto
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 const (
 	StatGranularityMinute = "minute"
@@ -135,4 +138,8 @@ type Stats struct {
 	XchgProducer  XchgMessages    `json:"xchgProducer" codec:"xchgProducer"`
 	XchgConsumer  XchgMessages    `json:"xchgConsumer" codec:"xchgConsumer"`
 	PeakRates     Rates           `json:"peakRates" codec:"peakRates"`
+}
+
+func (s Stats) String() string {
+	return fmt.Sprintf("<Stats %v; unit=%v; count=%v>", s.IntervalID, s.Unit, s.Count)
 }

--- a/ably/proto/stat.go
+++ b/ably/proto/stat.go
@@ -46,7 +46,7 @@ type MessageCount struct {
 
 type MessageTypes struct {
 	All      MessageCount `json:"all" codec:"all"`
-	Plain    MessageCount `json:"plain" codec:"plain"`
+	Messages MessageCount `json:"messages" codec:"messages"`
 	Presence MessageCount `json:"presence" codec:"presence"`
 }
 

--- a/ably/readme_examples_test.go
+++ b/ably/readme_examples_test.go
@@ -170,54 +170,70 @@ func TestReadmeExamples(t *testing.T) {
 			/* README.md:240 */ panic(err)
 			/* README.md:241 */
 		}
-		/* README.md:247 */ page, err := channel.History(ctx, nil)
-		/* README.md:248 */ for ; err == nil && page != nil; page, err = page.Next(ctx) {
-			/* README.md:249 */ for _, message := range page.Messages() {
-				/* README.md:250 */ fmt.Println(message)
-				/* README.md:251 */
+		/* README.md:247 */ {
+			/* README.md:251 */ page, err := channel.History(ctx, nil)
+			/* README.md:252 */ for ; err == nil && page != nil; page, err = page.Next(ctx) {
+				/* README.md:253 */ for _, message := range page.Messages() {
+					/* README.md:254 */ fmt.Println(message)
+					/* README.md:255 */
+				}
+				/* README.md:256 */
 			}
-			/* README.md:252 */
-		}
-		/* README.md:253 */ if err != nil {
-			/* README.md:254 */ panic(err)
-			/* README.md:255 */
-		}
-		/* README.md:261 */ page, err = channel.Presence.Get(ctx, nil)
-		/* README.md:262 */ for ; err == nil && page != nil; page, err = page.Next(ctx) {
-			/* README.md:263 */ for _, presence := range page.PresenceMessages() {
-				/* README.md:264 */ fmt.Println(presence)
-				/* README.md:265 */
+			/* README.md:257 */ if err != nil {
+				/* README.md:258 */ panic(err)
+				/* README.md:259 */
 			}
-			/* README.md:266 */
+			/* README.md:263 */
 		}
-		/* README.md:267 */ if err != nil {
-			/* README.md:268 */ panic(err)
-			/* README.md:269 */
-		}
-		/* README.md:275 */ page, err = channel.Presence.History(ctx, nil)
-		/* README.md:276 */ for ; err == nil && page != nil; page, err = page.Next(ctx) {
-			/* README.md:277 */ for _, presence := range page.PresenceMessages() {
-				/* README.md:278 */ fmt.Println(presence)
-				/* README.md:279 */
+		/* README.md:269 */ {
+			/* README.md:273 */ page, err := channel.Presence.Get(ctx, nil)
+			/* README.md:274 */ for ; err == nil && page != nil; page, err = page.Next(ctx) {
+				/* README.md:275 */ for _, presence := range page.PresenceMessages() {
+					/* README.md:276 */ fmt.Println(presence)
+					/* README.md:277 */
+				}
+				/* README.md:278 */
 			}
-			/* README.md:280 */
-		}
-		/* README.md:281 */ if err != nil {
-			/* README.md:282 */ panic(err)
-			/* README.md:283 */
-		}
-		/* README.md:289 */ page, err = client.Stats(ctx, &ably.PaginateParams{})
-		/* README.md:290 */ for ; err == nil && page != nil; page, err = page.Next(ctx) {
-			/* README.md:291 */ for _, stat := range page.Stats() {
-				/* README.md:292 */ fmt.Println(stat)
-				/* README.md:293 */
+			/* README.md:279 */ if err != nil {
+				/* README.md:280 */ panic(err)
+				/* README.md:281 */
 			}
-			/* README.md:294 */
+			/* README.md:285 */
 		}
-		/* README.md:295 */ if err != nil {
-			/* README.md:296 */ panic(err)
-			/* README.md:297 */
+		/* README.md:291 */ {
+			/* README.md:295 */ page, err := channel.Presence.History(ctx, nil)
+			/* README.md:296 */ for ; err == nil && page != nil; page, err = page.Next(ctx) {
+				/* README.md:297 */ for _, presence := range page.PresenceMessages() {
+					/* README.md:298 */ fmt.Println(presence)
+					/* README.md:299 */
+				}
+				/* README.md:300 */
+			}
+			/* README.md:301 */ if err != nil {
+				/* README.md:302 */ panic(err)
+				/* README.md:303 */
+			}
+			/* README.md:307 */
 		}
-		/* README.md:301 */
+		/* README.md:313 */ {
+			/* README.md:317 */ pages, err := client.Stats().Pages(ctx)
+			/* README.md:318 */ if err != nil {
+				/* README.md:319 */ panic(err)
+				/* README.md:320 */
+			}
+			/* README.md:321 */ for pages.Next(ctx) {
+				/* README.md:322 */ for _, stat := range pages.Items() {
+					/* README.md:323 */ fmt.Println(stat)
+					/* README.md:324 */
+				}
+				/* README.md:325 */
+			}
+			/* README.md:326 */ if err := pages.Err(); err != nil {
+				/* README.md:327 */ panic(err)
+				/* README.md:328 */
+			}
+			/* README.md:332 */
+		}
+		/* README.md:336 */
 	}
 }

--- a/ably/realtime_client.go
+++ b/ably/realtime_client.go
@@ -51,11 +51,9 @@ func (c *Realtime) Close() {
 	c.Connection.Close()
 }
 
-// Stats gives the clients metrics according to the given parameters. The
-// returned result can be inspected for the statistics via the Stats()
-// method.
-func (c *Realtime) Stats(ctx context.Context, params *PaginateParams) (*PaginatedResult, error) {
-	return c.rest.Stats(ctx, params)
+// Stats is the same as REST.Stats.
+func (c *Realtime) Stats(o ...StatsOption) StatsRequest {
+	return c.rest.Stats(o...)
 }
 
 // Time

--- a/ably/rest_client.go
+++ b/ably/rest_client.go
@@ -215,24 +215,38 @@ func (o *statsOptions) apply(opts ...StatsOption) url.Values {
 	return o.params
 }
 
+// StatsRequest represents a request prepared by the REST.Stats or
+// Realtime.Stats method, ready to be performed by its Pages or Items methods.
 type StatsRequest struct {
 	r paginatedRequestNew
 }
 
+// Pages returns an iterator for whole pages of Stats.
+//
+// See "Paginated results" section in the package-level documentation.
 func (r StatsRequest) Pages(ctx context.Context) (*StatsPaginatedResult, error) {
 	var res StatsPaginatedResult
 	return &res, res.load(ctx, r.r)
 }
 
+// A StatsPaginatedResult is an iterator for the result of a Stats request.
+//
+// See "Paginated results" section in the package-level documentation.
 type StatsPaginatedResult struct {
 	PaginatedResultNew
 	items []*Stats
 }
 
+// Next retrieves the next page of results.
+//
+// See the "Paginated results" section in the package-level documentation.
 func (p *StatsPaginatedResult) Next(ctx context.Context) bool {
 	return p.next(ctx, &p.items)
 }
 
+// Items returns the current page of results.
+//
+// See the "Paginated results" section in the package-level documentation.
 func (p *StatsPaginatedResult) Items() []*Stats {
 	return p.items
 }

--- a/ably/rest_client.go
+++ b/ably/rest_client.go
@@ -241,6 +241,7 @@ type StatsPaginatedResult struct {
 //
 // See the "Paginated results" section in the package-level documentation.
 func (p *StatsPaginatedResult) Next(ctx context.Context) bool {
+	p.items = nil // avoid mutating already returned items
 	return p.next(ctx, &p.items)
 }
 
@@ -259,6 +260,7 @@ func (r StatsRequest) Items(ctx context.Context) (*StatsPaginatedItems, error) {
 	var res StatsPaginatedItems
 	var err error
 	res.next, err = res.loadItems(ctx, r.r, func() (interface{}, func() int) {
+		res.items = nil // avoid mutating already returned items
 		return &res.items, func() int { return len(res.items) }
 	})
 	return &res, err


### PR DESCRIPTION
https://github.com/ably/ably-go/issues/278

The innards of paginated result handling have been simplified too.
(Only for stats; once all paginated results are refactored, the old
handling code can be removed and the "New" suffixes dropped.)