### PR TITLE
Add connection key to messages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ if err != nil {
 
 // A REST client can publish messages on behalf of a realtime client
 // by providing the connection key of the realtime client.
-err := channel.Publish(ctx, "temperature", "12.7", ably.PublishWithConnectionKey("108yZeOBAB7iva!QQJ2CnCSa6A4ql22-a7443108yZeOBAB7iva"))
+err := channel.Publish(ctx, "temperature", "12.7", ably.PublishWithConnectionKey("ConnectionKeyOfPublisherClientHere"))
 if err != nil {
         panic(err)
 }

--- a/README.md
+++ b/README.md
@@ -224,6 +224,13 @@ err = channel.PublishMultiple(ctx, []*ably.Message{
 if err != nil {
         panic(err)
 }
+
+// A REST client can publish messages on behalf of a realtime client
+// by providing the connection key of the realtime client.
+err := channel.Publish(ctx, "temperature", "12.7", ably.PublishWithConnectionKey("108yZeOBAB7iva!QQJ2CnCSa6A4ql22-a7443108yZeOBAB7iva"))
+if err != nil {
+        panic(err)
+}
 ```
 
 ### Querying the History

--- a/ably/rest_channel.go
+++ b/ably/rest_channel.go
@@ -53,9 +53,16 @@ func newRESTChannel(name string, client *REST) *RESTChannel {
 
 // Publish publishes a message on the channel.
 func (c *RESTChannel) Publish(ctx context.Context, name string, data interface{}) error {
-	msg := data.(Message)
+	//Check to see if data received is of type message.
+	if msg, ok := data.(Message); ok {
+		// Publish the message with connection key.
+		return c.PublishMultiple(ctx, []*Message{
+			{Name: name, Data: data, ConnectionKey: msg.ConnectionKey},
+		})
+	}
+	// Only the name and data are published.
 	return c.PublishMultiple(ctx, []*Message{
-		{Name: name, Data: data, ConnectionKey: msg.ConnectionKey},
+		{Name: name, Data: data},
 	})
 }
 

--- a/ably/rest_channel.go
+++ b/ably/rest_channel.go
@@ -53,8 +53,9 @@ func newRESTChannel(name string, client *REST) *RESTChannel {
 
 // Publish publishes a message on the channel.
 func (c *RESTChannel) Publish(ctx context.Context, name string, data interface{}) error {
+	msg := data.(Message)
 	return c.PublishMultiple(ctx, []*Message{
-		{Name: name, Data: data},
+		{Name: name, Data: data, ConnectionKey: msg.ConnectionKey},
 	})
 }
 


### PR DESCRIPTION
This fixes #442  a customer previously raised a PR to add ConnectionKey to the message. However the value of this new connection key field was never populated, so it still was not possible for a rest client to publish on behalf of a realtime client. This PR populates the connection key when rest messages are published.