### PR TITLE
Remove named returns to increase code readability.

### DIFF
--- a/ably/realtime_channel.go
+++ b/ably/realtime_channel.go
@@ -427,8 +427,8 @@ func (*subscriptionMessage) isEmitterData() {}
 //
 // See package-level documentation on Event Emitter for details about
 // messages dispatch.
-func (c *RealtimeChannel) Subscribe(ctx context.Context, name string, handle func(*Message)) (unsubscribe func(), err error) {
-	unsubscribe = c.messageEmitter.On(subscriptionName(name), func(message emitterData) {
+func (c *RealtimeChannel) Subscribe(ctx context.Context, name string, handle func(*Message)) (func(), error) {
+	unsubscribe := c.messageEmitter.On(subscriptionName(name), func(message emitterData) {
 		handle((*Message)(message.(*subscriptionMessage)))
 	})
 	res, err := c.attach()
@@ -454,8 +454,8 @@ func (c *RealtimeChannel) Subscribe(ctx context.Context, name string, handle fun
 //
 // See package-level documentation on Event Emitter for details about
 // messages dispatch.
-func (c *RealtimeChannel) SubscribeAll(ctx context.Context, handle func(*Message)) (unsubscribe func(), err error) {
-	unsubscribe = c.messageEmitter.OnAll(func(message emitterData) {
+func (c *RealtimeChannel) SubscribeAll(ctx context.Context, handle func(*Message)) (func(), error) {
+	unsubscribe := c.messageEmitter.OnAll(func(message emitterData) {
 		handle((*Message)(message.(*subscriptionMessage)))
 	})
 	res, err := c.attach()

--- a/ably/realtime_presence.go
+++ b/ably/realtime_presence.go
@@ -268,8 +268,8 @@ func (*subscriptionPresenceMessage) isEmitterData() {}
 //
 // See package-level documentation on Event Emitter for details about
 // messages dispatch.
-func (pres *RealtimePresence) Subscribe(ctx context.Context, action PresenceAction, handle func(*PresenceMessage)) (unsubscribe func(), err error) {
-	unsubscribe = pres.messageEmitter.On(action, func(message emitterData) {
+func (pres *RealtimePresence) Subscribe(ctx context.Context, action PresenceAction, handle func(*PresenceMessage)) (func(), error) {
+	unsubscribe := pres.messageEmitter.On(action, func(message emitterData) {
 		handle((*PresenceMessage)(message.(*subscriptionPresenceMessage)))
 	})
 	res, err := pres.channel.attach()
@@ -295,8 +295,8 @@ func (pres *RealtimePresence) Subscribe(ctx context.Context, action PresenceActi
 //
 // See package-level documentation on Event Emitter for details about
 // messages dispatch.
-func (pres *RealtimePresence) SubscribeAll(ctx context.Context, handle func(*PresenceMessage)) (unsubscribe func(), err error) {
-	unsubscribe = pres.messageEmitter.OnAll(func(message emitterData) {
+func (pres *RealtimePresence) SubscribeAll(ctx context.Context, handle func(*PresenceMessage)) (func(), error) {
+	unsubscribe := pres.messageEmitter.OnAll(func(message emitterData) {
 		handle((*PresenceMessage)(message.(*subscriptionPresenceMessage)))
 	})
 	res, err := pres.channel.attach()


### PR DESCRIPTION
Small chore to remove some named returns.
A few reasons not to use them can be found at https://dave.cheney.net/practical-go/presentations/gophercon-israel.html#_avoid_named_return_values