### PR TITLE
Add version 1.17 to our supported Go versions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.13, 1.14, 1.15, 1.16]
+        go-version: [1.13, 1.14, 1.15, 1.16, 1.17]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Add the current latest, 1.17, supported version of Go.