### PR TITLE
Add status badge for integration test workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ## [Ably Go](https://ably.com/)
 
 [![.github/workflows/check.yml](https://github.com/ably/ably-go/actions/workflows/check.yml/badge.svg)](https://github.com/ably/ably-go/actions/workflows/check.yml)
+[![.github/workflows/integration-test.yml](https://github.com/ably/ably-go/actions/workflows/integration-test.yml/badge.svg)](https://github.com/ably/ably-go/actions/workflows/integration-test.yml)
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/ably/ably-go/ably.svg)](https://pkg.go.dev/github.com/ably/ably-go/ably)
 


### PR DESCRIPTION
I made this quick edit in the GitHub UI and it's committed an unrelated change (probably line endings related) to the end of the readme. Should be harmless.