### PR TITLE
Fix a decode error when the server returns 204

### DIFF
--- a/ably/paginated_result.go
+++ b/ably/paginated_result.go
@@ -267,11 +267,13 @@ func newPaginatedResult(ctx context.Context, opts *proto.ChannelOptions, req pag
 	}
 	p.path = builtPath
 	p.links = resp.Header["Link"]
-	v, err := p.req.decoder(opts, p.req.typ, resp)
-	if err != nil {
-		return nil, err
+	if p.statusCode != 204 { // Don't try to decode when there is no content.
+		v, err := p.req.decoder(opts, p.req.typ, resp)
+		if err != nil {
+			return nil, err
+		}
+		p.typItems = v
 	}
-	p.typItems = v
 	return p, nil
 }
 


### PR DESCRIPTION
This fixes a `mime: no media type` error returned on calling `rest.Request` when the server returns 204 (no content). This occurred when trying to unsubscribe a push device from a channel.

I am not sure if there are other cases where the is no content to decode and how to catch them. Maybe we should not use the statusCode but the length of the data instead?