### PR TITLE
Allow setting connection and request timeouts separately

### DIFF
--- a/ably/export_test.go
+++ b/ably/export_test.go
@@ -91,12 +91,6 @@ func (c *Connection) MsgSerial() int64 {
 	return c.msgSerial
 }
 
-func WithRealtimeRequestTimeout(d time.Duration) ClientOption {
-	return func(os *clientOptions) {
-		os.RealtimeRequestTimeout = d
-	}
-}
-
 func WithTrace(trace *httptrace.ClientTrace) ClientOption {
 	return func(os *clientOptions) {
 		os.Trace = trace

--- a/ably/options.go
+++ b/ably/options.go
@@ -340,7 +340,7 @@ func (opts *clientOptions) httpclient() *http.Client {
 		return opts.HTTPClient
 	}
 	return &http.Client{
-		Timeout: defaultOptions.HTTPRequestTimeout,
+		Timeout: opts.HTTPRequestTimeout,
 	}
 }
 
@@ -609,6 +609,12 @@ func WithRESTHost(host string) ClientOption {
 	}
 }
 
+func WithHTTPRequestTimeout(timeout time.Duration) ClientOption {
+	return func(os *clientOptions) {
+		os.HTTPRequestTimeout = timeout
+	}
+}
+
 func WithRealtimeHost(host string) ClientOption {
 	return func(os *clientOptions) {
 		os.RealtimeHost = host
@@ -660,6 +666,12 @@ func WithDisconnectedRetryTimeout(d time.Duration) ClientOption {
 func WithHTTPOpenTimeout(d time.Duration) ClientOption {
 	return func(os *clientOptions) {
 		os.HTTPOpenTimeout = d
+	}
+}
+
+func WithRealtimeRequestTimeout(d time.Duration) ClientOption {
+	return func(os *clientOptions) {
+		os.RealtimeRequestTimeout = d
 	}
 }
 

--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -115,7 +115,7 @@ func (c *Connection) dial(proto string, u *url.URL) (conn proto.Conn, err error)
 	query := u.Query()
 	query.Add("heartbeats", "true")
 	u.RawQuery = query.Encode()
-	timeout := c.opts.realtimeRequestTimeout()
+	timeout := c.opts.httpOpenTimeout()
 	if c.opts.Dial != nil {
 		conn, err = c.opts.Dial(proto, u, timeout)
 	} else {


### PR DESCRIPTION
See the discussion [there](https://github.com/ably/ably-boomer/pull/44).

This is a minimal set of changes required to set a different connection and request timeout for Realtime. This also adds `WithHTTPRequestTimeout` to set a timeout for REST requests without using `WithHTTPClient`.