### PR TITLE
Don't set message encoding for valid utf-8 string data

### DIFF
--- a/ably/proto_message.go
+++ b/ably/proto_message.go
@@ -44,16 +44,12 @@ func (m Message) withEncodedData(cipher channelCipher) (Message, error) {
 		return m, nil
 	}
 
-	switch d := m.Data.(type) {
-	case string:
-		if utf8.ValidString(d) {
-			m.Encoding = mergeEncoding(m.Encoding, encUTF8)
-		} else {
-			// If string isn't UTF-8, convert to []byte to encode it as base64
-			// below.
-			m.Data = []byte(d)
-		}
+	// If string isn't UTF-8, convert to []byte to encode it as base64
+	// below.
+	if d, ok := m.Data.(string); ok && !utf8.ValidString(d) {
+		m.Data = []byte(d)
 	}
+
 	switch d := m.Data.(type) {
 	case string:
 	case []byte:

--- a/ably/proto_message.go
+++ b/ably/proto_message.go
@@ -83,10 +83,10 @@ func (m Message) withEncodedData(cipher channelCipher) (Message, error) {
 	if err != nil {
 		return Message{}, fmt.Errorf("encrypting message data: %w", err)
 	}
-	// if the plain text is a string, then add utf-8 to the list of encodings
-	// to indicate to the client-side decoder that the plain text should be
-	// further decoded into a utf-8 string after being decrypted.
-	if _, ok := m.Data.(string); ok {
+	// if the plain text is a valid utf-8 string, then add utf-8 to the list
+	// of encodings to indicate to the client-side decoder that the plain text
+	// should be further decoded into a utf-8 string after being decrypted.
+	if s, ok := m.Data.(string); ok && utf8.ValidString(s) {
 		m.Encoding = mergeEncoding(m.Encoding, encUTF8)
 	}
 	m.Data = base64.StdEncoding.EncodeToString(e)

--- a/ably/proto_message.go
+++ b/ably/proto_message.go
@@ -84,9 +84,10 @@ func (m Message) withEncodedData(cipher channelCipher) (Message, error) {
 	if err != nil {
 		return Message{}, fmt.Errorf("encrypting message data: %w", err)
 	}
+	// if the plain text is a string, then add utf-8 to the list of encodings
+	// to indicate to the client-side decoder that the plain text should be
+	// further decoded into a utf-8 string after being decrypted.
 	if _, ok := m.Data.(string); ok {
-		// Not sure why this is useful, and can't find the requirement in the
-		// spec, but test fixtures expect this.
 		m.Encoding = mergeEncoding(m.Encoding, encUTF8)
 	}
 	m.Data = base64.StdEncoding.EncodeToString(e)

--- a/ably/proto_message.go
+++ b/ably/proto_message.go
@@ -39,7 +39,6 @@ func unencodableDataErr(data interface{}) error {
 }
 
 func (m Message) withEncodedData(cipher channelCipher) (Message, error) {
-	// TODO: Unexport once proto gets merged into package ably.
 	if m.Data == nil {
 		return m, nil
 	}

--- a/ably/proto_message_test.go
+++ b/ably/proto_message_test.go
@@ -42,6 +42,21 @@ func TestMessage(t *testing.T) {
 		decoded     interface{}
 	}{
 		{
+			// utf-8 string data should not have an encoding set, see:
+			// https://github.com/ably/docs/issues/1165
+			desc:        "with valid utf-8 string data",
+			data:        "a string",
+			decoded:     "a string",
+			encodedJSON: `{"data":"a string"}`,
+		},
+		{
+			// invalid utf-8 string data should be base64 encoded
+			desc:        "with invalid utf-8 string data",
+			data:        "\xf0\x80\x80",
+			decoded:     []byte("\xf0\x80\x80"),
+			encodedJSON: `{"data":"8ICA","encoding":"base64"}`,
+		},
+		{
 			desc: "with a json encoding RSL4d3 map data",
 			data: map[string]interface{}{
 				"string": ably.EncUTF8,


### PR DESCRIPTION
See explanation in https://github.com/ably/docs/issues/1165.