### PR TITLE
Remove useless switch

### DIFF
--- a/ably/realtime_presence.go
+++ b/ably/realtime_presence.go
@@ -186,20 +186,7 @@ func (pres *RealtimePresence) processIncomingMessage(msg *protocolMessage, syncS
 	msg.Count = len(messages)
 	msg.Presence = messages
 	for _, msg := range msg.Presence {
-		var action PresenceAction
-		switch msg.Action {
-		case PresenceActionAbsent:
-			action = PresenceActionAbsent
-		case PresenceActionPresent:
-			action = PresenceActionPresent
-		case PresenceActionEnter:
-			action = PresenceActionEnter
-		case PresenceActionLeave:
-			action = PresenceActionLeave
-		case PresenceActionUpdate:
-			action = PresenceActionUpdate
-		}
-		pres.messageEmitter.Emit(action, (*subscriptionPresenceMessage)(msg))
+		pres.messageEmitter.Emit(msg.Action, (*subscriptionPresenceMessage)(msg))
 	}
 }
 


### PR DESCRIPTION
This switch just matched the presence event and for each case set a new
varable to whatever the presence event was. There's no need to swtich as
the new varable will always equal the original.