### PR TITLE
Fix hang when joining existing channel with no presence

### DIFF
--- a/ably/realtime_presence.go
+++ b/ably/realtime_presence.go
@@ -96,7 +96,7 @@ func (pres *RealtimePresence) onAttach(msg *protocolMessage) {
 	pres.mtx.Lock()
 	defer pres.mtx.Unlock()
 	switch {
-	case msg.Flags.Has(flagHasPresence) || serial != "":
+	case msg.Flags.Has(flagHasPresence):
 		pres.syncStart(serial)
 	case pres.syncState == syncInitial:
 		pres.syncState = syncComplete


### PR DESCRIPTION
When getting a channel the sync mutex would be unconditionally locked to
wait for sync. But sync's are only sent if the channel is new or has
presence.

This means the mutex would remain locked forever waiting for a sync that
isn't coming.