### PR TITLE
Draft of scoped logging

### DIFF
--- a/ably/logger.go
+++ b/ably/logger.go
@@ -1,8 +1,12 @@
 package ably
 
 import (
+	"context"
 	"fmt"
 	"log"
+	"reflect"
+	"strings"
+	"sync/atomic"
 )
 
 type LogLevel uint
@@ -105,4 +109,130 @@ func (l logger) Debug(v ...interface{}) {
 
 func (l logger) print(level LogLevel, v ...interface{}) {
 	l.l.Printf(level, fmt.Sprint(v...))
+}
+
+// Begin starts a log scope. A log scope has a beginning and an end, and
+// contains a number of log messages; at least, a begin and end message. Each
+// scope has a unique ID that is appended to each log message in the scope.
+//
+// Log scopes can be nested, in which case each scope ID will be appended to
+// each log message in it.
+//
+// A log message will be logged with the scope name, and a (maybe empty) list
+// of arguments as key-value pairs.
+//
+// Log scope IDs are kept in contexts. The returned context will carry the
+// new scope ID, plus any scope IDs from the provided context.
+//
+// Use logger.scoped to get a logger that will include its log messages in the
+// scopes associated with the context. For convenience, it's also returned.
+//
+// When the scope is finished, the end function should be called. It takes a
+// pointer to an error, which, if non-nil, will be logged along with any other
+// provided result values as key-value pairs. The result values should be
+// pointers, so the end function can be called with defer. The log level if the
+// error is non-nil will be ERROR if level is INFO, WARNING otherwise.
+func (l logger) Begin(ctx context.Context, level LogLevel, name string, args ...interface{}) (
+	scopedCtx context.Context,
+	scopedLogger logger,
+	end func(err *error, results ...interface{}),
+) {
+	parent, _ := ctx.Value(logScopeCtxKey{}).(*logScope)
+	ctx = context.WithValue(ctx, logScopeCtxKey{}, &logScope{
+		parent: parent,
+		id:     nextLogScopeID(),
+		name:   name,
+	})
+
+	l = l.scoped(ctx)
+	l.l.Printf(level, "BEGIN%s", logKeyValues(false, args...))
+
+	return ctx, l, func(err *error, results ...interface{}) {
+		endLevel := level
+		if err != nil && *err != nil {
+			if level == LogInfo {
+				endLevel = LogError
+			} else {
+				endLevel = LogWarning
+			}
+			results = append([]interface{}{"err", err}, results...)
+		}
+		l.l.Printf(endLevel, "END%s", logKeyValues(true, results...))
+	}
+}
+
+func logKeyValues(indirect bool, kvs ...interface{}) string {
+	if len(kvs) == 0 {
+		return ""
+	}
+	var s strings.Builder
+	s.WriteString(" (")
+	for i := 0; i < len(kvs); i += 2 {
+		k, v := kvs[i], kvs[i+1]
+		if i > 0 {
+			s.WriteString(" ")
+		}
+		if indirect {
+			v = reflect.Indirect(reflect.ValueOf(v)).Interface()
+		}
+		fmt.Fprintf(&s, "%s=%q", k, fmt.Sprint(v))
+	}
+	s.WriteString(")")
+	return s.String()
+}
+
+func (l logger) scoped(ctx context.Context) logger {
+	scope, _ := ctx.Value(logScopeCtxKey{}).(*logScope)
+	if scope == nil {
+		return l
+	}
+	return logger{
+		l: scopedLogger{l: l.l, scopePrefix: scope.String()},
+	}
+}
+
+type logScopeCtxKey struct{}
+
+type logScope struct {
+	id     logScopeID
+	name   string
+	parent *logScope
+}
+
+func (scope *logScope) String() string {
+	var s strings.Builder
+	for scope != nil {
+		if s.Len() > 0 {
+			s.WriteString("←")
+		}
+		fmt.Fprintf(&s, "%s:%s", scope.name, scope.id)
+		scope = scope.parent
+	}
+	return s.String()
+}
+
+var nextLogScopeID = func() func() logScopeID {
+	var counter uint32
+	return func() logScopeID {
+		return logScopeID(atomic.AddUint32(&counter, 1))
+	}
+}()
+
+type logScopeID uint32
+
+func (id logScopeID) String() string {
+	// Take only the last 2 bytes (4 hex characters); 8 characters is too noise for
+	// logs. This gives ~65k unique IDs, which should be good enough for
+	// correlating logs. We "waste" the other 2 bytes of the uint32 but that's the
+	// smallest uint for which there's an atomic add.
+	return fmt.Sprintf("%04x", (1<<16-1)&uint32(id))
+}
+
+type scopedLogger struct {
+	l           Logger
+	scopePrefix string
+}
+
+func (l scopedLogger) Printf(level LogLevel, fmt string, v ...interface{}) {
+	l.l.Printf(level, "["+l.scopePrefix+"] "+fmt, v...)
 }

--- a/ably/logger.go
+++ b/ably/logger.go
@@ -145,7 +145,7 @@ func (l logger) Begin(ctx context.Context, level LogLevel, name string, args ...
 	})
 
 	l = l.scoped(ctx)
-	l.l.Printf(level, "BEGIN%s", logKeyValues(false, args...))
+	l.l.Printf(level, "%s:begin %s", name, logKeyValues(false, args...))
 
 	return ctx, l, func(err *error, results ...interface{}) {
 		endLevel := level
@@ -157,7 +157,7 @@ func (l logger) Begin(ctx context.Context, level LogLevel, name string, args ...
 			}
 			results = append([]interface{}{"err", err}, results...)
 		}
-		l.l.Printf(endLevel, "END%s", logKeyValues(true, results...))
+		l.l.Printf(endLevel, "%s:end %s", name, logKeyValues(true, results...))
 	}
 }
 
@@ -187,7 +187,7 @@ func (l logger) scoped(ctx context.Context) logger {
 		return l
 	}
 	return logger{
-		l: scopedLogger{l: l.l, scopePrefix: scope.String()},
+		l: scopedLogger{l: l.l, scope: scope.String()},
 	}
 }
 
@@ -229,10 +229,10 @@ func (id logScopeID) String() string {
 }
 
 type scopedLogger struct {
-	l           Logger
-	scopePrefix string
+	l     Logger
+	scope string
 }
 
 func (l scopedLogger) Printf(level LogLevel, fmt string, v ...interface{}) {
-	l.l.Printf(level, "["+l.scopePrefix+"] "+fmt, v...)
+	l.l.Printf(level, fmt+" @ "+l.scope, v...)
 }

--- a/ably/logger.go
+++ b/ably/logger.go
@@ -145,7 +145,7 @@ func (l logger) Begin(ctx context.Context, level LogLevel, name string, args ...
 	})
 
 	l = l.scoped(ctx)
-	l.l.Printf(level, "%s:begin %s", name, logKeyValues(false, args...))
+	l.l.Printf(level, "%s:begin%s", name, logKeyValues(false, args...))
 
 	return ctx, l, func(err *error, results ...interface{}) {
 		endLevel := level
@@ -157,7 +157,7 @@ func (l logger) Begin(ctx context.Context, level LogLevel, name string, args ...
 			}
 			results = append([]interface{}{"err", err}, results...)
 		}
-		l.l.Printf(endLevel, "%s:end %s", name, logKeyValues(true, results...))
+		l.l.Printf(endLevel, "%s:end%s", name, logKeyValues(true, results...))
 	}
 }
 

--- a/ably/logger.go
+++ b/ably/logger.go
@@ -21,11 +21,11 @@ const (
 )
 
 var logLevelNames = map[LogLevel]string{
-	LogError:   "ERROR",
+	LogError:   "ERRO",
 	LogWarning: "WARN",
 	LogInfo:    "INFO",
-	LogVerbose: "VERBOSE",
-	LogDebug:   "DEBUG",
+	LogVerbose: "VBOS",
+	LogDebug:   "DBUG",
 }
 
 func (l LogLevel) String() string {

--- a/ably/state.go
+++ b/ably/state.go
@@ -247,7 +247,7 @@ func (q *msgQueue) Fail(err error) {
 }
 
 func (q *msgQueue) log() logger {
-	return q.conn.log()
+	return q.conn.log
 }
 
 var nopResult *errResult


### PR DESCRIPTION
#160 says:

> every operation should have at least a "begin" and "end" log message, with parameters and outcome

This is a proposal on how to do that, by introducing log scopes.

A pet peeve of mine is when logs from concurrent threads interleave, making it hard to discern what causes what. Log scopes fix that by prepending a mini stack trace to each log message, with IDs. Scopes have a beginning and an end, and can nest.

A scope is created like this:

```go
ctx, log, end := a.log().Begin(ctx, LogVerbose, "requestToken", "params", params)
defer end(&err)
```

This way, the rest of the function will be inside the log scope, and any log message from it, or from functions called from it, will be included in the scope.

To get a taste of how this looks like, I've run `TestRealtimeConn_RTN14b` (reauthorization) with different log levels. The default one (WARNING):

```
2021/05/25 17:26:24 [WARN] requestToken:end (err="[ErrorInfo :bad token request code=40170 error from client token callback statusCode=401] See https://help.ably.io/error/40170") @ requestToken:000c←authorize:000a←reauth:0007
2021/05/25 17:26:24 [WARN] authorize:end (err="[ErrorInfo :bad token request code=40170 error from client token callback statusCode=401] See https://help.ably.io/error/40170") @ authorize:000a←reauth:0007
```

From this, we now some non-critical error happened and can see how: reauthorization called authorize called requestToken, and that failed.

INFO:

```
2021/05/25 17:25:55 [INFO] conn:begin @ conn:0001
2021/05/25 17:25:55 [INFO] Connection state change: INITIALIZED → CONNECTING (reason=<nil>) @ conn:0001
2021/05/25 17:25:55 [INFO] Auth: sending  token request @ authorize:0005
2021/05/25 17:25:55 [INFO] Auth: sending  token request @ authorize:000c←reauth:000b
2021/05/25 17:25:55 [WARN] requestToken:end (err="[ErrorInfo :bad token request code=40170 error from client token callback statusCode=401] See https://help.ably.io/error/40170") @ requestToken:000d←authorize:000c←reauth:000b
2021/05/25 17:25:55 [WARN] authorize:end (err="[ErrorInfo :bad token request code=40170 error from client token callback statusCode=401] See https://help.ably.io/error/40170") @ authorize:000c←reauth:000b
2021/05/25 17:25:55 [INFO] Connection state change: CONNECTING → DISCONNECTED (reason=[ErrorInfo :bad token request code=40170 error from client token callback statusCode=401] See https://help.ably.io/error/40170) @ conn:0001
```

This includes connection state changes, which makes it clear at what point reauthorization happened.

VERBOSE:

```
2021/05/25 17:25:02 [INFO] conn:begin @ conn:0001
2021/05/25 17:25:02 [INFO] Connection state change: INITIALIZED → CONNECTING (reason=<nil>) @ conn:0001
2021/05/25 17:25:02 [VBOS] authorize:begin (params="<nil>" force="false") @ authorize:0009
2021/05/25 17:25:02 [INFO] Auth: sending  token request @ authorize:0009
2021/05/25 17:25:02 [VBOS] requestToken:begin (params="<nil>") @ requestToken:000a←authorize:0009
2021/05/25 17:25:02 [VBOS] Auth: found AuthCallback in []AuthOption @ requestToken:000a←authorize:0009
2021/05/25 17:25:02 [VBOS] requestToken:end @ requestToken:000a←authorize:0009
2021/05/25 17:25:02 [VBOS] authorize:end @ authorize:0009
2021/05/25 17:25:02 [VBOS] Realtime Connection: received (action="error", error=&proto.ErrorInfo{StatusCode: 401, Code: 40140, HRef:"", Message:"", Server:""}) @ conn:0001
2021/05/25 17:25:02 [VBOS] Protocol message received: error @ conn:0001
2021/05/25 17:25:02 [VBOS] reauth:begin @ reauth:000b
2021/05/25 17:25:02 [VBOS] authorize:begin (params="<nil>" force="true") @ authorize:000c←reauth:000b
2021/05/25 17:25:02 [INFO] Auth: sending  token request @ authorize:000c←reauth:000b
2021/05/25 17:25:02 [VBOS] requestToken:begin (params="<nil>") @ requestToken:000d←authorize:000c←reauth:000b
2021/05/25 17:25:02 [VBOS] Auth: found AuthCallback in []AuthOption @ requestToken:000d←authorize:000c←reauth:000b
2021/05/25 17:25:02 [WARN] requestToken:end (err="[ErrorInfo :bad token request code=40170 error from client token callback statusCode=401] See https://help.ably.io/error/40170") @ requestToken:000d←authorize:000c←reauth:000b
2021/05/25 17:25:02 [WARN] authorize:end (err="[ErrorInfo :bad token request code=40170 error from client token callback statusCode=401] See https://help.ably.io/error/40170") @ authorize:000c←reauth:000b
2021/05/25 17:25:02 [VBOS] reauth:end @ reauth:000b
2021/05/25 17:25:02 [INFO] Connection state change: CONNECTING → DISCONNECTED (reason=[ErrorInfo :bad token request code=40170 error from client token callback statusCode=401] See https://help.ably.io/error/40170) @ conn:0001
```

This includes the beginning and end of each scope, plus fine-grained branching inside each scope.

Adding @QuintinWillison as a reviewer in case he wants to provide feedback on the output (or, well, anything else!).