### PR TITLE
Add `ConnectionKey` to message

### DIFF
--- a/ably/proto_message.go
+++ b/ably/proto_message.go
@@ -20,14 +20,15 @@ const (
 
 // Message is what Ably channels send and receive.
 type Message struct {
-	ID           string                 `json:"id,omitempty" codec:"id,omitempty"`
-	ClientID     string                 `json:"clientId,omitempty" codec:"clientId,omitempty"`
-	ConnectionID string                 `json:"connectionId,omitempty" codec:"connectionID,omitempty"`
-	Name         string                 `json:"name,omitempty" codec:"name,omitempty"`
-	Data         interface{}            `json:"data,omitempty" codec:"data,omitempty"`
-	Encoding     string                 `json:"encoding,omitempty" codec:"encoding,omitempty"`
-	Timestamp    int64                  `json:"timestamp,omitempty" codec:"timestamp,omitempty"`
-	Extras       map[string]interface{} `json:"extras,omitempty" codec:"extras,omitempty"`
+	ID            string                 `json:"id,omitempty" codec:"id,omitempty"`
+	ClientID      string                 `json:"clientId,omitempty" codec:"clientId,omitempty"`
+	ConnectionID  string                 `json:"connectionId,omitempty" codec:"connectionID,omitempty"`
+	ConnectionKey string                 `json:"connectionKey,omitempty" codec:"connectionKey,omitempty"`
+	Name          string                 `json:"name,omitempty" codec:"name,omitempty"`
+	Data          interface{}            `json:"data,omitempty" codec:"data,omitempty"`
+	Encoding      string                 `json:"encoding,omitempty" codec:"encoding,omitempty"`
+	Timestamp     int64                  `json:"timestamp,omitempty" codec:"timestamp,omitempty"`
+	Extras        map[string]interface{} `json:"extras,omitempty" codec:"extras,omitempty"`
 }
 
 func (m Message) String() string {


### PR DESCRIPTION
If you are publishing from a REST client and want to prevent one particular realtime client (which has echoMessages set to false) from receiving the message, as if that client was the one that published the message, you can do that by setting the connectionKey.

https://faqs.ably.com/is-it-possible-to-prevent-messages-published-being-echoed-back-to-the-publishing-client