### PR TITLE
Split integration tests into separate workflow

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,6 +1,3 @@
-# Based upon:
-#   https://github.com/actions/starter-workflows/blob/main/ci/go.yml
-
 on:
   pull_request:
   push:
@@ -8,13 +5,14 @@ on:
       - main
 
 jobs:
-  check:
+  integration-test:
 
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         go-version: [1.17, 1.18]
+        protocol: ['json', 'msgpack']
 
     steps:
       - uses: actions/checkout@v2
@@ -29,19 +27,13 @@ jobs:
       - name: Download Packages
         run: go get -t -v ./ably/...
 
-      - name: Vet
-        run: go vet ./ably/... ./scripts/...
-
-      - name: Ensure generated code is up-to-date
-        run: scripts/ci-generate.sh
-
       - name: Install go-junit-report
         run: go install github.com/jstemmer/go-junit-report@latest
 
-      - name: Unit Tests
+      - name: Integration Tests with ${{ matrix.protocol }} Protocol
         run: |
           set -o pipefail
-          go test -v -tags=unit ./... |& tee >(~/go/bin/go-junit-report > unit.junit)
+          scripts/test.sh --protocol application/${{ matrix.protocol == 'json' && 'json' || 'x-msgpack' }} |& tee >(~/go/bin/go-junit-report > ${{ matrix.protocol }}-integration.junit)
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
Moves the integration tests into a separate workflow file. Naming convention comes from our [SDK engineering guidance](https://github.com/ably/engineering/blob/main/sdk/github.md#filenames).

This has two main advantages over keeping them in the check workflow:
1. Tests will run in parallel on separate github runners so CI runs should be much faster. Based on the first few runs it seems to have gone from on average of about 35 minutes down to about 17.
2. Will allow us to re-run integration tests for one protocol without having to re-run tests for the other protocol if they're already passing, which should mean much less re-runs required to see all tests passing.

#### For reviewers
- The arcane syntax used in integration-test.yml line 36 comes from https://github.com/actions/runner/issues/409#issuecomment-727565588 which is a workaround for the fact that github workflow syntax doesn't have a proper ternary if statement. An alternative could be to move that logic into a shell script file and just pass in `${{ matrix.protocol }}` as an arg. Leave a comment if you think this would be worth doing.
- I'm not all that familiar with how test-observability works. The uploading seems to still work as expected but bear in mind that I might have inadvertently changed some part of the existing setup.