### PR TITLE
Fix unit test that always failed when run locally.

### DIFF
--- a/ably/internal/ablyutil/time_test.go
+++ b/ably/internal/ablyutil/time_test.go
@@ -59,6 +59,6 @@ func TestAfterCanceled(t *testing.T) {
 }
 
 func isCloseTo(d time.Duration, to time.Duration) bool {
-	const leeway = 1 * time.Millisecond
+	const leeway = 2 * time.Millisecond
 	return d > to-leeway && d < to+leeway
 }


### PR DESCRIPTION
Fixes #445 
We have a test that compared two times and asserted they were within 1ms of each other. 
The results of this test when run locally was it failed as the times were about ~1.01ms of each other.
Have increased the tolerance of this check to 2ms. This test passes locally now.