### PR TITLE
Ensure generated code is up-to-date in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Vet
         run: go vet ./ably/... ./scripts/...
 
+      - name: Ensure generated code is up-to-date
+        run: go generate ./... && [ -z "$(git status --porcelain)" ]
+
       - name: Test with JSON Protocol
         env:
           ABLY_PROTOCOL: application/json


### PR DESCRIPTION
To avoid forgetting running `go generate` before merging.