### PR TITLE
Publish godoc for every commit

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,11 +29,11 @@ jobs:
           go get github.com/johnstarich/go/gopages
           go install github.com/johnstarich/go/gopages
 
-      - uses: ably/sdk-upload-action@v1
-        id: sdk-upload-prempt
-        with:
-          mode: preempt
-          artifactName: godoc
+#      - uses: ably/sdk-upload-action@v1
+#        id: sdk-upload-prempt
+#        with:
+#          mode: preempt
+#          artifactName: godoc
 
       - name: Build Documentation
         run: >
@@ -41,7 +41,8 @@ jobs:
           -source-link "https://github.com/ably/ably-go/blob/${{ github.sha }}/ably/{{slice .Path 5}}{{if .Line}}#L{{.Line}}{{end}}"
           -brand-description "Go client library for Ably realtime messaging service."
           -brand-title "Ably Go SDK"
-          -base $BASE_URL
+          -base ./../../../../..
+#          -base $BASE_URL
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Download Packages
         run: |
           go install golang.org/x/tools/cmd/godoc@latest
+          go get github.com/johnstarich/go/gopages
           go install github.com/johnstarich/go/gopages
 
       - name: Build Documentation

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-region: eu-west-2
-          role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-js
+          role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-go
           role-session-name: "${{ github.run_id }}-${{ github.run_number }}"
 
       - name: Upload Documentation

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build Documentation
         run: >
           gopages
-          -source-link "https://github.com/ably/ably-go/blob/".${{ github.sha }}."/ably/{{slice .Path 5}}{{if .Line}}#L{{.Line}}{{end}}"
+          -source-link "https://github.com/ably/ably-go/blob/${{ github.sha }}/ably/{{slice .Path 5}}{{if .Line}}#L{{.Line}}{{end}}"
           -brand-description "Go client library for Ably realtime messaging service."
           -brand-title "Ably Go SDK"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build Documentation
         run: >
           gopages
-          -source-link "https://github.com/ably/ably-go/blob/${{ env.GITHUB_SHA }}/ably/{{slice .Path 5}}{{if .Line}}#L{{.Line}}{{end}}"
+          -source-link "https://github.com/ably/ably-go/blob/".${{ github.sha }}."/ably/{{slice .Path 5}}{{if .Line}}#L{{.Line}}{{end}}"
           -brand-description "Go client library for Ably realtime messaging service."
           -brand-title "Ably Go SDK"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Download Packages
         run: |
           go install golang.org/x/tools/cmd/godoc@v0.3.0
-          go install github.com/johnstarich/go/gopages@v0.1.11
+          go install github.com/johnstarich/go/gopages@v0.1.16
 
 #      - uses: ably/sdk-upload-action@v1
 #        id: sdk-upload-prempt

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,50 @@
+name: API Reference
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      deployments: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.19
+
+      - name: Download Packages
+        run: |
+          go install golang.org/x/tools/cmd/godoc@latest
+          go install github.com/johnstarich/go/gopages
+
+      - name: Build Documentation
+        run: >
+          gopages
+          -source-link "https://github.com/ably/ably-go/blob/${{ env.GITHUB_SHA }}/ably/{{slice .Path 5}}{{if .Line}}#L{{.Line}}{{end}}"
+          -brand-description "Go client library for Ably realtime messaging service."
+          -brand-title "Ably Go SDK"
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: eu-west-2
+          role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-js
+          role-session-name: "${{ github.run_id }}-${{ github.run_number }}"
+
+      - name: Upload Documentation
+        uses: ably/sdk-upload-action@v1
+        with:
+          sourcePath: dist
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          artifactName: godoc

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,9 +25,9 @@ jobs:
 
       - name: Download Packages
         run: |
-          go install golang.org/x/tools/cmd/godoc@latest
-          go get github.com/johnstarich/go/gopages
-          go install github.com/johnstarich/go/gopages
+          go install golang.org/x/tools/cmd/godoc@v0.3.0
+          go get github.com/johnstarich/go/gopages@v0.1.11
+          go install github.com/johnstarich/go/gopages@v0.1.11
 
 #      - uses: ably/sdk-upload-action@v1
 #        id: sdk-upload-prempt

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
           -source-link "https://github.com/ably/ably-go/blob/${{ github.sha }}/ably/{{slice .Path 5}}{{if .Line}}#L{{.Line}}{{end}}"
           -brand-description "Go client library for Ably realtime messaging service."
           -brand-title "Ably Go SDK"
-          -base ./../../../../
+          -base ./../../../..
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,12 +28,6 @@ jobs:
           go install golang.org/x/tools/cmd/godoc@v0.3.0
           go install github.com/johnstarich/go/gopages@v0.1.16
 
-#      - uses: ably/sdk-upload-action@v1
-#        id: sdk-upload-prempt
-#        with:
-#          mode: preempt
-#          artifactName: godoc
-
       - name: Build Documentation
         run: >
           gopages
@@ -41,7 +35,6 @@ jobs:
           -brand-description "Go client library for Ably realtime messaging service."
           -brand-title "Ably Go SDK"
           -base ./../../../../..
-#          -base $BASE_URL
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - '*'
+      - 'v*'
 
 jobs:
   build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Download Packages
         run: |
           go install golang.org/x/tools/cmd/godoc@v0.3.0
-          go get github.com/johnstarich/go/gopages@v0.1.11
           go install github.com/johnstarich/go/gopages@v0.1.11
 
 #      - uses: ably/sdk-upload-action@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,13 +29,19 @@ jobs:
           go get github.com/johnstarich/go/gopages
           go install github.com/johnstarich/go/gopages
 
+      - uses: ably/sdk-upload-action@v1
+        id: sdk-upload-prempt
+        with:
+          mode: preempt
+          artifactName: godoc
+
       - name: Build Documentation
         run: >
           gopages
           -source-link "https://github.com/ably/ably-go/blob/${{ github.sha }}/ably/{{slice .Path 5}}{{if .Line}}#L{{.Line}}{{end}}"
           -brand-description "Go client library for Ably realtime messaging service."
           -brand-title "Ably Go SDK"
-          -base ./../../../..
+          -base $BASE_URL
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,6 +35,7 @@ jobs:
           -source-link "https://github.com/ably/ably-go/blob/${{ github.sha }}/ably/{{slice .Path 5}}{{if .Line}}#L{{.Line}}{{end}}"
           -brand-description "Go client library for Ably realtime messaging service."
           -brand-title "Ably Go SDK"
+          -base ./../../../../
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
- Added `docs.yml` github workflow file.
- Added steps to generate static html site and upload the same on ABLY AWS BUCKET.
- Fixed #559 
- Fixed https://github.com/ably/ably-go/issues/347

Update - Fixing styling for godoc depends on -> https://github.com/ably/sdk-upload-action/issues/32