### PR TITLE
Use the correct release of the test observability action

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: ably-labs/test-observability-action@main
+        uses: ably/test-observability-action@v1
         with:
           server-url: 'https://test-observability.herokuapp.com'
           server-auth: ${{ secrets.TEST_OBSERVABILITY_SERVER_AUTH_KEY }}


### PR DESCRIPTION
I noticed that this workflow was still using the archived and obsoleted instance of this action from the `ably-labs` org.