### PR TITLE
Fix calling renamed method

### DIFF
--- a/examples/rest/publish.go
+++ b/examples/rest/publish.go
@@ -62,7 +62,7 @@ func restPublish(channel *ably.RESTChannel, message string) {
 
 func restPublishBatch(channel *ably.RESTChannel, message1 string, message2 string) {
 
-	err := channel.PublishBatch(context.Background(), []*ably.Message{
+	err := channel.PublishMultiple(context.Background(), []*ably.Message{
 		{Name: EventName, Data: message1},
 		{Name: EventName, Data: message2},
 	})


### PR DESCRIPTION
This reflects the earlier renaming of [`PublishBatch`](https://github.com/ably/ably-go/pull/303) .