### PR TITLE
Handle errors in Request()

### DIFF
--- a/ably/http_paginated_response_integration_test.go
+++ b/ably/http_paginated_response_integration_test.go
@@ -24,7 +24,6 @@ func TestHTTPPaginatedResponse(t *testing.T) {
 	client, err := ably.NewREST(opts...)
 	assert.NoError(t, err)
 	t.Run("request_time", func(t *testing.T) {
-
 		res, err := client.Request("get", "/time").Pages(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusOK, res.StatusCode(),
@@ -39,7 +38,6 @@ func TestHTTPPaginatedResponse(t *testing.T) {
 	})
 
 	t.Run("request_404", func(t *testing.T) {
-
 		res, err := client.Request("get", "/keys/ablyjs.test/requestToken").Pages(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusNotFound, res.StatusCode(),

--- a/ably/http_paginated_response_integration_test.go
+++ b/ably/http_paginated_response_integration_test.go
@@ -16,6 +16,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestHTTPPaginatedFallback(t *testing.T) {
+	app, err := ablytest.NewSandbox(nil)
+	assert.NoError(t, err)
+	defer app.Close()
+	opts := app.Options(ably.WithUseBinaryProtocol(false), ably.WithRESTHost("ably.invalid"), ably.WithFallbackHostsUseDefault(true))
+	client, err := ably.NewREST(opts...)
+	assert.NoError(t, err)
+	t.Run("request_time", func(t *testing.T) {
+		_, err := client.Request("get", "/time").Pages(context.Background())
+		assert.Error(t, err)
+	})
+}
+
 func TestHTTPPaginatedResponse(t *testing.T) {
 	app, err := ablytest.NewSandbox(nil)
 	assert.NoError(t, err)

--- a/ably/rest_client.go
+++ b/ably/rest_client.go
@@ -629,11 +629,11 @@ func (c *REST) doWithHandle(ctx context.Context, r *request, handle func(*http.R
 		c.log.Verbose("RestClient: enabling httptrace")
 	}
 	resp, err := c.opts.httpclient().Do(req)
-	if err != nil {
+	if err == nil {
+		resp, err = handle(resp, r.Out)
+	} else {
 		c.log.Error("RestClient: failed sending a request ", err)
-		return nil, newError(ErrInternalError, err)
 	}
-	resp, err = handle(resp, r.Out)
 	if err != nil {
 		c.log.Error("RestClient: error handling response: ", err)
 		if e, ok := err.(*ErrorInfo); ok {
@@ -676,11 +676,11 @@ func (c *REST) doWithHandle(ctx context.Context, r *request, handle func(*http.R
 						req.Host = ""
 						req.Header.Set(hostHeader, h)
 						resp, err := c.opts.httpclient().Do(req)
-						if err != nil {
+						if err == nil {
+							resp, err = handle(resp, r.Out)
+						} else {
 							c.log.Error("RestClient: failed sending a request to a fallback host", err)
-							return nil, newError(ErrInternalError, err)
 						}
-						resp, err = handle(resp, r.Out)
 						if err != nil {
 							c.log.Error("RestClient: error handling response: ", err)
 							if iteration == maxLimit-1 {


### PR DESCRIPTION
Currently errors like 500 response codes are not checked and don't
return an error.

Request is still broken but may as well push this fix as I've moved to other stuff for the time being.