### PR TITLE
Run single Go version in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.13, 1.14, 1.15]
+        go-version: [1.13]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Many PRs now look like this:

<img width="438" alt="Screenshot 2021-03-05 at 08 41 37" src="https://user-images.githubusercontent.com/727422/110083191-add24a00-7d8e-11eb-9b43-4768671d14f9.png">

We can extract the following information from that:

1. The test suite _can_ pass, more often than not.
2. Since it passes in Go 1.13, and Go versions are guaranteed to be backwards-compatible, failures in Go 1.14 and 1.15 aren't due to incompatibilities.
3. Since, by design, most of our tests target real Ably connections, they're inherently flaky; chances are the PR being tested didn't cause the flakiness that's making tests fail, and, if it's bad enough, can be dealt with separately.

Following this, we can conclude that this PR is probably good to merge.

Exactly the same information can be extracted from just testing with Go 1.13, and at the end we'll have a nice green checkmark aligned with the conclusion that the PR is good. So I propose doing that instead.