### PR TITLE
Deprecate RESTChannel.PublishMultipleWithOptions

### DIFF
--- a/ably/rest_channel.go
+++ b/ably/rest_channel.go
@@ -56,13 +56,12 @@ func (c *RESTChannel) Publish(ctx context.Context, name string, data interface{}
 	return c.PublishMultiple(ctx, []*Message{{Name: name, Data: data}}, options...)
 }
 
-// PublishMultiple publishes multiple messages in a batch.
-func (c *RESTChannel) PublishMultiple(ctx context.Context, messages []*Message, options ...PublishMultipleOption) error {
-	return c.PublishMultipleWithOptions(ctx, messages, options...)
-}
-
 // PublishMultipleOption is an optional parameter for
-// RESTChannel.PublishMultipleWithOptions.
+// RESTChannel.Publish and RESTChannel.PublishMultiple.
+//
+// TODO: This started out as just an option for PublishMultiple, but has since
+//       been added as an option for Publish too, so it should be renamed to
+//       PublishOption when we perform the next major version bump to 2.x.x.
 type PublishMultipleOption func(*publishMultipleOptions)
 
 type publishMultipleOptions struct {
@@ -77,15 +76,24 @@ func PublishWithConnectionKey(connectionKey string) PublishMultipleOption {
 	}
 }
 
-// Params adds query parameters to the resulting HTTP request to the REST API.
-func PublishMultipleWithParams(params map[string]string) PublishMultipleOption {
+// PublishWithParams adds query parameters to the resulting HTTP request to the REST API.
+func PublishWithParams(params map[string]string) PublishMultipleOption {
 	return func(options *publishMultipleOptions) {
 		options.params = params
 	}
 }
 
-// PublishMultipleWithOptions is PublishMultiple with optional parameters.
-func (c *RESTChannel) PublishMultipleWithOptions(ctx context.Context, messages []*Message, options ...PublishMultipleOption) error {
+// PublishMultipleWithParams is the same as PublishWithParams.
+//
+// Deprecated: Use PublishWithParams instead.
+//
+// TODO: Remove this in the next major version bump to 2.x.x.
+func PublishMultipleWithParams(params map[string]string) PublishMultipleOption {
+	return PublishWithParams(params)
+}
+
+// PublishMultiple publishes multiple messages in a batch.
+func (c *RESTChannel) PublishMultiple(ctx context.Context, messages []*Message, options ...PublishMultipleOption) error {
 	var publishOpts publishMultipleOptions
 	for _, o := range options {
 		o(&publishOpts)
@@ -149,6 +157,15 @@ func (c *RESTChannel) PublishMultipleWithOptions(ctx context.Context, messages [
 		return err
 	}
 	return res.Body.Close()
+}
+
+// PublishMultipleWithOptions is the same as PublishMultiple.
+//
+// Deprecated: Use PublishMultiple instead.
+//
+// TODO: Remove this in the next major version bump to 2.x.x.
+func (c *RESTChannel) PublishMultipleWithOptions(ctx context.Context, messages []*Message, options ...PublishMultipleOption) error {
+	return c.PublishMultiple(ctx, messages, options...)
 }
 
 // History gives the channel's message history.


### PR DESCRIPTION
This deprecates `RESTChannel.PublishMultipleWithOptions` in favour of `RESTChannel.PublishMultiple` which now also accepts options (see https://github.com/ably/ably-go/pull/443), making the two identical.

I've also deprecated `PublishMultipleWithParams` in favour of `PublishWithParams`, and added a TODO to rename `PublishMultipleOption` to `PublishOption` in the next major version bump to 2.x.x.

For more context, see https://github.com/ably/ably-go/pull/443#discussion_r802625559.