### PR TITLE
Use persisted namespace for history tests

### DIFF
--- a/ably/rest_channel_spec_test.go
+++ b/ably/rest_channel_spec_test.go
@@ -133,7 +133,7 @@ func TestHistory_RSL2_RSL2b3(t *testing.T) {
 			t.Parallel()
 			app, rest := ablytest.NewREST()
 			defer app.Close()
-			channel := rest.Channels.Get("test")
+			channel := rest.Channels.Get("persisted:test")
 
 			fixtures := historyFixtures()
 			channel.PublishMultiple(context.Background(), fixtures)
@@ -171,7 +171,7 @@ func TestHistory_Direction_RSL2b2(t *testing.T) {
 		t.Run(fmt.Sprintf("direction=%v", c.direction), func(t *testing.T) {
 			app, rest := ablytest.NewREST()
 			defer app.Close()
-			channel := rest.Channels.Get("test")
+			channel := rest.Channels.Get("persisted:test")
 
 			fixtures := historyFixtures()
 			channel.PublishMultiple(context.Background(), fixtures)


### PR DESCRIPTION
Ably makes no guarantees about history for non-persisted channels, and
does indeed drop history in the middle of tests, causing flakiness.

Fixes #310.