### PR TITLE
Disable flaky tests.

### DIFF
--- a/ably/auth_test.go
+++ b/ably/auth_test.go
@@ -31,6 +31,7 @@ func recorder() (*ablytest.RoundTripRecorder, []ably.ClientOption) {
 }
 
 func TestAuth_BasicAuth(t *testing.T) {
+	t.Skip("FLAKY TEST")
 	rec, extraOpt := recorder()
 	defer rec.Stop()
 	opts := []ably.ClientOption{ably.WithQueryTime(true)}
@@ -593,6 +594,7 @@ func TestAuth_RequestToken_PublishClientID(t *testing.T) {
 }
 
 func TestAuth_ClientID(t *testing.T) {
+	t.Skip("FLAKY TEST")
 	in := make(chan *ably.ProtocolMessage, 16)
 	out := make(chan *ably.ProtocolMessage, 16)
 	app := ablytest.MustSandbox(nil)

--- a/ably/auth_test.go
+++ b/ably/auth_test.go
@@ -31,6 +31,7 @@ func recorder() (*ablytest.RoundTripRecorder, []ably.ClientOption) {
 }
 
 func TestAuth_BasicAuth(t *testing.T) {
+	// Skipping test, see https://github.com/ably/ably-go/issues/438
 	t.Skip("FLAKY TEST")
 	rec, extraOpt := recorder()
 	defer rec.Stop()
@@ -594,6 +595,7 @@ func TestAuth_RequestToken_PublishClientID(t *testing.T) {
 }
 
 func TestAuth_ClientID(t *testing.T) {
+	// Skipping test, see https://github.com/ably/ably-go/issues/438
 	t.Skip("FLAKY TEST")
 	in := make(chan *ably.ProtocolMessage, 16)
 	out := make(chan *ably.ProtocolMessage, 16)

--- a/ably/realtime_conn_spec_test.go
+++ b/ably/realtime_conn_spec_test.go
@@ -123,6 +123,7 @@ func Test_RTN3_ConnectionAutoConnect(t *testing.T) {
 }
 
 func Test_RTN4a_ConnectionEventForStateChange(t *testing.T) {
+	t.Skip("FLAKY TEST")
 	t.Run(fmt.Sprintf("on %s", ably.ConnectionStateConnecting), func(t *testing.T) {
 
 		app, realtime := ablytest.NewRealtime(ably.WithAutoConnect(false))

--- a/ably/realtime_conn_spec_test.go
+++ b/ably/realtime_conn_spec_test.go
@@ -123,6 +123,7 @@ func Test_RTN3_ConnectionAutoConnect(t *testing.T) {
 }
 
 func Test_RTN4a_ConnectionEventForStateChange(t *testing.T) {
+	// Skipping test, see https://github.com/ably/ably-go/issues/438
 	t.Skip("FLAKY TEST")
 	t.Run(fmt.Sprintf("on %s", ably.ConnectionStateConnecting), func(t *testing.T) {
 


### PR DESCRIPTION
The following tests have been seen to flake in CI, this PR disables them.

- Test_RTN4a_ConnectionEventForStateChange
- TestAuth_BasicAuth
- TestAuth_ClientID

https://github.com/ably/ably-go/issues/438 has been created to
investigate fixing them and turning them back on