### PR TITLE
log request time outs when attempting retry

### DIFF
--- a/ablytest/sandbox.go
+++ b/ablytest/sandbox.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -164,6 +165,7 @@ func NewSandboxWIthEnv(config *Config, env string) (*Sandbox, error) {
 
 		if err != nil {
 			// Timeout. Back off before allowing another attempt.
+			log.Println("warn: request timeout, attempting retry")
 			time.Sleep(retryInterval)
 			retryInterval *= 2
 		} else {


### PR DESCRIPTION
Adding logging so we can see when tests are retried due to timeout. 

Some of our flakey tests might only be flaking when requests are retried. This logging will show when a request is retried.