### PR TITLE
RTC8a: client-requested reauthorization while CONNECTED

### DIFF
--- a/ably/ably_test.go
+++ b/ably/ably_test.go
@@ -86,24 +86,32 @@ func checkError(code ably.ErrorCode, err error) error {
 }
 
 func assertEquals(t *testing.T, expected interface{}, actual interface{}) {
+	t.Helper()
+
 	if expected != actual {
 		t.Errorf("%v is not equal to %v", expected, actual)
 	}
 }
 
 func assertTrue(t *testing.T, value bool) {
+	t.Helper()
+
 	if !value {
 		t.Errorf("%v is not true", value)
 	}
 }
 
 func assertFalse(t *testing.T, value bool) {
+	t.Helper()
+
 	if value {
 		t.Errorf("%v is not false", value)
 	}
 }
 
 func assertNil(t *testing.T, object interface{}) {
+	t.Helper()
+
 	if object != nil {
 		value := reflect.ValueOf(object)
 		if !value.IsNil() {
@@ -113,6 +121,8 @@ func assertNil(t *testing.T, object interface{}) {
 }
 
 func assertDeepEquals(t *testing.T, expected interface{}, actual interface{}) {
+	t.Helper()
+
 	areEqual := reflect.DeepEqual(expected, actual)
 	if !areEqual {
 		t.Errorf("%v is not equal to %v", expected, actual)

--- a/ably/auth.go
+++ b/ably/auth.go
@@ -68,9 +68,9 @@ type Auth struct {
 	host     string       // a host part of AuthURL
 	clientID string       // clientID of the authenticated user or wildcard "*"
 
-	// onClientAuthorize is the callback that Realtime sets to reauthorize with the
+	// onExplicitAuthorize is the callback that Realtime sets to reauthorize with the
 	// server when Authorize is explicitly called.
-	onClientAuthorize func(context.Context, *TokenDetails)
+	onExplicitAuthorize func(context.Context, *TokenDetails)
 
 	serverTimeOffset time.Duration
 
@@ -80,8 +80,8 @@ type Auth struct {
 
 func newAuth(client *REST) (*Auth, error) {
 	a := &Auth{
-		client:            client,
-		onClientAuthorize: func(context.Context, *TokenDetails) {},
+		client:              client,
+		onExplicitAuthorize: func(context.Context, *TokenDetails) {},
 	}
 	method, err := detectAuthMethod(a.opts())
 	if err != nil {
@@ -276,7 +276,7 @@ func (a *Auth) Authorize(ctx context.Context, params *TokenParams, setOpts ...Au
 	if err != nil {
 		return nil, err
 	}
-	a.onClientAuthorize(ctx, token)
+	a.onExplicitAuthorize(ctx, token)
 	return token, nil
 }
 

--- a/ably/proto_action.go
+++ b/ably/proto_action.go
@@ -20,6 +20,7 @@ const (
 	actionPresence
 	actionMessage
 	actionSync
+	actionAuth
 )
 
 var actions = map[protoAction]string{
@@ -40,6 +41,7 @@ var actions = map[protoAction]string{
 	actionPresence:     "presence",
 	actionMessage:      "message",
 	actionSync:         "sync",
+	actionAuth:         "auth",
 }
 
 func (a protoAction) String() string {

--- a/ably/proto_protocol_message.go
+++ b/ably/proto_protocol_message.go
@@ -103,6 +103,11 @@ type protocolMessage struct {
 	Action            protoAction        `json:"action,omitempty" codec:"action,omitempty"`
 	Flags             protoFlag          `json:"flags,omitempty" codec:"flags,omitempty"`
 	Params            channelParams      `json:"params,omitempty" codec:"params,omitempty"`
+	Auth              *authDetails       `json:"auth,omitempty" codec:"auth,omitempty"`
+}
+
+type authDetails struct {
+	AccessToken string `json:"accessToken,omitempty" codec:"accessToken,omitempty"`
 }
 
 func (p *protocolMessage) SetModesAsFlag(modes []ChannelMode) {

--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -81,7 +81,6 @@ type connCallbacks struct {
 
 func newConn(opts *clientOptions, auth *Auth, callbacks connCallbacks) *Connection {
 	c := &Connection{
-
 		ConnectionEventEmitter: ConnectionEventEmitter{newEventEmitter(auth.log())},
 		state:                  ConnectionStateInitialized,
 		internalEmitter:        ConnectionEventEmitter{newEventEmitter(auth.log())},
@@ -91,6 +90,7 @@ func newConn(opts *clientOptions, auth *Auth, callbacks connCallbacks) *Connecti
 		auth:      auth,
 		callbacks: callbacks,
 	}
+	auth.onClientAuthorize = c.onClientAuthorize
 	c.queue = newMsgQueue(c)
 	if !opts.NoConnect {
 		c.setState(ConnectionStateConnecting, nil, 0)
@@ -878,6 +878,33 @@ func (c *Connection) reauthorize(arg connArgs) {
 	c.reauthorizing = true
 	c.mtx.Unlock()
 	c.reconnect(arg)
+}
+
+func (c *Connection) onClientAuthorize(ctx context.Context, token *TokenDetails) {
+	switch c.State() {
+	case ConnectionStateConnected:
+		c.log().Verbosef("starting client-requested reauthorization with token: %+v", token)
+
+		changes := make(connStateChanges, 2)
+		{
+			off := c.internalEmitter.Once(ConnectionEventUpdate, changes.Receive)
+			defer off()
+		}
+		{
+			off := c.internalEmitter.Once(ConnectionEventFailed, changes.Receive)
+			defer off()
+		}
+
+		c.send(&protocolMessage{
+			Action: actionAuth,
+			Auth:   &authDetails{AccessToken: token.Token},
+		}, nil)
+
+		select {
+		case <-ctx.Done():
+		case <-changes:
+		}
+	}
 }
 
 func (c *Connection) lockedReauthorizationFailed(err error) {

--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -90,7 +90,7 @@ func newConn(opts *clientOptions, auth *Auth, callbacks connCallbacks) *Connecti
 		auth:      auth,
 		callbacks: callbacks,
 	}
-	auth.onClientAuthorize = c.onClientAuthorize
+	auth.onExplicitAuthorize = c.onClientAuthorize
 	c.queue = newMsgQueue(c)
 	if !opts.NoConnect {
 		c.setState(ConnectionStateConnecting, nil, 0)

--- a/ably/realtime_conn_spec_test.go
+++ b/ably/realtime_conn_spec_test.go
@@ -3390,6 +3390,185 @@ func TestIdempotentACK(t *testing.T) {
 	ablytest.Instantly.NoRecv(t, nil, out, t.Fatalf)
 }
 
+func TestRealtimeConn_RTC8a_ExplicitAuthorizeWhileConnected(t *testing.T) {
+	t.Parallel()
+
+	// Set up a Realtime with AuthCallback that the test controls. Auth requests
+	// are sent to the authRequested channel.
+
+	type authResponse struct {
+		token ably.Tokener
+		err   error
+	}
+	type authRequest struct {
+		params ably.TokenParams
+		resp   chan<- authResponse
+	}
+	authRequests := make(chan authRequest, 1)
+	handleAuth := func(getToken func(ably.TokenParams) ably.Tokener, err error) {
+		t.Helper()
+
+		var authReq authRequest
+		ablytest.Soon.Recv(t, &authReq, authRequests, t.Fatalf)
+		ablytest.Instantly.Send(t, authReq.resp, authResponse{
+			token: getToken(authReq.params),
+			err:   err,
+		}, t.Fatalf)
+	}
+
+	// We'll use this REST to get real, working tokens.
+	app, rest := ablytest.NewREST()
+	getToken := func(params ably.TokenParams) ably.Tokener {
+		t.Helper()
+		token, err := rest.Auth.RequestToken(context.Background(), &params)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return token
+	}
+	dial, intercept := DialIntercept(ably.DialWebsocket)
+	c := app.NewRealtime(
+		ably.WithDial(dial),
+		ably.WithDefaultTokenParams(ably.TokenParams{
+			Capability: `{"foo":["subscribe"]}`,
+		}),
+		ably.WithAuthCallback(func(ctx context.Context, params ably.TokenParams) (ably.Tokener, error) {
+			respCh := make(chan authResponse, 1)
+			authRequests <- authRequest{
+				params: params,
+				resp:   respCh,
+			}
+			resp := <-respCh
+			return resp.token, resp.err
+		}),
+	)
+	defer safeclose(t, ablytest.FullRealtimeCloser(c), app)
+
+	stateChanges := make(ably.ConnStateChanges, 1)
+	off := c.Connection.OnAll(stateChanges.Receive)
+	defer off()
+	expectConnEvent := func(expected ably.ConnectionEvent) {
+		t.Helper()
+
+		var change ably.ConnectionStateChange
+		ablytest.Soon.Recv(t, &change, stateChanges, t.Fatalf)
+		if got := change.Event; expected != got {
+			t.Fatalf("expected: %v; got: %v", expected, got)
+		}
+	}
+
+	// Expect a first auth when connecting.
+	handleAuth(getToken, nil)
+	expectConnEvent(ably.ConnectionEventConnected)
+
+	t.Run("RTC8a1: Successful reauth with more capabilities", func(t *testing.T) {
+		var rg ablytest.ResultGroup
+		rg.GoAdd(func(ctx context.Context) error {
+			_, err := c.Auth.Authorize(ctx, nil)
+			return err
+		})
+
+		handleAuth(getToken, nil)
+		expectConnEvent(ably.ConnectionEventUpdate)
+		assertEquals(t, connected, c.Connection.State())
+
+		rg.Wait()
+	})
+
+	t.Run("RTC8a1: Successful reauth with more capabilities", func(t *testing.T) {
+		var rg ablytest.ResultGroup
+		rg.GoAdd(func(ctx context.Context) error {
+			_, err := c.Auth.Authorize(ctx, &ably.TokenParams{
+				Capability: `{"*":["*"]}`,
+			})
+			return err
+		})
+
+		handleAuth(getToken, nil)
+		expectConnEvent(ably.ConnectionEventUpdate)
+		assertEquals(t, connected, c.Connection.State())
+
+		rg.Wait()
+	})
+
+	t.Run("RTC8a1: Unsuccessful reauth with capabilities downgrade", func(t *testing.T) {
+		ch := c.Channels.Get("notfoo")
+		err := ch.Attach(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		channelChanges := make(ably.ChannelStateChanges, 1)
+		off := ch.OnAll(channelChanges.Receive)
+		defer off()
+
+		var rg ablytest.ResultGroup
+		rg.GoAdd(func(ctx context.Context) error {
+			_, err := c.Auth.Authorize(ctx, &ably.TokenParams{
+				Capability: `{"foo":["publish"]}`,
+			})
+			return err
+		})
+
+		handleAuth(getToken, nil)
+		expectConnEvent(ably.ConnectionEventUpdate)
+		assertEquals(t, connected, c.Connection.State())
+
+		rg.Wait()
+
+		var change ably.ChannelStateChange
+		ablytest.Soon.Recv(t, &change, channelChanges, t.Fatalf)
+		assertEquals(t, ably.ChannelEventFailed, change.Event)
+		assertEquals(t, chFailed, ch.State())
+	})
+
+	t.Run("RTC8a3: Authorize waits for connection update", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		connectedMsg := intercept(ctx, ably.ActionConnected)
+
+		authorizeDone := make(chan struct{})
+		go func() {
+			defer close(authorizeDone)
+			c.Auth.Authorize(context.Background(), nil)
+		}()
+
+		handleAuth(getToken, nil)
+
+		ablytest.Soon.Recv(t, nil, connectedMsg, t.Fatalf)
+
+		// At this point, we have a new token and the server has sent a CONNECTED
+		// message, but the library hasn't got it yet. So Authorize should still
+		// be waiting.
+		ablytest.Instantly.NoRecv(t, nil, authorizeDone, t.Fatalf)
+
+		// Let go of the CONNECTED message, completing Authorization.
+		cancel()
+		expectConnEvent(ably.ConnectionEventUpdate)
+		ablytest.Instantly.Recv(t, nil, authorizeDone, t.Fatalf)
+	})
+
+	t.Run("RTC8a4: reauthorize with JWT token", func(t *testing.T) {
+		t.Skip("not implemented")
+	})
+
+	t.Run("RTC8a2: Failed reauth moves connection to FAILED", func(t *testing.T) {
+		var rg ablytest.ResultGroup
+		rg.GoAdd(func(ctx context.Context) error {
+			_, err := c.Auth.Authorize(ctx, nil)
+			return err
+		})
+
+		handleAuth(func(ably.TokenParams) ably.Tokener {
+			return ably.TokenString("made:up")
+		}, nil)
+		expectConnEvent(ably.ConnectionEventFailed)
+		assertEquals(t, failed, c.Connection.State())
+
+		rg.Wait()
+	})
+}
+
 func testConcurrentPublisher(t *testing.T, ch *ably.RealtimeChannel, out <-chan *ably.ProtocolMessage) (
 	publish func(),
 	receiveAck func() error,

--- a/ably/realtime_conn_spec_test.go
+++ b/ably/realtime_conn_spec_test.go
@@ -3528,10 +3528,13 @@ func TestRealtimeConn_RTC8a_ExplicitAuthorizeWhileConnected(t *testing.T) {
 		connectedMsg := intercept(ctx, ably.ActionConnected)
 
 		authorizeDone := make(chan struct{})
-		go func() {
+		var rg ablytest.ResultGroup
+		defer rg.Wait()
+		rg.GoAdd(func(ctx context.Context) error {
 			defer close(authorizeDone)
-			c.Auth.Authorize(context.Background(), nil)
-		}()
+			_, err := c.Auth.Authorize(ctx, nil)
+			return err
+		})
 
 		handleAuth(getToken, nil)
 


### PR DESCRIPTION
Part of #228. Implements [RTC8a](https://docs.ably.io/client-lib-development-guide/features/#RTC8a) for explicit calls to `Authorize`.

This work is a prerequisite for RTN22 and the rest of RTC8.