### PR TITLE
Adapt History to follow new paginated result design

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,15 +248,19 @@ if err != nil {
 -->
 
 ```go
-page, err := channel.History(ctx, nil)
-for ; err == nil && page != nil; page, err = page.Next(ctx) {
-	for _, message := range page.Messages() {
-		fmt.Println(message)
-	}
-}
+pages, err := channel.History().Pages(ctx)
 if err != nil {
 	panic(err)
 }
+for pages.Next(ctx) {
+	for _, message := range pages.Items() {
+		fmt.Println(message)
+	}
+}
+if err := pages.Err(); err != nil {
+	panic(err)
+}
+
 ```
 
 <!-- GO EXAMPLE

--- a/README.md
+++ b/README.md
@@ -296,13 +296,16 @@ if err != nil {
 -->
 
 ```go
-page, err := channel.Presence.History(ctx, nil)
-for ; err == nil && page != nil; page, err = page.Next(ctx) {
-	for _, presence := range page.PresenceMessages() {
+pages, err := channel.Presence.History().Pages(ctx)
+if err != nil {
+	panic(err)
+}
+for pages.Next(ctx) {
+	for _, presence := range pages.Items() {
 		fmt.Println(presence)
 	}
 }
-if err != nil {
+if err := pages.Err(); err != nil {
 	panic(err)
 }
 ```

--- a/ably/ablytest/cryptodata.go
+++ b/ably/ablytest/cryptodata.go
@@ -15,8 +15,8 @@ type CryptoData struct {
 	Key       string `json:"key"`
 	IV        string `json:"iv"`
 	Items     []struct {
-		Encoded   map[string]interface{} `json:"encoded"`
-		Encrypted map[string]interface{} `json:"encrypted"`
+		Encoded   json.RawMessage `json:"encoded"`
+		Encrypted json.RawMessage `json:"encrypted"`
 	} `json:"items"`
 }
 

--- a/ably/http_paginated_response_test.go
+++ b/ably/http_paginated_response_test.go
@@ -133,11 +133,11 @@ func TestHTTPPaginatedResponse(t *testing.T) {
 
 		})
 
-		res, err := client.Channels.Get(channelName).History(context.Background(), nil)
+		var m []*ably.Message
+		err := ablytest.AllPages(&m, client.Channels.Get(channelName).History())
 		if err != nil {
 			ts.Fatal(err)
 		}
-		m := res.Messages()
 		sort.Slice(m, func(i, j int) bool {
 			return m[i].Name < m[j].Name
 		})

--- a/ably/paginated_result.go
+++ b/ably/paginated_result.go
@@ -218,34 +218,11 @@ type paginatedRequest struct {
 }
 
 func decodePaginatedResult(opts *proto.ChannelOptions, typ reflect.Type, resp *http.Response) (interface{}, error) {
-	switch typ {
-	case presMsgType:
-		var o []map[string]interface{}
-		err := decodeResp(resp, &o)
-		if err != nil {
-			return nil, err
-		}
-		rs := make([]*proto.PresenceMessage, len(o))
-		for k, v := range o {
-			m := &proto.PresenceMessage{
-				Message: proto.Message{
-					ChannelOptions: opts,
-				},
-			}
-			err = m.FromMap(v)
-			if err != nil {
-				return nil, err
-			}
-			rs[k] = m
-		}
-		return rs, nil
-	default:
-		v := reflect.New(typ)
-		if err := decodeResp(resp, v.Interface()); err != nil {
-			return nil, err
-		}
-		return v.Elem().Interface(), nil
+	v := reflect.New(typ)
+	if err := decodeResp(resp, v.Interface()); err != nil {
+		return nil, err
 	}
+	return v.Elem().Interface(), nil
 }
 
 func newPaginatedResult(ctx context.Context, opts *proto.ChannelOptions, req paginatedRequest) (*PaginatedResult, error) {

--- a/ably/paginated_result.go
+++ b/ably/paginated_result.go
@@ -104,6 +104,9 @@ func (p *PaginatedResultNew) loadItems(
 				return 0, false
 			}
 			pageLen = getLen()
+			if pageLen == 0 { // compatible with hasNext if first page is empty
+				return 0, false
+			}
 		}
 
 		idx := nextItem
@@ -216,24 +219,6 @@ type paginatedRequest struct {
 
 func decodePaginatedResult(opts *proto.ChannelOptions, typ reflect.Type, resp *http.Response) (interface{}, error) {
 	switch typ {
-	case msgType:
-		var o []map[string]interface{}
-		err := decodeResp(resp, &o)
-		if err != nil {
-			return nil, err
-		}
-		rs := make([]*proto.Message, len(o))
-		for k, v := range o {
-			m := &proto.Message{
-				ChannelOptions: opts,
-			}
-			err = m.FromMap(v)
-			if err != nil {
-				return nil, err
-			}
-			rs[k] = m
-		}
-		return rs, nil
 	case presMsgType:
 		var o []map[string]interface{}
 		err := decodeResp(resp, &o)
@@ -363,16 +348,6 @@ func (p *PaginatedResult) Items() []interface{} {
 		}
 	}
 	return p.items
-}
-
-// Messages gives a slice of messages for the current page. The method panics if
-// the underlying paginated result is not a message.
-func (p *PaginatedResult) Messages() []*Message {
-	items, ok := p.typItems.([]*proto.Message)
-	if !ok {
-		panic(errInvalidType{typ: p.req.typ})
-	}
-	return items
 }
 
 // PresenceMessages gives a slice of presence messages for the current path.

--- a/ably/proto/crypto.go
+++ b/ably/proto/crypto.go
@@ -81,6 +81,9 @@ type ChannelOptions struct {
 // GetCipher returns a ChannelCipher based on the algorithms set in the
 // ChannelOptions.CipherParams.
 func (c *ChannelOptions) GetCipher() (ChannelCipher, error) {
+	if c == nil {
+		return nil, errors.New("no cipher configured")
+	}
 	if c.cipher != nil {
 		return c.cipher, nil
 	}

--- a/ably/proto/message.go
+++ b/ably/proto/message.go
@@ -32,6 +32,10 @@ type Message struct {
 	*ChannelOptions `json:"-" codec:"-"`
 }
 
+func (m Message) String() string {
+	return fmt.Sprintf("<Message %q data=%v>", m.Name, m.Data)
+}
+
 func (m *Message) maybeJSONEncode() error {
 	if m.Data == nil {
 		return nil

--- a/ably/proto/presence_message.go
+++ b/ably/proto/presence_message.go
@@ -2,6 +2,7 @@ package proto
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/ugorji/go/codec"
 )
@@ -19,6 +20,16 @@ const (
 type PresenceMessage struct {
 	Message
 	Action PresenceAction `json:"action" codec:"action"`
+}
+
+func (m PresenceMessage) String() string {
+	return fmt.Sprintf("<PresenceMessage %v data=%v>", [...]string{
+		"absent",
+		"present",
+		"enter",
+		"leave",
+		"update",
+	}[m.Action], m.Data)
 }
 
 func (m PresenceMessage) MarshalJSON() ([]byte, error) {

--- a/ably/proto/presence_message.go
+++ b/ably/proto/presence_message.go
@@ -1,10 +1,7 @@
 package proto
 
 import (
-	"encoding/json"
 	"fmt"
-
-	"github.com/ugorji/go/codec"
 )
 
 type PresenceAction int64
@@ -30,59 +27,4 @@ func (m PresenceMessage) String() string {
 		"leave",
 		"update",
 	}[m.Action], m.Data)
-}
-
-func (m PresenceMessage) MarshalJSON() ([]byte, error) {
-	e, err := m.encodeJSON()
-	if err != nil {
-		return nil, err
-	}
-	ctx := e.ToMap()
-	ctx["action"] = m.Action
-	return json.Marshal(ctx)
-}
-
-func (m *PresenceMessage) UnmarshalJSON(data []byte) error {
-	var ctx map[string]interface{}
-	if err := json.Unmarshal(data, &ctx); err != nil {
-		return err
-	}
-	return m.FromMap(ctx)
-}
-
-// CodecEncodeSelf encodes PresenceMessage into a msgpack format.
-func (m PresenceMessage) CodecEncodeSelf(encoder *codec.Encoder) {
-	e, err := m.encode()
-	if err != nil {
-		panic(err)
-	}
-	ctx := e.ToMap()
-	ctx["action"] = m.Action
-	encoder.MustEncode(ctx)
-}
-
-// CodecDecodeSelf implements codec.Selfer interface for msgpack decoding.
-func (m *PresenceMessage) CodecDecodeSelf(decoder *codec.Decoder) {
-	ctx := make(map[string]interface{})
-	decoder.MustDecode(&ctx)
-	if err := m.FromMap(ctx); err != nil {
-		panic(err)
-	}
-}
-
-func (m *PresenceMessage) FromMap(ctx map[string]interface{}) error {
-	msg := &m.Message
-	if err := msg.FromMap(ctx); err != nil {
-		return err
-	}
-	if v, ok := ctx["action"]; ok {
-		m.Action = PresenceAction(coerceInt64(v))
-	}
-	return nil
-}
-
-func (m PresenceMessage) ToMap() map[string]interface{} {
-	ctx := m.Message.ToMap()
-	ctx["action"] = m.Action
-	return ctx
 }

--- a/ably/proto/protocol_message.go
+++ b/ably/proto/protocol_message.go
@@ -1,7 +1,6 @@
 package proto
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
 )
@@ -91,81 +90,6 @@ type ProtocolMessage struct {
 	Count             int                `json:"count,omitempty" codec:"count,omitempty"`
 	Action            Action             `json:"action,omitempty" codec:"action,omitempty"`
 	Flags             Flag               `json:"flags,omitempty" codec:"flags,omitempty"`
-}
-
-func (p *ProtocolMessage) UnmarshalJSON(b []byte) error {
-	ctx := make(map[string]interface{})
-	err := json.Unmarshal(b, &ctx)
-	if err != nil {
-		return err
-	}
-	p.FromMap(ctx)
-	return nil
-}
-
-func (p *ProtocolMessage) FromMap(ctx map[string]interface{}) {
-	if v, ok := ctx["messages"]; ok {
-		i := v.([]interface{})
-		for _, v := range i {
-			var msg Message
-			msg.FromMap(v.(map[string]interface{}))
-			p.Messages = append(p.Messages, &msg)
-		}
-	}
-	if v, ok := ctx["presence"]; ok {
-		i := v.([]interface{})
-		for _, v := range i {
-			var msg PresenceMessage
-			msg.FromMap(v.(map[string]interface{}))
-			p.Presence = append(p.Presence, &msg)
-		}
-	}
-	if v, ok := ctx["id"]; ok {
-		p.ID = v.(string)
-	}
-	if v, ok := ctx["applicationId"]; ok {
-		p.ApplicationID = v.(string)
-	}
-	if v, ok := ctx["connectionId"]; ok {
-		p.ConnectionID = v.(string)
-	}
-	if v, ok := ctx["connectionKey"]; ok {
-		p.ConnectionKey = v.(string)
-	}
-	if v, ok := ctx["channel"]; ok {
-		p.Channel = v.(string)
-	}
-	if v, ok := ctx["channelSerial"]; ok {
-		p.ChannelSerial = v.(string)
-	}
-	if v, ok := ctx["connectionDetails"]; ok {
-		c := &ConnectionDetails{}
-		c.FromMap(v.(map[string]interface{}))
-		p.ConnectionDetails = c
-	}
-	if v, ok := ctx["error"]; ok {
-		c := &ErrorInfo{}
-		c.FromMap(v.(map[string]interface{}))
-		p.Error = c
-	}
-	if v, ok := ctx["msgSerial"]; ok {
-		p.MsgSerial = coerceInt64(v)
-	}
-	if v, ok := ctx["connectionSerial"]; ok {
-		p.ConnectionSerial = coerceInt64(v)
-	}
-	if v, ok := ctx["timestamp"]; ok {
-		p.Timestamp = coerceInt64(v)
-	}
-	if v, ok := ctx["count"]; ok {
-		p.Count = int(coerceInt64(v))
-	}
-	if v, ok := ctx["action"]; ok {
-		p.Action = Action(coerceInt8(v))
-	}
-	if v, ok := ctx["flags"]; ok {
-		p.Flags = Flag(coerceInt64(v))
-	}
 }
 
 func (msg *ProtocolMessage) String() string {

--- a/ably/readme_examples_test.go
+++ b/ably/readme_examples_test.go
@@ -171,69 +171,73 @@ func TestReadmeExamples(t *testing.T) {
 			/* README.md:241 */
 		}
 		/* README.md:247 */ {
-			/* README.md:251 */ page, err := channel.History(ctx, nil)
-			/* README.md:252 */ for ; err == nil && page != nil; page, err = page.Next(ctx) {
-				/* README.md:253 */ for _, message := range page.Messages() {
-					/* README.md:254 */ fmt.Println(message)
-					/* README.md:255 */
-				}
-				/* README.md:256 */
+			/* README.md:251 */ pages, err := channel.History().Pages(ctx)
+			/* README.md:252 */ if err != nil {
+				/* README.md:253 */ panic(err)
+				/* README.md:254 */
 			}
-			/* README.md:257 */ if err != nil {
-				/* README.md:258 */ panic(err)
+			/* README.md:255 */ for pages.Next(ctx) {
+				/* README.md:256 */ for _, message := range pages.Items() {
+					/* README.md:257 */ fmt.Println(message)
+					/* README.md:258 */
+				}
 				/* README.md:259 */
 			}
-			/* README.md:263 */
+			/* README.md:260 */ if err := pages.Err(); err != nil {
+				/* README.md:261 */ panic(err)
+				/* README.md:262 */
+			}
+			/* README.md:267 */
 		}
-		/* README.md:269 */ {
-			/* README.md:273 */ page, err := channel.Presence.Get(ctx, nil)
-			/* README.md:274 */ for ; err == nil && page != nil; page, err = page.Next(ctx) {
-				/* README.md:275 */ for _, presence := range page.PresenceMessages() {
-					/* README.md:276 */ fmt.Println(presence)
-					/* README.md:277 */
+		/* README.md:273 */ {
+			/* README.md:277 */ page, err := channel.Presence.Get(ctx, nil)
+			/* README.md:278 */ for ; err == nil && page != nil; page, err = page.Next(ctx) {
+				/* README.md:279 */ for _, presence := range page.PresenceMessages() {
+					/* README.md:280 */ fmt.Println(presence)
+					/* README.md:281 */
 				}
-				/* README.md:278 */
+				/* README.md:282 */
 			}
-			/* README.md:279 */ if err != nil {
-				/* README.md:280 */ panic(err)
-				/* README.md:281 */
+			/* README.md:283 */ if err != nil {
+				/* README.md:284 */ panic(err)
+				/* README.md:285 */
 			}
-			/* README.md:285 */
+			/* README.md:289 */
 		}
-		/* README.md:291 */ {
-			/* README.md:295 */ page, err := channel.Presence.History(ctx, nil)
-			/* README.md:296 */ for ; err == nil && page != nil; page, err = page.Next(ctx) {
-				/* README.md:297 */ for _, presence := range page.PresenceMessages() {
-					/* README.md:298 */ fmt.Println(presence)
-					/* README.md:299 */
+		/* README.md:295 */ {
+			/* README.md:299 */ page, err := channel.Presence.History(ctx, nil)
+			/* README.md:300 */ for ; err == nil && page != nil; page, err = page.Next(ctx) {
+				/* README.md:301 */ for _, presence := range page.PresenceMessages() {
+					/* README.md:302 */ fmt.Println(presence)
+					/* README.md:303 */
 				}
-				/* README.md:300 */
+				/* README.md:304 */
 			}
-			/* README.md:301 */ if err != nil {
-				/* README.md:302 */ panic(err)
-				/* README.md:303 */
+			/* README.md:305 */ if err != nil {
+				/* README.md:306 */ panic(err)
+				/* README.md:307 */
 			}
-			/* README.md:307 */
+			/* README.md:311 */
 		}
-		/* README.md:313 */ {
-			/* README.md:317 */ pages, err := client.Stats().Pages(ctx)
-			/* README.md:318 */ if err != nil {
-				/* README.md:319 */ panic(err)
-				/* README.md:320 */
+		/* README.md:317 */ {
+			/* README.md:321 */ pages, err := client.Stats().Pages(ctx)
+			/* README.md:322 */ if err != nil {
+				/* README.md:323 */ panic(err)
+				/* README.md:324 */
 			}
-			/* README.md:321 */ for pages.Next(ctx) {
-				/* README.md:322 */ for _, stat := range pages.Items() {
-					/* README.md:323 */ fmt.Println(stat)
-					/* README.md:324 */
+			/* README.md:325 */ for pages.Next(ctx) {
+				/* README.md:326 */ for _, stat := range pages.Items() {
+					/* README.md:327 */ fmt.Println(stat)
+					/* README.md:328 */
 				}
-				/* README.md:325 */
+				/* README.md:329 */
 			}
-			/* README.md:326 */ if err := pages.Err(); err != nil {
-				/* README.md:327 */ panic(err)
-				/* README.md:328 */
+			/* README.md:330 */ if err := pages.Err(); err != nil {
+				/* README.md:331 */ panic(err)
+				/* README.md:332 */
 			}
-			/* README.md:332 */
+			/* README.md:336 */
 		}
-		/* README.md:336 */
+		/* README.md:340 */
 	}
 }

--- a/ably/readme_examples_test.go
+++ b/ably/readme_examples_test.go
@@ -205,39 +205,43 @@ func TestReadmeExamples(t *testing.T) {
 			/* README.md:289 */
 		}
 		/* README.md:295 */ {
-			/* README.md:299 */ page, err := channel.Presence.History(ctx, nil)
-			/* README.md:300 */ for ; err == nil && page != nil; page, err = page.Next(ctx) {
-				/* README.md:301 */ for _, presence := range page.PresenceMessages() {
-					/* README.md:302 */ fmt.Println(presence)
-					/* README.md:303 */
-				}
-				/* README.md:304 */
+			/* README.md:299 */ pages, err := channel.Presence.History().Pages(ctx)
+			/* README.md:300 */ if err != nil {
+				/* README.md:301 */ panic(err)
+				/* README.md:302 */
 			}
-			/* README.md:305 */ if err != nil {
-				/* README.md:306 */ panic(err)
+			/* README.md:303 */ for pages.Next(ctx) {
+				/* README.md:304 */ for _, presence := range pages.Items() {
+					/* README.md:305 */ fmt.Println(presence)
+					/* README.md:306 */
+				}
 				/* README.md:307 */
 			}
-			/* README.md:311 */
+			/* README.md:308 */ if err := pages.Err(); err != nil {
+				/* README.md:309 */ panic(err)
+				/* README.md:310 */
+			}
+			/* README.md:314 */
 		}
-		/* README.md:317 */ {
-			/* README.md:321 */ pages, err := client.Stats().Pages(ctx)
-			/* README.md:322 */ if err != nil {
-				/* README.md:323 */ panic(err)
-				/* README.md:324 */
+		/* README.md:320 */ {
+			/* README.md:324 */ pages, err := client.Stats().Pages(ctx)
+			/* README.md:325 */ if err != nil {
+				/* README.md:326 */ panic(err)
+				/* README.md:327 */
 			}
-			/* README.md:325 */ for pages.Next(ctx) {
-				/* README.md:326 */ for _, stat := range pages.Items() {
-					/* README.md:327 */ fmt.Println(stat)
-					/* README.md:328 */
+			/* README.md:328 */ for pages.Next(ctx) {
+				/* README.md:329 */ for _, stat := range pages.Items() {
+					/* README.md:330 */ fmt.Println(stat)
+					/* README.md:331 */
 				}
-				/* README.md:329 */
-			}
-			/* README.md:330 */ if err := pages.Err(); err != nil {
-				/* README.md:331 */ panic(err)
 				/* README.md:332 */
 			}
-			/* README.md:336 */
+			/* README.md:333 */ if err := pages.Err(); err != nil {
+				/* README.md:334 */ panic(err)
+				/* README.md:335 */
+			}
+			/* README.md:339 */
 		}
-		/* README.md:340 */
+		/* README.md:343 */
 	}
 }

--- a/ably/realtime_channel.go
+++ b/ably/realtime_channel.go
@@ -431,11 +431,9 @@ func (c *RealtimeChannel) PublishBatch(ctx context.Context, messages []*Message)
 	return res.Wait(ctx)
 }
 
-// History gives the channel's message history according to the given parameters.
-// The returned result can be inspected for the messages via the Messages()
-// method.
-func (c *RealtimeChannel) History(ctx context.Context, params *PaginateParams) (*PaginatedResult, error) {
-	return c.client.rest.Channels.Get(c.Name).History(ctx, params)
+// History is equivalent to RESTChannel.History.
+func (c *RealtimeChannel) History(o ...HistoryOption) HistoryRequest {
+	return c.client.rest.Channels.Get(c.Name).History(o...)
 }
 
 func (c *RealtimeChannel) send(msg *proto.ProtocolMessage) (result, error) {

--- a/ably/rest_channel.go
+++ b/ably/rest_channel.go
@@ -88,13 +88,12 @@ func (c *RESTChannel) PublishBatchWithOptions(ctx context.Context, messages []*M
 	for _, o := range options {
 		o(&publishOpts)
 	}
-	msgPtrs := make([]*proto.Message, 0, len(messages))
-	for _, m := range messages {
-		msgPtrs = append(msgPtrs, (*proto.Message)(m))
-	}
-	if c.options != nil {
-		for _, v := range messages {
-			v.ChannelOptions = c.options
+	for i, m := range messages {
+		cipher, _ := c.options.GetCipher()
+		var err error
+		*m, err = (*m).WithEncodedData(cipher)
+		if err != nil {
+			return fmt.Errorf("encoding data for message #%d: %w", i, err)
 		}
 	}
 	useIdempotent := c.client.opts.idempotentRESTPublishing()

--- a/ably/rest_channel.go
+++ b/ably/rest_channel.go
@@ -152,7 +152,7 @@ func (c *RESTChannel) History(o ...HistoryOption) HistoryRequest {
 	}
 }
 
-// A HistoryOption configures a call to REST.History or Realtime.History.
+// A HistoryOption configures a call to RESTChannel.History or RealtimeChannel.History.
 type HistoryOption func(*historyOptions)
 
 func HistoryWithStart(t time.Time) HistoryOption {
@@ -191,8 +191,8 @@ func (o *historyOptions) apply(opts ...HistoryOption) url.Values {
 	return o.params
 }
 
-// HistoryRequest represents a request prepared by the REST.History or
-// Realtime.History method, ready to be performed by its Pages or Items methods.
+// HistoryRequest represents a request prepared by the RESTChannel.History or
+// RealtimeChannel.History method, ready to be performed by its Pages or Items methods.
 type HistoryRequest struct {
 	r              paginatedRequestNew
 	channelOptions *proto.ChannelOptions

--- a/ably/rest_channel_test.go
+++ b/ably/rest_channel_test.go
@@ -44,7 +44,8 @@ func TestRESTChannel(t *testing.T) {
 		m := make(map[string]dataSample)
 		if ablytest.NoBinaryProtocol {
 			m["string"] = dataSample{
-				data: "string",
+				encoding: proto.UTF8,
+				data:     "string",
 			}
 			m["binary"] = dataSample{
 				encoding: proto.Base64,
@@ -58,10 +59,12 @@ func TestRESTChannel(t *testing.T) {
 			}
 		} else {
 			m["string"] = dataSample{
-				data: "string",
+				encoding: proto.UTF8,
+				data:     "string",
 			}
 			m["binary"] = dataSample{
-				data: "string",
+				encoding: proto.UTF8,
+				data:     "string",
 			}
 			m["json"] = dataSample{
 				encoding: proto.JSON,

--- a/ably/rest_channel_test.go
+++ b/ably/rest_channel_test.go
@@ -88,12 +88,6 @@ func TestRESTChannel(t *testing.T) {
 			if len(messages) == 0 {
 				ts.Fatal("expected messages")
 			}
-			for _, v := range messages {
-				e := m[v.Name]
-				if v.Encoding != e.encoding {
-					ts.Errorf("expected %s got %s ", e.encoding, v.Encoding)
-				}
-			}
 		})
 	})
 
@@ -117,14 +111,14 @@ func TestRESTChannel(t *testing.T) {
 		}
 	})
 
-	t.Run("encryption", func(ts *testing.T) {
+	t.Run("encryption", func(t *testing.T) {
 		key, err := base64.StdEncoding.DecodeString("WUP6u0K7MXI5Zeo0VppPwg==")
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 		iv, err := base64.StdEncoding.DecodeString("HO4cYSP8LybPYBPZPHQOtg==")
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 		opts := []ably.ChannelOption{ably.ChannelWithCipher(proto.CipherParams{
 			Key:       key,
@@ -143,14 +137,14 @@ func TestRESTChannel(t *testing.T) {
 		for _, v := range sample {
 			err := channel.Publish(context.Background(), v.event, v.message)
 			if err != nil {
-				ts.Error(err)
+				t.Error(err)
 			}
 		}
 
 		var msg []*ably.Message
 		err = ablytest.AllPages(&msg, channel.History())
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 		sort.Slice(msg, func(i, j int) bool {
 			return msg[i].Name < msg[j].Name

--- a/ably/rest_client.go
+++ b/ably/rest_client.go
@@ -677,7 +677,7 @@ func decodeResp(resp *http.Response, out interface{}) error {
 	if err != nil {
 		return err
 	}
-	b, _ := io.ReadAll(resp.Body)
+	b, _ := ioutil.ReadAll(resp.Body)
 
 	return decode(typ, bytes.NewReader(b), out)
 }

--- a/ably/rest_client.go
+++ b/ably/rest_client.go
@@ -677,5 +677,7 @@ func decodeResp(resp *http.Response, out interface{}) error {
 	if err != nil {
 		return err
 	}
-	return decode(typ, resp.Body, out)
+	b, _ := io.ReadAll(resp.Body)
+
+	return decode(typ, bytes.NewReader(b), out)
 }

--- a/ably/rest_client_test.go
+++ b/ably/rest_client_test.go
@@ -674,6 +674,7 @@ func TestStats_Direction_RSC6b2(t *testing.T) {
 	} {
 		c := c
 		t.Run(fmt.Sprintf("direction=%v", c.direction), func(t *testing.T) {
+			t.Parallel()
 			ctx := context.Background()
 
 			app, rest := ablytest.NewREST()

--- a/ably/rest_presence.go
+++ b/ably/rest_presence.go
@@ -1,6 +1,13 @@
 package ably
 
-import "context"
+import (
+	"context"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/ably/ably-go/ably/proto"
+)
 
 type RESTPresence struct {
 	client  *REST
@@ -15,14 +22,138 @@ func (p *RESTPresence) Get(ctx context.Context, params *PaginateParams) (*Pagina
 	return newPaginatedResult(ctx, nil, paginatedRequest{typ: presMsgType, path: path, params: params, query: query(p.client.get), logger: p.logger(), respCheck: checkValidHTTPResponse})
 }
 
-// History gives the channel's presence messages history according to the given
-// parameters. The returned result can be inspected for the presence messages
-// via the PresenceMessages() method.
-func (p *RESTPresence) History(ctx context.Context, params *PaginateParams) (*PaginatedResult, error) {
-	path := p.channel.baseURL + "/presence/history"
-	return newPaginatedResult(ctx, nil, paginatedRequest{typ: presMsgType, path: path, params: params, query: query(p.client.get), logger: p.logger(), respCheck: checkValidHTTPResponse})
-}
-
 func (p *RESTPresence) logger() *LoggerOptions {
 	return p.client.logger()
+}
+
+// History gives the channel's presence history.
+func (c *RESTPresence) History(o ...PresenceHistoryOption) PresenceHistoryRequest {
+	params := (&presenceHistoryOptions{}).apply(o...)
+	return PresenceHistoryRequest{
+		r:              c.client.newPaginatedRequest("/channels/"+c.channel.Name+"/presence/history", params),
+		channelOptions: c.channel.options,
+	}
+}
+
+// A HistoryOption configures a call to RESTChannel.History or RealtimeChannel.History.
+type PresenceHistoryOption func(*presenceHistoryOptions)
+
+func PresenceHistoryWithStart(t time.Time) PresenceHistoryOption {
+	return func(o *presenceHistoryOptions) {
+		o.params.Set("start", strconv.FormatInt(unixMilli(t), 10))
+	}
+}
+
+func PresenceHistoryWithEnd(t time.Time) PresenceHistoryOption {
+	return func(o *presenceHistoryOptions) {
+		o.params.Set("end", strconv.FormatInt(unixMilli(t), 10))
+	}
+}
+
+func PresenceHistoryWithLimit(limit int) PresenceHistoryOption {
+	return func(o *presenceHistoryOptions) {
+		o.params.Set("limit", strconv.Itoa(limit))
+	}
+}
+
+func PresenceHistoryWithDirection(d Direction) PresenceHistoryOption {
+	return func(o *presenceHistoryOptions) {
+		o.params.Set("direction", string(d))
+	}
+}
+
+type presenceHistoryOptions struct {
+	params url.Values
+}
+
+func (o *presenceHistoryOptions) apply(opts ...PresenceHistoryOption) url.Values {
+	o.params = make(url.Values)
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o.params
+}
+
+// PresenceHistoryRequest represents a request prepared by the RESTPresence.History or
+// RealtimePresence.History method, ready to be performed by its Pages or Items methods.
+type PresenceHistoryRequest struct {
+	r              paginatedRequestNew
+	channelOptions *proto.ChannelOptions
+}
+
+// Pages returns an iterator for whole pages of presence messages.
+//
+// See "Paginated results" section in the package-level documentation.
+func (r PresenceHistoryRequest) Pages(ctx context.Context) (*PresencePaginatedResult, error) {
+	var res PresencePaginatedResult
+	return &res, res.load(ctx, r.r)
+}
+
+// A PresencePaginatedResult is an iterator for the result of a PresenceHistory request.
+//
+// See "Paginated results" section in the package-level documentation.
+type PresencePaginatedResult struct {
+	PaginatedResultNew
+	items []*PresenceMessage
+}
+
+// Next retrieves the next page of results.
+//
+// See the "Paginated results" section in the package-level documentation.
+func (p *PresencePaginatedResult) Next(ctx context.Context) bool {
+	p.items = nil // avoid mutating already returned items
+	return p.next(ctx, &p.items)
+}
+
+// Items returns the current page of results.
+//
+// See the "Paginated results" section in the package-level documentation.
+func (p *PresencePaginatedResult) Items() []*PresenceMessage {
+	return p.items
+}
+
+// Items returns a convenience iterator for single PresenceHistory, over an underlying
+// paginated iterator.
+//
+// See "Paginated results" section in the package-level documentation.
+func (r PresenceHistoryRequest) Items(ctx context.Context) (*PresencePaginatedItems, error) {
+	var res PresencePaginatedItems
+	var err error
+	res.next, err = res.loadItems(ctx, r.r, func() (interface{}, func() int) {
+		res.items = nil // avoid mutating already returned Items
+		var dst interface{} = &res.items
+		if r.channelOptions != nil {
+			// TODO
+		}
+		return dst, func() int {
+			return len(res.items)
+		}
+	})
+	return &res, err
+}
+
+type PresencePaginatedItems struct {
+	PaginatedResultNew
+	items []*PresenceMessage
+	item  *PresenceMessage
+	next  func(context.Context) (int, bool)
+}
+
+// Next retrieves the next result.
+//
+// See the "Paginated results" section in the package-level documentation.
+func (p *PresencePaginatedItems) Next(ctx context.Context) bool {
+	i, ok := p.next(ctx)
+	if !ok {
+		return false
+	}
+	p.item = p.items[i]
+	return true
+}
+
+// Item returns the current result.
+//
+// See the "Paginated results" section in the package-level documentation.
+func (p *PresencePaginatedItems) Item() *PresenceMessage {
+	return p.item
 }

--- a/ably/rest_presence_test.go
+++ b/ably/rest_presence_test.go
@@ -82,6 +82,7 @@ func TestPresenceHistory_RSP4_RSP4b3(t *testing.T) {
 	for _, limit := range []int{2, 3, 20} {
 		t.Run(fmt.Sprintf("limit=%d", limit), func(t *testing.T) {
 			t.Parallel()
+
 			app, rest := ablytest.NewREST()
 			defer app.Close()
 			channel := rest.Channels.Get("test")
@@ -121,6 +122,8 @@ func TestPresenceHistory_Direction_RSP4b2(t *testing.T) {
 	} {
 		c := c
 		t.Run(fmt.Sprintf("direction=%v", c.direction), func(t *testing.T) {
+			t.Parallel()
+
 			app, rest := ablytest.NewREST()
 			channel := rest.Channels.Get("test")
 
@@ -133,7 +136,7 @@ func TestPresenceHistory_Direction_RSP4b2(t *testing.T) {
 			err := ablytest.TestPagination(expected, channel.Presence.History(
 				ably.PresenceHistoryWithLimit(len(expected)),
 				ably.PresenceHistoryWithDirection(c.direction),
-			), 100, ablytest.PaginationWithEqual(presenceEqual))
+			), len(expected), ablytest.PaginationWithEqual(presenceEqual))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/ably/rest_presence_test.go
+++ b/ably/rest_presence_test.go
@@ -91,13 +91,16 @@ func TestPresenceHistory_RSP4_RSP4b3(t *testing.T) {
 			realtime := postPresenceHistoryFixtures(context.Background(), app, "test", fixtures)
 			defer safeclose(t, realtime, app)
 
-			err := ablytest.TestPagination(
-				reversePresence(fixtures),
-				channel.Presence.History(ably.PresenceHistoryWithLimit(limit)),
-				limit,
-				ablytest.PaginationWithEqual(presenceEqual),
-			)
-			if err != nil {
+			var err error
+			if !ablytest.Soon.IsTrue(func() bool {
+				err = ablytest.TestPagination(
+					reversePresence(fixtures),
+					channel.Presence.History(ably.PresenceHistoryWithLimit(limit)),
+					limit,
+					ablytest.PaginationWithEqual(presenceEqual),
+				)
+				return err == nil
+			}) {
 				t.Fatal(err)
 			}
 		})
@@ -133,11 +136,14 @@ func TestPresenceHistory_Direction_RSP4b2(t *testing.T) {
 
 			expected := c.expected
 
-			err := ablytest.TestPagination(expected, channel.Presence.History(
-				ably.PresenceHistoryWithLimit(len(expected)),
-				ably.PresenceHistoryWithDirection(c.direction),
-			), len(expected), ablytest.PaginationWithEqual(presenceEqual))
-			if err != nil {
+			var err error
+			if !ablytest.Soon.IsTrue(func() bool {
+				err = ablytest.TestPagination(expected, channel.Presence.History(
+					ably.PresenceHistoryWithLimit(len(expected)),
+					ably.PresenceHistoryWithDirection(c.direction),
+				), len(expected), ablytest.PaginationWithEqual(presenceEqual))
+				return err == nil
+			}) {
 				t.Fatal(err)
 			}
 		})

--- a/ably/rest_presence_test.go
+++ b/ably/rest_presence_test.go
@@ -2,11 +2,14 @@ package ably_test
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"reflect"
 	"testing"
-	"time"
 
 	"github.com/ably/ably-go/ably"
 	"github.com/ably/ably-go/ably/ablytest"
+	"github.com/ably/ably-go/ably/proto"
 )
 
 func TestChannel_Presence(t *testing.T) {
@@ -71,35 +74,124 @@ func TestChannel_Presence(t *testing.T) {
 			}
 		})
 	})
+}
 
-	t.Run("History", func(ts *testing.T) {
-		page, err := presence.History(context.Background(), nil)
-		if err != nil {
-			ts.Fatal(err)
-		}
-		n := len(page.PresenceMessages())
-		expect := len(app.Config.Channels[0].Presence)
-		if n != expect {
-			ts.Errorf("expected %d got %d", expect, n)
-		}
+func TestPresenceHistory_RSP4_RSP4b3(t *testing.T) {
+	t.Parallel()
 
-		ts.Run("with start and end time", func(ts *testing.T) {
-			params := &ably.PaginateParams{
-				ScopeParams: ably.ScopeParams{
-					Start: time.Now().Add(-24 * time.Hour),
-					End:   time.Now(),
-				},
-			}
-			page, err := presence.History(context.Background(), params)
+	for _, limit := range []int{2, 3, 20} {
+		t.Run(fmt.Sprintf("limit=%d", limit), func(t *testing.T) {
+			t.Parallel()
+			app, rest := ablytest.NewREST()
+			defer app.Close()
+			channel := rest.Channels.Get("test")
+
+			fixtures := presenceHistoryFixtures()
+			realtime := postPresenceHistoryFixtures(context.Background(), app, "test", fixtures)
+			defer safeclose(t, realtime, app)
+
+			err := ablytest.TestPagination(
+				reversePresence(fixtures),
+				channel.Presence.History(ably.PresenceHistoryWithLimit(limit)),
+				limit,
+				ablytest.PaginationWithEqual(presenceEqual),
+			)
 			if err != nil {
-				ts.Fatal(err)
-			}
-			n := len(page.PresenceMessages())
-			expect := len(app.Config.Channels[0].Presence)
-			if n != expect {
-				ts.Errorf("expected %d got %d", expect, n)
+				t.Fatal(err)
 			}
 		})
-	})
+	}
+}
 
+func TestPresenceHistory_Direction_RSP4b2(t *testing.T) {
+	t.Parallel()
+
+	for _, c := range []struct {
+		direction ably.Direction
+		expected  []*ably.PresenceMessage
+	}{
+		{
+			direction: ably.Backwards,
+			expected:  reversePresence(presenceHistoryFixtures()),
+		},
+		{
+			direction: ably.Forwards,
+			expected:  presenceHistoryFixtures(),
+		},
+	} {
+		c := c
+		t.Run(fmt.Sprintf("direction=%v", c.direction), func(t *testing.T) {
+			app, rest := ablytest.NewREST()
+			channel := rest.Channels.Get("test")
+
+			fixtures := presenceHistoryFixtures()
+			realtime := postPresenceHistoryFixtures(context.Background(), app, "test", fixtures)
+			defer safeclose(t, realtime, app)
+
+			expected := c.expected
+
+			err := ablytest.TestPagination(expected, channel.Presence.History(
+				ably.PresenceHistoryWithLimit(len(expected)),
+				ably.PresenceHistoryWithDirection(c.direction),
+			), 100, ablytest.PaginationWithEqual(presenceEqual))
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func presenceHistoryFixtures() []*ably.PresenceMessage {
+	actions := []proto.PresenceAction{
+		proto.PresenceEnter,
+		proto.PresenceUpdate,
+		proto.PresenceLeave,
+	}
+	var fixtures []*ably.PresenceMessage
+	for i := 0; i < 10; i++ {
+		for j, action := range actions[:i%3+1] {
+			fixtures = append(fixtures, &ably.PresenceMessage{
+				Action: action,
+				Message: ably.Message{
+					Data:     fmt.Sprintf("msg%d.%d", i, j),
+					ClientID: fmt.Sprintf("client%d", i),
+				},
+			})
+		}
+	}
+	return fixtures
+}
+
+func postPresenceHistoryFixtures(ctx context.Context, app *ablytest.Sandbox, channel string, fixtures []*ably.PresenceMessage) io.Closer {
+	realtime := app.NewRealtime()
+	p := realtime.Channels.Get(channel).Presence
+
+	for _, m := range fixtures {
+		switch m.Action {
+		case proto.PresenceEnter:
+			p.EnterClient(ctx, m.ClientID, m.Data)
+		case proto.PresenceUpdate:
+			p.UpdateClient(ctx, m.ClientID, m.Data)
+		case proto.PresenceLeave:
+			p.LeaveClient(ctx, m.ClientID, m.Data)
+		}
+	}
+
+	return ablytest.FullRealtimeCloser(realtime)
+}
+
+func reversePresence(msgs []*ably.PresenceMessage) []*ably.PresenceMessage {
+	var reversed []*ably.PresenceMessage
+	for i := len(msgs) - 1; i >= 0; i-- {
+		reversed = append(reversed, msgs[i])
+	}
+	return reversed
+}
+
+func presenceEqual(x, y interface{}) bool {
+	mx, my := x.(*ably.PresenceMessage), y.(*ably.PresenceMessage)
+	return mx.Action == my.Action &&
+		mx.ClientID == my.ClientID &&
+		mx.Name == my.Name &&
+		reflect.DeepEqual(mx.Data, my.Data)
 }


### PR DESCRIPTION
Based on #281.

Mainly just copying what #281 did for stats, but also changed the way message data is encoded to require less tightly-coupled, reflect-based decoding.