### PR TITLE
Replace all `ts *testing.T` instances with `t`

### DIFF
--- a/ably/auth_test.go
+++ b/ably/auth_test.go
@@ -168,7 +168,9 @@ func TestAuth_TimestampRSA10k(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Run("must use local time when UseQueryTime is false", func(ts *testing.T) {
+	t.Run("must use local time when UseQueryTime is false", func(t *testing.T) {
+		t.Parallel()
+
 		rest, _ := ably.NewREST(
 			ably.WithKey("fake:key"),
 			ably.WithNow(func() time.Time {
@@ -180,13 +182,15 @@ func TestAuth_TimestampRSA10k(t *testing.T) {
 		})
 		stamp, err := a.Timestamp(context.Background(), false)
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 		if !stamp.Equal(now) {
-			ts.Errorf("expected %s got %s", now, stamp)
+			t.Errorf("expected %s got %s", now, stamp)
 		}
 	})
-	t.Run("must use server time when UseQueryTime is true", func(ts *testing.T) {
+	t.Run("must use server time when UseQueryTime is true", func(t *testing.T) {
+		t.Parallel()
+
 		rest, _ := ably.NewREST(
 			ably.WithKey("fake:key"),
 			ably.WithNow(func() time.Time {
@@ -198,14 +202,16 @@ func TestAuth_TimestampRSA10k(t *testing.T) {
 		})
 		stamp, err := rest.Timestamp(true)
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 		serverTime := now.Add(time.Minute)
 		if !stamp.Equal(serverTime) {
-			ts.Errorf("expected %s got %s", serverTime, stamp)
+			t.Errorf("expected %s got %s", serverTime, stamp)
 		}
 	})
-	t.Run("must use server time offset ", func(ts *testing.T) {
+	t.Run("must use server time offset ", func(t *testing.T) {
+		t.Parallel()
+
 		now := now
 		rest, _ := ably.NewREST(
 			ably.WithKey("fake:key"),
@@ -218,11 +224,11 @@ func TestAuth_TimestampRSA10k(t *testing.T) {
 		})
 		stamp, err := rest.Timestamp(true)
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 		serverTime := now.Add(time.Minute)
 		if !stamp.Equal(serverTime) {
-			ts.Errorf("expected %s got %s", serverTime, stamp)
+			t.Errorf("expected %s got %s", serverTime, stamp)
 		}
 
 		now = now.Add(time.Minute)
@@ -231,11 +237,11 @@ func TestAuth_TimestampRSA10k(t *testing.T) {
 		})
 		stamp, err = rest.Timestamp(true)
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 		serverTime = now.Add(time.Minute)
 		if !stamp.Equal(serverTime) {
-			ts.Errorf("expected %s got %s", serverTime, stamp)
+			t.Errorf("expected %s got %s", serverTime, stamp)
 		}
 	})
 }
@@ -710,60 +716,60 @@ func TestAuth_CreateTokenRequest(t *testing.T) {
 		TTL:        (5 * time.Second).Milliseconds(),
 		Capability: `{"presence":["read", "write"]}`,
 	}
-	t.Run("RSA9h", func(ts *testing.T) {
-		ts.Run("parameters are optional", func(ts *testing.T) {
+	t.Run("RSA9h", func(t *testing.T) {
+		t.Run("parameters are optional", func(t *testing.T) {
 			_, err := client.Auth.CreateTokenRequest(params)
 			if err != nil {
-				ts.Fatalf("expected no error to occur got %v instead", err)
+				t.Fatalf("expected no error to occur got %v instead", err)
 			}
 			_, err = client.Auth.CreateTokenRequest(nil, opts...)
 			if err != nil {
-				ts.Fatalf("expected no error to occur got %v instead", err)
+				t.Fatalf("expected no error to occur got %v instead", err)
 			}
 			_, err = client.Auth.CreateTokenRequest(nil)
 			if err != nil {
-				ts.Fatalf("expected no error to occur got %v instead", err)
+				t.Fatalf("expected no error to occur got %v instead", err)
 			}
 		})
-		ts.Run("authOptions must not be merged", func(ts *testing.T) {
+		t.Run("authOptions must not be merged", func(t *testing.T) {
 			opts := []ably.AuthOption{ably.AuthWithQueryTime(true)}
 			_, err := client.Auth.CreateTokenRequest(params, opts...)
 			if err == nil {
-				ts.Fatal("expected an error")
+				t.Fatal("expected an error")
 			}
 			e := err.(*ably.ErrorInfo)
 			if e.Code != ably.ErrInvalidCredentials {
-				ts.Errorf("expected error code %d got %d", ably.ErrInvalidCredentials, e.Code)
+				t.Errorf("expected error code %d got %d", ably.ErrInvalidCredentials, e.Code)
 			}
 
 			// override with bad key
 			opts = append(opts, ably.AuthWithKey("some bad key"))
 			_, err = client.Auth.CreateTokenRequest(params, opts...)
 			if err == nil {
-				ts.Fatal("expected an error")
+				t.Fatal("expected an error")
 			}
 			e = err.(*ably.ErrorInfo)
 			if e.Code != ably.ErrIncompatibleCredentials {
-				ts.Errorf("expected error code %d got %d", ably.ErrIncompatibleCredentials, e.Code)
+				t.Errorf("expected error code %d got %d", ably.ErrIncompatibleCredentials, e.Code)
 			}
 		})
 	})
-	t.Run("RSA9c must generate a unique 16+ character nonce", func(ts *testing.T) {
+	t.Run("RSA9c must generate a unique 16+ character nonce", func(t *testing.T) {
 		req, err := client.Auth.CreateTokenRequest(params, opts...)
 		if err != nil {
-			ts.Fatalf("CreateTokenRequest()=%v", err)
+			t.Fatalf("CreateTokenRequest()=%v", err)
 		}
 		if len(req.Nonce) < 16 {
-			ts.Fatalf("want len(nonce)>=16; got %d", len(req.Nonce))
+			t.Fatalf("want len(nonce)>=16; got %d", len(req.Nonce))
 		}
 	})
-	t.Run("RSA9g generate a signed request", func(ts *testing.T) {
+	t.Run("RSA9g generate a signed request", func(t *testing.T) {
 		req, err := client.Auth.CreateTokenRequest(nil)
 		if err != nil {
-			ts.Fatalf("CreateTokenRequest()=%v", err)
+			t.Fatalf("CreateTokenRequest()=%v", err)
 		}
 		if req.MAC == "" {
-			ts.Fatalf("want mac to be not empty")
+			t.Fatalf("want mac to be not empty")
 		}
 	})
 }

--- a/ably/error_test.go
+++ b/ably/error_test.go
@@ -61,25 +61,31 @@ func TestIssue127ErrorResponse(t *testing.T) {
 }
 
 func TestErrorInfo(t *testing.T) {
-	t.Run("without an error code", func(ts *testing.T) {
+	t.Run("without an error code", func(t *testing.T) {
+		t.Parallel()
+
 		e := &ably.ErrorInfo{
 			StatusCode: 401,
 		}
 		h := "help.ably.io"
 		if strings.Contains(e.Error(), h) {
-			ts.Errorf("expected error message not to contain %s", h)
+			t.Errorf("expected error message not to contain %s", h)
 		}
 	})
-	t.Run("with an error code", func(ts *testing.T) {
+	t.Run("with an error code", func(t *testing.T) {
+		t.Parallel()
+
 		e := &ably.ErrorInfo{
 			Code: 44444,
 		}
 		h := "https://help.ably.io/error/44444"
 		if !strings.Contains(e.Error(), h) {
-			ts.Errorf("expected error message %s  to contain %s", e.Error(), h)
+			t.Errorf("expected error message %s  to contain %s", e.Error(), h)
 		}
 	})
-	t.Run("with an error code and an href attribute", func(ts *testing.T) {
+	t.Run("with an error code and an href attribute", func(t *testing.T) {
+		t.Parallel()
+
 		href := "http://foo.bar.com/"
 		e := &ably.ErrorInfo{
 			Code: 44444,
@@ -87,41 +93,45 @@ func TestErrorInfo(t *testing.T) {
 		}
 		h := "https://help.ably.io/error/44444"
 		if strings.Contains(e.Error(), h) {
-			ts.Errorf("expected error message %s not to contain %s", e.Error(), h)
+			t.Errorf("expected error message %s not to contain %s", e.Error(), h)
 		}
 		if !strings.Contains(e.Error(), href) {
-			ts.Errorf("expected error message %s  to contain %s", e.Error(), href)
+			t.Errorf("expected error message %s  to contain %s", e.Error(), href)
 		}
 	})
 
-	t.Run("with an error code and a message with the same error URL", func(ts *testing.T) {
+	t.Run("with an error code and a message with the same error URL", func(t *testing.T) {
+		t.Parallel()
+
 		e := ably.NewErrorInfo(44444, errors.New("error https://help.ably.io/error/44444"))
 		h := "https://help.ably.io/error/44444"
 		if !strings.Contains(e.Error(), h) {
-			ts.Errorf("expected error message %s  to contain %s", e.Error(), h)
+			t.Errorf("expected error message %s  to contain %s", e.Error(), h)
 		}
 		n := strings.Count(e.Error(), h)
 		if n != 1 {
-			ts.Errorf("expected 1 occupance of %s got %d", h, n)
+			t.Errorf("expected 1 occupance of %s got %d", h, n)
 		}
 	})
-	t.Run("with an error code and a message with a different error URL", func(ts *testing.T) {
+	t.Run("with an error code and a message with a different error URL", func(t *testing.T) {
+		t.Parallel()
+
 		e := ably.NewErrorInfo(44444, errors.New("error https://help.ably.io/error/123123"))
 		h := "https://help.ably.io/error/44444"
 		if !strings.Contains(e.Error(), h) {
-			ts.Errorf("expected error message %s  to contain %s", e.Error(), h)
+			t.Errorf("expected error message %s  to contain %s", e.Error(), h)
 		}
 		n := strings.Count(e.Error(), "help.ably.io")
 		if n != 2 {
-			ts.Errorf("expected 2 got %d", n)
+			t.Errorf("expected 2 got %d", n)
 		}
 		n = strings.Count(e.Error(), "/123123")
 		if n != 1 {
-			ts.Errorf("expected 1 got %d", n)
+			t.Errorf("expected 1 got %d", n)
 		}
 		n = strings.Count(e.Error(), "/44444")
 		if n != 1 {
-			ts.Errorf("expected 1 got %d", n)
+			t.Errorf("expected 1 got %d", n)
 		}
 	})
 }

--- a/ably/logger_test.go
+++ b/ably/logger_test.go
@@ -20,33 +20,33 @@ func (d *dummyLogger) Printf(level ably.LogLevel, format string, v ...interface{
 }
 
 func TestLoggerOptions(t *testing.T) {
-	t.Run("must use default logger when no custom logger", func(ts *testing.T) {
+	t.Run("must use default logger when no custom logger", func(t *testing.T) {
 		lg := &ably.LoggerOptions{}
 		l := lg.GetLogger()
 		if l == nil {
-			ts.Fatal("expected to get a valid logger")
+			t.Fatal("expected to get a valid logger")
 		}
 		_, ok := l.(*ably.StdLogger)
 		if !ok {
-			ts.Error("expected default logger")
+			t.Error("expected default logger")
 		}
 	})
 
-	t.Run("must use custom logger", func(ts *testing.T) {
+	t.Run("must use custom logger", func(t *testing.T) {
 		lg := &ably.LoggerOptions{
 			Logger: &dummyLogger{},
 		}
 		l := lg.GetLogger()
 		if l == nil {
-			ts.Fatal("expected to get a valid logger")
+			t.Fatal("expected to get a valid logger")
 		}
 		_, ok := l.(*dummyLogger)
 		if !ok {
-			ts.Error("expected custom logger")
+			t.Error("expected custom logger")
 		}
 	})
 
-	t.Run("must log smaller or same level", func(ts *testing.T) {
+	t.Run("must log smaller or same level", func(t *testing.T) {
 		lg := &ably.LoggerOptions{
 			Level:  ably.LogDebug,
 			Logger: &dummyLogger{},
@@ -61,7 +61,7 @@ func TestLoggerOptions(t *testing.T) {
 			t.Errorf("expected 4 log messages got %d", l.print)
 		}
 	})
-	t.Run("must log nothing  for LogNone", func(ts *testing.T) {
+	t.Run("must log nothing  for LogNone", func(t *testing.T) {
 		lg := &ably.LoggerOptions{
 			Logger: &dummyLogger{},
 		}
@@ -72,7 +72,7 @@ func TestLoggerOptions(t *testing.T) {
 		lg.Print(ably.LogError, say)
 		l := lg.GetLogger().(*dummyLogger)
 		if l.print > 0 {
-			ts.Error("expected nothing to be logged")
+			t.Error("expected nothing to be logged")
 		}
 	})
 }

--- a/ably/options_test.go
+++ b/ably/options_test.go
@@ -10,28 +10,32 @@ import (
 
 func TestClientOptions(t *testing.T) {
 	t.Parallel()
-	t.Run("must return error on invalid key", func(ts *testing.T) {
+	t.Run("must return error on invalid key", func(t *testing.T) {
 		_, err := ably.NewREST([]ably.ClientOption{ably.WithKey("invalid")}...)
 		if err == nil {
-			ts.Error("expected an error")
+			t.Error("expected an error")
 		}
 	})
 }
 
 func TestScopeParams(t *testing.T) {
 	t.Parallel()
-	t.Run("must error when given invalid range", func(ts *testing.T) {
+	t.Run("must error when given invalid range", func(t *testing.T) {
+		t.Parallel()
+
 		params := ably.ScopeParams{
 			Start: time.Unix(0, 0).Add(123 * time.Millisecond),
 			End:   time.Unix(0, 0).Add(122 * time.Millisecond),
 		}
 		err := params.EncodeValues(nil)
 		if err == nil {
-			ts.Fatal("expected an error")
+			t.Fatal("expected an error")
 		}
 	})
 
-	t.Run("must set url values", func(ts *testing.T) {
+	t.Run("must set url values", func(t *testing.T) {
+		t.Parallel()
+
 		params := ably.ScopeParams{
 			Start: time.Unix(0, 0).Add(122 * time.Millisecond),
 			End:   time.Unix(0, 0).Add(123 * time.Millisecond),
@@ -39,7 +43,7 @@ func TestScopeParams(t *testing.T) {
 		u := make(url.Values)
 		err := params.EncodeValues(&u)
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 		start := u.Get("start")
 		end := u.Get("end")
@@ -54,12 +58,14 @@ func TestScopeParams(t *testing.T) {
 
 func TestPaginateParams(t *testing.T) {
 	t.Parallel()
-	t.Run("returns nil with no values", func(ts *testing.T) {
+	t.Run("returns nil with no values", func(t *testing.T) {
+		t.Parallel()
+
 		params := ably.PaginateParams{}
 		values := make(url.Values)
 		err := params.EncodeValues(&values)
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 		encode := values.Encode()
 		if encode != "" {
@@ -67,7 +73,9 @@ func TestPaginateParams(t *testing.T) {
 		}
 	})
 
-	t.Run("returns the full params encoded", func(ts *testing.T) {
+	t.Run("returns the full params encoded", func(t *testing.T) {
+		t.Parallel()
+
 		params := ably.PaginateParams{
 			Limit:     1,
 			Direction: "backwards",
@@ -80,7 +88,7 @@ func TestPaginateParams(t *testing.T) {
 		values := make(url.Values)
 		err := params.EncodeValues(&values)
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 		expect := "direction=backwards&end=124&limit=1&start=123&unit=hello"
 		got := values.Encode()
@@ -89,7 +97,9 @@ func TestPaginateParams(t *testing.T) {
 		}
 	})
 
-	t.Run("with value", func(ts *testing.T) {
+	t.Run("with value", func(t *testing.T) {
+		t.Parallel()
+
 		params := ably.PaginateParams{
 			Limit:     10,
 			Direction: "backwards",
@@ -97,39 +107,45 @@ func TestPaginateParams(t *testing.T) {
 		values := make(url.Values)
 		err := params.EncodeValues(&values)
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 	})
 
-	t.Run("with a value for ScopeParams", func(ts *testing.T) {
+	t.Run("with a value for ScopeParams", func(t *testing.T) {
+		t.Parallel()
+
 		values := make(url.Values)
 		params := ably.PaginateParams{}
 		params.Start = time.Unix(0, 0).Add(123 * time.Millisecond)
 		err := params.EncodeValues(&values)
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 		start := values.Get("start")
 		if start != "123" {
-			ts.Errorf("expected 123 got %s", start)
+			t.Errorf("expected 123 got %s", start)
 		}
 	})
-	t.Run("with invalid value for direction", func(ts *testing.T) {
+	t.Run("with invalid value for direction", func(t *testing.T) {
+		t.Parallel()
+
 		values := make(url.Values)
 		params := ably.PaginateParams{}
 		params.Direction = "unknown"
 		err := params.EncodeValues(&values)
 		if err == nil {
-			ts.Fatal("expected an error")
+			t.Fatal("expected an error")
 		}
 	})
-	t.Run("with invalid value for limit", func(ts *testing.T) {
+	t.Run("with invalid value for limit", func(t *testing.T) {
+		t.Parallel()
+
 		values := make(url.Values)
 		params := ably.PaginateParams{}
 		params.Limit = -1
 		err := params.EncodeValues(&values)
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 		limit := values.Get("limit")
 		if limit != "100" {

--- a/ably/rest_channel_spec_test.go
+++ b/ably/rest_channel_spec_test.go
@@ -70,7 +70,7 @@ func TestRSL1g(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Run("RSL1g1b", func(ts *testing.T) {
+	t.Run("RSL1g1b", func(t *testing.T) {
 		channel := client.Channels.Get("RSL1g1b")
 		err := channel.PublishMultiple(context.Background(), []*ably.Message{
 			{Name: "some 1"},
@@ -78,20 +78,20 @@ func TestRSL1g(t *testing.T) {
 			{Name: "some 3"},
 		})
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 		var history []*ably.Message
 		err = ablytest.AllPages(&history, channel.History())
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 		for _, m := range history {
 			if m.ClientID != clientID {
-				ts.Errorf("expected %s got %s", clientID, m.ClientID)
+				t.Errorf("expected %s got %s", clientID, m.ClientID)
 			}
 		}
 	})
-	t.Run("RSL1g2", func(ts *testing.T) {
+	t.Run("RSL1g2", func(t *testing.T) {
 		channel := client.Channels.Get("RSL1g2")
 		err := channel.PublishMultiple(context.Background(), []*ably.Message{
 			{Name: "1", ClientID: clientID},
@@ -99,20 +99,20 @@ func TestRSL1g(t *testing.T) {
 			{Name: "3", ClientID: clientID},
 		})
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 		var history []*ably.Message
 		err = ablytest.AllPages(&history, channel.History())
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 		for _, m := range history {
 			if m.ClientID != clientID {
-				ts.Errorf("expected %s got %s", clientID, m.ClientID)
+				t.Errorf("expected %s got %s", clientID, m.ClientID)
 			}
 		}
 	})
-	t.Run("RSL1g3", func(ts *testing.T) {
+	t.Run("RSL1g3", func(t *testing.T) {
 		channel := client.Channels.Get("RSL1g3")
 		err := channel.PublishMultiple(context.Background(), []*ably.Message{
 			{Name: "1", ClientID: clientID},
@@ -120,7 +120,7 @@ func TestRSL1g(t *testing.T) {
 			{Name: "3", ClientID: clientID},
 		})
 		if err == nil {
-			ts.Fatal("expected an error")
+			t.Fatal("expected an error")
 		}
 	})
 }

--- a/ably/rest_client_test.go
+++ b/ably/rest_client_test.go
@@ -40,8 +40,8 @@ func TestRestClient(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer app.Close()
-	t.Run("encoding messages", func(ts *testing.T) {
-		ts.Run("json", func(ts *testing.T) {
+	t.Run("encoding messages", func(t *testing.T) {
+		t.Run("json", func(t *testing.T) {
 			var buffer []byte
 			mockType := "application/json"
 			mockBody := []byte("{}")
@@ -49,7 +49,7 @@ func TestRestClient(t *testing.T) {
 				var err error
 				buffer, err = ioutil.ReadAll(r.Body)
 				if err != nil {
-					ts.Fatal(err)
+					t.Fatal(err)
 				}
 				w.Header().Set("Content-Type", mockType)
 				w.WriteHeader(200)
@@ -64,19 +64,19 @@ func TestRestClient(t *testing.T) {
 
 			client, err := ably.NewREST(app.Options(options...)...)
 			if err != nil {
-				ts.Fatal(err)
+				t.Fatal(err)
 			}
 			err = client.Channels.Get("test").Publish(context.Background(), "ping", "pong")
 			if err != nil {
-				ts.Fatal(err)
+				t.Fatal(err)
 			}
 			var anyJson []map[string]interface{}
 			err = json.Unmarshal(buffer, &anyJson)
 			if err != nil {
-				ts.Error(err)
+				t.Error(err)
 			}
 		})
-		ts.Run("msgpack", func(ts *testing.T) {
+		t.Run("msgpack", func(t *testing.T) {
 			var buffer []byte
 			mockType := "application/x-msgpack"
 			mockBody := []byte{0x80}
@@ -84,7 +84,7 @@ func TestRestClient(t *testing.T) {
 				var err error
 				buffer, err = ioutil.ReadAll(r.Body)
 				if err != nil {
-					ts.Fatal(err)
+					t.Fatal(err)
 				}
 				w.Header().Set("Content-Type", mockType)
 				w.WriteHeader(200)
@@ -99,16 +99,16 @@ func TestRestClient(t *testing.T) {
 
 			client, err := ably.NewREST(app.Options(options...)...)
 			if err != nil {
-				ts.Fatal(err)
+				t.Fatal(err)
 			}
 			err = client.Channels.Get("test").Publish(context.Background(), "ping", "pong")
 			if err != nil {
-				ts.Fatal(err)
+				t.Fatal(err)
 			}
 			var anyMsgPack []map[string]interface{}
 			err = ablyutil.UnmarshalMsgpack(buffer, &anyMsgPack)
 			if err != nil {
-				ts.Fatal(err)
+				t.Fatal(err)
 			}
 			name := anyMsgPack[0]["name"].(string)
 			data := anyMsgPack[0]["data"].(string)
@@ -116,38 +116,38 @@ func TestRestClient(t *testing.T) {
 			expectName := "ping"
 			expectData := "pong"
 			if name != expectName {
-				ts.Errorf("expected %s got %s", expectName, string(name))
+				t.Errorf("expected %s got %s", expectName, string(name))
 			}
 			if data != expectData {
-				ts.Errorf("expected %s got %s", expectData, string(data))
+				t.Errorf("expected %s got %s", expectData, string(data))
 			}
 		})
 	})
 
-	t.Run("Time", func(ts *testing.T) {
+	t.Run("Time", func(t *testing.T) {
 		client, err := ably.NewREST(app.Options()...)
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
-		t, err := client.Time(context.Background())
+		ti, err := client.Time(context.Background())
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 		before := time.Now().Add(2 * time.Second).Unix()
 		after := time.Now().Add(-2 * time.Second).Unix()
-		n := t.Unix()
+		n := ti.Unix()
 		if n > before {
-			ts.Errorf("expected %d <= %d", n, before)
+			t.Errorf("expected %d <= %d", n, before)
 		}
 		if n < after {
-			ts.Errorf("expected %d >= %d", n, before)
+			t.Errorf("expected %d >= %d", n, before)
 		}
 	})
 
-	t.Run("Stats", func(ts *testing.T) {
+	t.Run("Stats", func(t *testing.T) {
 		client, err := ably.NewREST(app.Options()...)
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 		lastInterval := time.Now().Add(-365 * 24 * time.Hour)
 		var stats []*proto.Stats
@@ -175,7 +175,7 @@ func TestRestClient(t *testing.T) {
 	`
 		err = json.Unmarshal([]byte(jsonStats), &stats)
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 		stats[0].IntervalID = proto.IntervalFormatFor(lastInterval.Add(-120*time.Minute), proto.StatGranularityMinute)
 		stats[1].IntervalID = proto.IntervalFormatFor(lastInterval.Add(-60*time.Minute), proto.StatGranularityMinute)
@@ -183,7 +183,7 @@ func TestRestClient(t *testing.T) {
 
 		res, err := client.Post(context.Background(), "/stats", &stats, nil)
 		if err != nil {
-			ts.Error(err)
+			t.Error(err)
 		}
 		res.Body.Close()
 
@@ -229,10 +229,10 @@ func TestRestClient(t *testing.T) {
 			re := regexp.MustCompile("[0-9]+\\-[0-9]+\\-[0-9]+:[0-9]+:[0-9]+")
 			interval := pageStats[0].IntervalID
 			if !re.MatchString(interval) {
-				ts.Errorf("got %s which is wrong interval format", interval)
+				t.Errorf("got %s which is wrong interval format", interval)
 			}
 		case err := <-errCh:
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 	})
 }
@@ -265,13 +265,13 @@ func TestRSC7(t *testing.T) {
 	var req *http.Request
 	ablytest.Instantly.Recv(t, &req, requests, t.Fatalf)
 
-	t.Run("must set version header", func(ts *testing.T) {
+	t.Run("must set version header", func(t *testing.T) {
 		h := req.Header.Get(proto.AblyVersionHeader)
 		if h != proto.AblyVersion {
 			t.Errorf("expected %s got %s", proto.AblyVersion, h)
 		}
 	})
-	t.Run("must set lib header", func(ts *testing.T) {
+	t.Run("must set lib header", func(t *testing.T) {
 		h := req.Header.Get(proto.AblyLibHeader)
 		if h != proto.LibraryString {
 			t.Errorf("expected %s got %s", proto.LibraryString, h)
@@ -280,12 +280,14 @@ func TestRSC7(t *testing.T) {
 }
 
 func TestRest_hostfallback(t *testing.T) {
+	t.Parallel()
+
 	app, err := ablytest.NewSandbox(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer app.Close()
-	runTestServer := func(ts *testing.T, options []ably.ClientOption) (int, []string) {
+	runTestServer := func(t *testing.T, options []ably.ClientOption) (int, []string) {
 		var retryCount int
 		var hosts []string
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -296,30 +298,32 @@ func TestRest_hostfallback(t *testing.T) {
 		defer server.Close()
 		client, err := ably.NewREST(app.Options(append(options, ably.WithHTTPClient(newHTTPClientMock(server)))...)...)
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 		err = client.Channels.Get("test").Publish(context.Background(), "ping", "pong")
 		if err == nil {
-			ts.Error("expected an error")
+			t.Error("expected an error")
 		}
 		return retryCount, hosts
 	}
-	t.Run("RSC15d RSC15a must use alternative host", func(ts *testing.T) {
+	t.Run("RSC15d RSC15a must use alternative host", func(t *testing.T) {
+		t.Parallel()
+
 		options := []ably.ClientOption{
 			ably.WithFallbackHosts(ably.DefaultFallbackHosts()),
 			ably.WithTLS(false),
 			ably.WithUseTokenAuth(true),
 		}
-		retryCount, hosts := runTestServer(ts, options)
+		retryCount, hosts := runTestServer(t, options)
 		if retryCount != 4 {
-			ts.Fatalf("expected 4 http calls got %d", retryCount)
+			t.Fatalf("expected 4 http calls got %d", retryCount)
 		}
 		// make sure the host header is set. Since we are using defaults from the spec
 		// the hosts should be in [a..e].ably-realtime.com
 		expect := strings.Join(ably.DefaultFallbackHosts(), ", ")
 		for _, host := range hosts[1:] {
 			if !strings.Contains(expect, host) {
-				ts.Errorf("expected %s got be in %s", host, expect)
+				t.Errorf("expected %s got be in %s", host, expect)
 			}
 		}
 
@@ -327,30 +331,34 @@ func TestRest_hostfallback(t *testing.T) {
 		uniq := make(map[string]bool)
 		for _, h := range hosts {
 			if _, ok := uniq[h]; ok {
-				ts.Errorf("duplicate fallback %s", h)
+				t.Errorf("duplicate fallback %s", h)
 			} else {
 				uniq[h] = true
 			}
 		}
 	})
-	t.Run("rsc15b", func(ts *testing.T) {
-		ts.Run("must not occur when default  rest.ably.io is overriden", func(ts *testing.T) {
+	t.Run("rsc15b", func(t *testing.T) {
+		t.Run("must not occur when default  rest.ably.io is overriden", func(t *testing.T) {
+			t.Parallel()
+
 			customHost := "example.com"
 			options := []ably.ClientOption{
 				ably.WithTLS(false),
 				ably.WithRESTHost(customHost),
 				ably.WithUseTokenAuth(true),
 			}
-			retryCount, hosts := runTestServer(ts, options)
+			retryCount, hosts := runTestServer(t, options)
 			if retryCount != 1 {
-				ts.Fatalf("expected 1 http call got %d", retryCount)
+				t.Fatalf("expected 1 http call got %d", retryCount)
 			}
 			host := hosts[0]
 			if !strings.Contains(host, customHost) {
-				ts.Errorf("expected %s got %s", customHost, host)
+				t.Errorf("expected %s got %s", customHost, host)
 			}
 		})
-		ts.Run("must occur when fallbackHostsUseDefault is true", func(ts *testing.T) {
+		t.Run("must occur when fallbackHostsUseDefault is true", func(t *testing.T) {
+			t.Parallel()
+
 			customHost := "example.com"
 			options := []ably.ClientOption{
 				ably.WithTLS(false),
@@ -358,9 +366,9 @@ func TestRest_hostfallback(t *testing.T) {
 				ably.WithFallbackHosts(ably.DefaultFallbackHosts()),
 				ably.WithUseTokenAuth(true),
 			}
-			retryCount, hosts := runTestServer(ts, options)
+			retryCount, hosts := runTestServer(t, options)
 			if retryCount != 4 {
-				ts.Fatalf("expected 4 http call got %d", retryCount)
+				t.Fatalf("expected 4 http call got %d", retryCount)
 			}
 			expect := strings.Join(ably.DefaultFallbackHosts(), ", ")
 			for _, host := range hosts[1:] {
@@ -369,7 +377,9 @@ func TestRest_hostfallback(t *testing.T) {
 				}
 			}
 		})
-		ts.Run("must occur when fallbackHosts is set", func(ts *testing.T) {
+		t.Run("must occur when fallbackHosts is set", func(t *testing.T) {
+			t.Parallel()
+
 			customHost := "example.com"
 			fallback := "a.example.com"
 			options := []ably.ClientOption{
@@ -378,9 +388,9 @@ func TestRest_hostfallback(t *testing.T) {
 				ably.WithFallbackHosts([]string{fallback}),
 				ably.WithUseTokenAuth(true),
 			}
-			retryCount, hosts := runTestServer(ts, options)
+			retryCount, hosts := runTestServer(t, options)
 			if retryCount != 2 {
-				ts.Fatalf("expected 2 http call got %d", retryCount)
+				t.Fatalf("expected 2 http call got %d", retryCount)
 			}
 			host := hosts[1]
 			if host != fallback {
@@ -388,23 +398,27 @@ func TestRest_hostfallback(t *testing.T) {
 			}
 		})
 	})
-	t.Run("RSC15e must start with default host", func(ts *testing.T) {
+	t.Run("RSC15e must start with default host", func(t *testing.T) {
+		t.Parallel()
+
 		options := []ably.ClientOption{
 			ably.WithEnvironment("production"),
 			ably.WithTLS(false),
 			ably.WithUseTokenAuth(true),
 		}
-		retryCount, hosts := runTestServer(ts, options)
+		retryCount, hosts := runTestServer(t, options)
 		if retryCount != 4 {
-			ts.Fatalf("expected 4 http calls got %d", retryCount)
+			t.Fatalf("expected 4 http calls got %d", retryCount)
 		}
 		firstHostCalled := hosts[0]
 		restURL, _ := url.Parse(ably.ApplyOptionsWithDefaults(options...).RestURL())
 		if !strings.HasPrefix(firstHostCalled, restURL.Hostname()) {
-			ts.Errorf("expected primary host got %s", firstHostCalled)
+			t.Errorf("expected primary host got %s", firstHostCalled)
 		}
 	})
-	t.Run("must not occur when FallbackHosts is an empty array", func(ts *testing.T) {
+	t.Run("must not occur when FallbackHosts is an empty array", func(t *testing.T) {
+		t.Parallel()
+
 		customHost := "example.com"
 		options := []ably.ClientOption{
 			ably.WithTLS(false),
@@ -412,14 +426,16 @@ func TestRest_hostfallback(t *testing.T) {
 			ably.WithFallbackHosts([]string{}),
 			ably.WithUseTokenAuth(true),
 		}
-		retryCount, _ := runTestServer(ts, options)
+		retryCount, _ := runTestServer(t, options)
 		if retryCount != 1 {
-			ts.Fatalf("expected 1 http calls got %d", retryCount)
+			t.Fatalf("expected 1 http calls got %d", retryCount)
 		}
 	})
 }
 
 func TestRest_rememberHostFallback(t *testing.T) {
+	t.Parallel()
+
 	app, err := ablytest.NewSandbox(nil)
 	if err != nil {
 		t.Fatal(err)
@@ -429,7 +445,7 @@ func TestRest_rememberHostFallback(t *testing.T) {
 	fallbackHosts := []string{"fallback0", "fallback1", "fallback2"}
 	var nopts []ably.ClientOption
 
-	t.Run("remember success host RSC15f", func(ts *testing.T) {
+	t.Run("remember success host RSC15f", func(t *testing.T) {
 		var retryCount int
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			retryCount++
@@ -467,34 +483,36 @@ func TestRest_rememberHostFallback(t *testing.T) {
 
 		client, err := ably.NewREST(app.Options(nopts...)...)
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 		channel := client.Channels.Get("remember_fallback_host")
 		err = channel.Publish(context.Background(), "ping", "pong")
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 		cachedHost := client.GetCachedFallbackHost()
 		if cachedHost != fallbackHosts[2] {
-			ts.Errorf("expected cached host to be %s got %s", fallbackHosts[2], cachedHost)
+			t.Errorf("expected cached host to be %s got %s", fallbackHosts[2], cachedHost)
 		}
 		retryCount = 0
 
 		// the same cached host is used again
 		err = channel.Publish(context.Background(), "pong", "ping")
 		if err != nil {
-			ts.Fatal(err)
+			t.Fatal(err)
 		}
 		cachedHost = client.GetCachedFallbackHost()
 		if cachedHost != fallbackHosts[2] {
-			ts.Errorf("expected cached host to be %s got %s", fallbackHosts[2], cachedHost)
+			t.Errorf("expected cached host to be %s got %s", fallbackHosts[2], cachedHost)
 		}
 		if retryCount != 0 {
-			ts.Errorf("expected 0 retries got %d retries", retryCount)
+			t.Errorf("expected 0 retries got %d retries", retryCount)
 		}
 	})
 }
 func TestRESTChannels_RSN1(t *testing.T) {
+	t.Parallel()
+
 	app, err := ablytest.NewSandbox(nil)
 	if err != nil {
 		t.Fatal(err)
@@ -515,26 +533,26 @@ func TestRESTChannels_RSN1(t *testing.T) {
 		{name: "third_channel"},
 	}
 
-	t.Run("RSN3 RSN3a  must create new channels when they don't exist", func(ts *testing.T) {
+	t.Run("RSN3 RSN3a  must create new channels when they don't exist", func(t *testing.T) {
 		for _, v := range sample {
 			client.Channels.Get(v.name)
 		}
 		size := client.Channels.Len()
 		if size != len(sample) {
-			ts.Errorf("expected %d got %d", len(sample), size)
+			t.Errorf("expected %d got %d", len(sample), size)
 		}
 	})
-	t.Run("RSN4 RSN4a must release channels", func(ts *testing.T) {
+	t.Run("RSN4 RSN4a must release channels", func(t *testing.T) {
 		for _, v := range sample {
 			ch := client.Channels.Get(v.name)
 			client.Channels.Release(ch.Name)
 		}
 		size := client.Channels.Len()
 		if size != 0 {
-			ts.Errorf("expected 0 channels  got %d", size)
+			t.Errorf("expected 0 channels  got %d", size)
 		}
 	})
-	t.Run("ensure no deadlock in Range", func(ts *testing.T) {
+	t.Run("ensure no deadlock in Range", func(t *testing.T) {
 		for _, v := range sample {
 			client.Channels.Get(v.name)
 		}
@@ -546,6 +564,8 @@ func TestRESTChannels_RSN1(t *testing.T) {
 }
 
 func TestFixConnLeak_ISSUE89(t *testing.T) {
+	t.Parallel()
+
 	app, err := ablytest.NewSandbox(nil)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Only the innermost `*testing.T` must be used from a test, that's why it
should always be named `t`, so that the `*testing.T` from outer scopes
are shadowed and can't be used accidentally. In fact, there were quite
a few instances of such accidental uses.

Also, add some of the missing `t.Parallel()`s.