### PR TITLE
Rename PublishBatch -> PublishMultiple

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ if err != nil {
 	panic(err)
 }
 
-// You can also publish a batch of messages in a single request.
+// You can also publish multiple messages in a single request.
 err = channel.PublishMultiple(ctx, []*ably.Message{
 	{Name: "HelloEvent", Data: "Hello!"},
 	{Name: "ByeEvent", Data: "Bye!"},

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ if err != nil {
 }
 
 // You can also publish a batch of messages in a single request.
-err = channel.PublishBatch(ctx, []*ably.Message{
+err = channel.PublishMultiple(ctx, []*ably.Message{
 	{Name: "HelloEvent", Data: "Hello!"},
 	{Name: "ByeEvent", Data: "Bye!"},
 })

--- a/ably/auth_test.go
+++ b/ably/auth_test.go
@@ -568,7 +568,7 @@ func TestAuth_RequestToken_PublishClientID(t *testing.T) {
 			Name:     "test",
 			Data:     "payload",
 		}}
-		err = channel.PublishBatch(context.Background(), msg)
+		err = channel.PublishMultiple(context.Background(), msg)
 		if cas.rejected {
 			if err == nil {
 				t.Errorf("%d: expected message to be rejected %#v", i, cas)
@@ -576,7 +576,7 @@ func TestAuth_RequestToken_PublishClientID(t *testing.T) {
 			continue
 		}
 		if err != nil {
-			t.Errorf("%d: PublishBatch()=%v", i, err)
+			t.Errorf("%d: PublishMultiple()=%v", i, err)
 			continue
 		}
 		select {

--- a/ably/readme_examples_test.go
+++ b/ably/readme_examples_test.go
@@ -162,7 +162,7 @@ func TestReadmeExamples(t *testing.T) {
 		}
 		/* README.md:234 */ // You can also publish a batch of messages in a single request.
 		/* README.md:235 */
-		err = channel.PublishBatch(ctx, []*ably.Message{
+		err = channel.PublishMultiple(ctx, []*ably.Message{
 			/* README.md:236 */ {Name: "HelloEvent", Data: "Hello!"},
 			/* README.md:237 */ {Name: "ByeEvent", Data: "Bye!"},
 			/* README.md:238 */})

--- a/ably/readme_examples_test.go
+++ b/ably/readme_examples_test.go
@@ -160,7 +160,7 @@ func TestReadmeExamples(t *testing.T) {
 			/* README.md:231 */ panic(err)
 			/* README.md:232 */
 		}
-		/* README.md:234 */ // You can also publish a batch of messages in a single request.
+		/* README.md:234 */ // You can also publish multiple messages in a single request.
 		/* README.md:235 */
 		err = channel.PublishMultiple(ctx, []*ably.Message{
 			/* README.md:236 */ {Name: "HelloEvent", Data: "Hello!"},

--- a/ably/realtime_channel.go
+++ b/ably/realtime_channel.go
@@ -402,16 +402,16 @@ func (em ChannelEventEmitter) OffAll() {
 // returns with an error, but the operation carries on in the background and
 // the channel may eventually be attached and the message published anyway.
 func (c *RealtimeChannel) Publish(ctx context.Context, name string, data interface{}) error {
-	return c.PublishBatch(ctx, []*Message{{Name: name, Data: data}})
+	return c.PublishMultiple(ctx, []*Message{{Name: name, Data: data}})
 }
 
-// PublishBatch publishes all given messages on the channel at once.
+// PublishMultiple publishes all given messages on the channel at once.
 //
 // This implicitly attaches the channel if it's not already attached. If the
 // context is canceled before the attach operation finishes, the call
 // returns with an error, but the operation carries on in the background and
 // the channel may eventually be attached and the message published anyway.
-func (c *RealtimeChannel) PublishBatch(ctx context.Context, messages []*Message) error {
+func (c *RealtimeChannel) PublishMultiple(ctx context.Context, messages []*Message) error {
 	id := c.client.Auth.clientIDForCheck()
 	for _, v := range messages {
 		if v.ClientID != "" && id != wildcardClientID && v.ClientID != id {

--- a/ably/rest_channel.go
+++ b/ably/rest_channel.go
@@ -55,7 +55,7 @@ func newRESTChannel(name string, client *REST) *RESTChannel {
 
 // Publish publishes a message on the channel.
 func (c *RESTChannel) Publish(ctx context.Context, name string, data interface{}) error {
-	return c.PublishBatch(ctx, []*Message{
+	return c.PublishMultiple(ctx, []*Message{
 		{Name: name, Data: data},
 	})
 }
@@ -63,29 +63,29 @@ func (c *RESTChannel) Publish(ctx context.Context, name string, data interface{}
 // Message is what Ably channels send and receive.
 type Message = proto.Message
 
-// PublishBatch publishes multiple messages in a batch.
-func (c *RESTChannel) PublishBatch(ctx context.Context, messages []*Message) error {
-	return c.PublishBatchWithOptions(ctx, messages)
+// PublishMultiple publishes multiple messages in a batch.
+func (c *RESTChannel) PublishMultiple(ctx context.Context, messages []*Message) error {
+	return c.PublishMultipleWithOptions(ctx, messages)
 }
 
-// PublishBatchOptions is an optional parameter for
-// RESTChannel.PublishBatchWithOptions.
-type PublishBatchOption func(*publishBatchOptions)
+// PublishMultipleOption is an optional parameter for
+// RESTChannel.PublishMultipleWithOptions.
+type PublishMultipleOption func(*publishMultipleOptions)
 
-type publishBatchOptions struct {
+type publishMultipleOptions struct {
 	params map[string]string
 }
 
 // Params adds query parameters to the resulting HTTP request to the REST API.
-func PublishBatchWithParams(params map[string]string) PublishBatchOption {
-	return func(options *publishBatchOptions) {
+func PublishMultipleWithParams(params map[string]string) PublishMultipleOption {
+	return func(options *publishMultipleOptions) {
 		options.params = params
 	}
 }
 
-// PublishBatchWithOptions is PublishBatch with optional parameters.
-func (c *RESTChannel) PublishBatchWithOptions(ctx context.Context, messages []*Message, options ...PublishBatchOption) error {
-	var publishOpts publishBatchOptions
+// PublishMultipleWithOptions is PublishMultiple with optional parameters.
+func (c *RESTChannel) PublishMultipleWithOptions(ctx context.Context, messages []*Message, options ...PublishMultipleOption) error {
+	var publishOpts publishMultipleOptions
 	for _, o := range options {
 		o(&publishOpts)
 	}

--- a/ably/rest_channel_test.go
+++ b/ably/rest_channel_test.go
@@ -91,13 +91,13 @@ func TestRESTChannel(t *testing.T) {
 		})
 	})
 
-	t.Run("PublishBatch", func(ts *testing.T) {
+	t.Run("PublishMultiple", func(ts *testing.T) {
 		encodingRESTChannel := client.Channels.Get("this?is#an?encoding#channel")
 		messages := []*ably.Message{
 			{Name: "send", Data: "test data 1"},
 			{Name: "send", Data: "test data 2"},
 		}
-		err := encodingRESTChannel.PublishBatch(context.Background(), messages)
+		err := encodingRESTChannel.PublishMultiple(context.Background(), messages)
 		if err != nil {
 			ts.Fatal(err)
 		}
@@ -200,7 +200,7 @@ func TestIdempotentPublishing(t *testing.T) {
 	t.Run("when ID is included (#RSL1k2, #RSL1k5)", func(ts *testing.T) {
 		channel := client.Channels.Get("idempotent_test_2")
 		for range make([]struct{}, 3) {
-			err := channel.PublishBatch(context.Background(), []*ably.Message{
+			err := channel.PublishMultiple(context.Background(), []*ably.Message{
 				{
 					ID:   randomStr,
 					Data: randomStr,
@@ -228,7 +228,7 @@ func TestIdempotentPublishing(t *testing.T) {
 
 	t.Run("multiple messages in one publish operation (#RSL1k3)", func(ts *testing.T) {
 		channel := client.Channels.Get("idempotent_test_3")
-		err := channel.PublishBatch(context.Background(), []*ably.Message{
+		err := channel.PublishMultiple(context.Background(), []*ably.Message{
 			{
 				ID:   randomStr,
 				Data: randomStr,
@@ -259,7 +259,7 @@ func TestIdempotentPublishing(t *testing.T) {
 				ID: fmt.Sprintf("%s:%d", randomStr, i),
 			})
 		}
-		err := channel.PublishBatch(context.Background(), m)
+		err := channel.PublishMultiple(context.Background(), m)
 		if err != nil {
 			ts.Fatal(err)
 		}
@@ -335,7 +335,7 @@ func TestIdempotentPublishing(t *testing.T) {
 	t.Run("publishing a batch of messages", func(ts *testing.T) {
 		channel := client.Channels.Get("idempotent_test_6")
 		name := "event"
-		err := channel.PublishBatch(context.Background(), []*ably.Message{
+		err := channel.PublishMultiple(context.Background(), []*ably.Message{
 			{Name: name},
 			{Name: name},
 			{Name: name},
@@ -460,7 +460,7 @@ func TestIdempotent_retry(t *testing.T) {
 				{Data: randomStr},
 			}
 			for range msgs {
-				channel.PublishBatch(context.Background(), msgs)
+				channel.PublishMultiple(context.Background(), msgs)
 			}
 			var m []*ably.Message
 			err := ablytest.AllPages(&m, channel.History())
@@ -498,7 +498,7 @@ func TestRSL1f1(t *testing.T) {
 			Data:     fmt.Sprint(i),
 		})
 	}
-	err = channel.PublishBatch(context.Background(), msgs)
+	err = channel.PublishMultiple(context.Background(), msgs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -536,7 +536,7 @@ func TestRSL1g(t *testing.T) {
 	}
 	t.Run("RSL1g1b", func(ts *testing.T) {
 		channel := client.Channels.Get("RSL1g1b")
-		err := channel.PublishBatch(context.Background(), []*ably.Message{
+		err := channel.PublishMultiple(context.Background(), []*ably.Message{
 			{Name: "some 1"},
 			{Name: "some 2"},
 			{Name: "some 3"},
@@ -557,7 +557,7 @@ func TestRSL1g(t *testing.T) {
 	})
 	t.Run("RSL1g2", func(ts *testing.T) {
 		channel := client.Channels.Get("RSL1g2")
-		err := channel.PublishBatch(context.Background(), []*ably.Message{
+		err := channel.PublishMultiple(context.Background(), []*ably.Message{
 			{Name: "1", ClientID: clientID},
 			{Name: "2", ClientID: clientID},
 			{Name: "3", ClientID: clientID},
@@ -578,7 +578,7 @@ func TestRSL1g(t *testing.T) {
 	})
 	t.Run("RSL1g3", func(ts *testing.T) {
 		channel := client.Channels.Get("RSL1g3")
-		err := channel.PublishBatch(context.Background(), []*ably.Message{
+		err := channel.PublishMultiple(context.Background(), []*ably.Message{
 			{Name: "1", ClientID: clientID},
 			{Name: "2", ClientID: "other client"},
 			{Name: "3", ClientID: clientID},
@@ -600,7 +600,7 @@ func TestHistory_RSL2_RSL2b3(t *testing.T) {
 			channel := rest.Channels.Get("test")
 
 			fixtures := historyFixtures()
-			channel.PublishBatch(context.Background(), fixtures)
+			channel.PublishMultiple(context.Background(), fixtures)
 
 			err := ablytest.TestPagination(
 				reverseMessages(fixtures),
@@ -638,7 +638,7 @@ func TestHistory_Direction_RSL2b2(t *testing.T) {
 			channel := rest.Channels.Get("test")
 
 			fixtures := historyFixtures()
-			channel.PublishBatch(context.Background(), fixtures)
+			channel.PublishMultiple(context.Background(), fixtures)
 
 			expected := c.expected
 


### PR DESCRIPTION
As @SimonWoolf points out, there's an unrelated feature called [batch publish](https://ably.com/documentation/rest-api/beta#batch) already.