### PR TITLE
Go 1.20 is out, so we should test against it, and remove 1.18

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.18, 1.19]
+        go-version: [1.19, 1.20]
 
     steps:
       - uses: actions/checkout@v2
@@ -30,7 +30,6 @@ jobs:
         run: go get -t -v ./ably/...
       
       - name: Format
-        if: matrix.go-version != '1.18'
         run: if [ "$(gofmt -l . | wc -l)" -gt 0 ]; then exit 1; fi
 
       - name: Vet

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.19, 1.20]
+        go-version: ['1.19', '1.20']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.19, 1.20]
+        go-version: ['1.19', '1.20']
         protocol: ['json', 'msgpack']
 
     steps:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.18, 1.19]
+        go-version: [1.19, 1.20]
         protocol: ['json', 'msgpack']
 
     steps:


### PR DESCRIPTION
See
https://github.com/ably/ably-go#supported-versions-of-go
Whenever a new version of Go is released, Ably adds support for that version. The [Go Release Policy](https://golang.org/doc/devel/release#policy) supports the last two major versions. This SDK follows the same policy of supporting the last two major versions of Go.