### PR TITLE
RTC8a: client-requested reauthorization while CONNECTED (to `main` branch)

### DIFF
--- a/ably/ably_test.go
+++ b/ably/ably_test.go
@@ -86,24 +86,32 @@ func checkError(code ably.ErrorCode, err error) error {
 }
 
 func assertEquals(t *testing.T, expected interface{}, actual interface{}) {
+	t.Helper()
+
 	if expected != actual {
 		t.Errorf("%v is not equal to %v", expected, actual)
 	}
 }
 
 func assertTrue(t *testing.T, value bool) {
+	t.Helper()
+
 	if !value {
 		t.Errorf("%v is not true", value)
 	}
 }
 
 func assertFalse(t *testing.T, value bool) {
+	t.Helper()
+
 	if value {
 		t.Errorf("%v is not false", value)
 	}
 }
 
 func assertNil(t *testing.T, object interface{}) {
+	t.Helper()
+
 	if object != nil {
 		value := reflect.ValueOf(object)
 		if !value.IsNil() {
@@ -113,6 +121,8 @@ func assertNil(t *testing.T, object interface{}) {
 }
 
 func assertDeepEquals(t *testing.T, expected interface{}, actual interface{}) {
+	t.Helper()
+
 	areEqual := reflect.DeepEqual(expected, actual)
 	if !areEqual {
 		t.Errorf("%v is not equal to %v", expected, actual)

--- a/ably/auth.go
+++ b/ably/auth.go
@@ -68,6 +68,10 @@ type Auth struct {
 	host     string       // a host part of AuthURL
 	clientID string       // clientID of the authenticated user or wildcard "*"
 
+	// onExplicitAuthorize is the callback that Realtime sets to reauthorize with the
+	// server when Authorize is explicitly called.
+	onExplicitAuthorize func(context.Context, *TokenDetails)
+
 	serverTimeOffset time.Duration
 
 	// ServerTimeHandler when provided this will be used to query server time.
@@ -76,7 +80,8 @@ type Auth struct {
 
 func newAuth(client *REST) (*Auth, error) {
 	a := &Auth{
-		client: client,
+		client:              client,
+		onExplicitAuthorize: func(context.Context, *TokenDetails) {},
 	}
 	method, err := detectAuthMethod(a.opts())
 	if err != nil {
@@ -266,8 +271,13 @@ func (a *Auth) Authorize(ctx context.Context, params *TokenParams, setOpts ...Au
 		opts = applyAuthOptionsWithDefaults(setOpts...)
 	}
 	a.mtx.Lock()
-	defer a.mtx.Unlock()
-	return a.authorize(ctx, params, opts, true)
+	token, err := a.authorize(ctx, params, opts, true)
+	a.mtx.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	a.onExplicitAuthorize(ctx, token)
+	return token, nil
 }
 
 func (a *Auth) authorize(ctx context.Context, params *TokenParams, opts *authOptions, force bool) (*TokenDetails, error) {

--- a/ably/proto_action.go
+++ b/ably/proto_action.go
@@ -20,6 +20,7 @@ const (
 	actionPresence
 	actionMessage
 	actionSync
+	actionAuth
 )
 
 var actions = map[protoAction]string{
@@ -40,6 +41,7 @@ var actions = map[protoAction]string{
 	actionPresence:     "presence",
 	actionMessage:      "message",
 	actionSync:         "sync",
+	actionAuth:         "auth",
 }
 
 func (a protoAction) String() string {

--- a/ably/proto_protocol_message.go
+++ b/ably/proto_protocol_message.go
@@ -103,6 +103,11 @@ type protocolMessage struct {
 	Action            protoAction        `json:"action,omitempty" codec:"action,omitempty"`
 	Flags             protoFlag          `json:"flags,omitempty" codec:"flags,omitempty"`
 	Params            channelParams      `json:"params,omitempty" codec:"params,omitempty"`
+	Auth              *authDetails       `json:"auth,omitempty" codec:"auth,omitempty"`
+}
+
+type authDetails struct {
+	AccessToken string `json:"accessToken,omitempty" codec:"accessToken,omitempty"`
 }
 
 func (p *protocolMessage) SetModesAsFlag(modes []ChannelMode) {


### PR DESCRIPTION
Contains just the work that was originally done under https://github.com/ably/ably-go/pull/336.