### PR TITLE
add agents option

### DIFF
--- a/ably/export_test.go
+++ b/ably/export_test.go
@@ -269,7 +269,7 @@ func ChannelModeToFlag(mode ChannelMode) ProtoFlag {
 }
 
 func DialWebsocket(proto string, u *url.URL, timeout time.Duration) (Conn, error) {
-	return dialWebsocket(proto, u, timeout)
+	return dialWebsocket(proto, u, timeout, nil)
 }
 
 func NewCBCCipher(opts CipherParams) (*cbcCipher, error) {

--- a/ably/options.go
+++ b/ably/options.go
@@ -390,6 +390,10 @@ type clientOptions struct {
 	Now   func() time.Time
 	After func(context.Context, time.Duration) <-chan time.Time
 
+	// Product/version key-value pairs to include in the agent library
+	// identifiers. This must only be used by Ably-authored SDKs (RSC7d6).
+	Agents map[string]string
+
 	// LogLevel controls the verbosity of the logs output from the library.
 	// Levels include verbose, debug, info, warn and error.
 	// platform specific (TO3b)
@@ -1067,6 +1071,14 @@ func WithLogHandler(handler Logger) ClientOption {
 func WithLogLevel(level LogLevel) ClientOption {
 	return func(os *clientOptions) {
 		os.LogLevel = level
+	}
+}
+
+// WithAgents is used to add product/version key-value pairs to include in the
+// agent library identifiers. This must only be used by Ably-authored SDKs.
+func WithAgents(agents map[string]string) ClientOption {
+	return func(os *clientOptions) {
+		os.Agents = agents
 	}
 }
 

--- a/ably/proto_http.go
+++ b/ably/proto_http.go
@@ -3,6 +3,7 @@ package ably
 import (
 	"fmt"
 	"runtime"
+	"strings"
 )
 
 // constants for rsc7
@@ -23,11 +24,24 @@ var goRuntimeIdentifier = func() string {
 	return fmt.Sprintf("%s/%s", libraryName, runtime.Version()[2:])
 }()
 
-var ablyAgentIdentifier = func() string {
-	osIdentifier := goOSIdentifier()
-	if empty(osIdentifier) {
-		return fmt.Sprintf("%s %s", ablySDKIdentifier, goRuntimeIdentifier)
-	} else {
-		return fmt.Sprintf("%s %s %s", ablySDKIdentifier, goRuntimeIdentifier, osIdentifier)
+func ablyAgentIdentifier(agents map[string]string) string {
+	identifiers := []string{
+		ablySDKIdentifier,
+		goRuntimeIdentifier,
 	}
-}()
+
+	osIdentifier := goOSIdentifier()
+	if !empty(osIdentifier) {
+		identifiers = append(identifiers, osIdentifier)
+	}
+
+	for product, version := range agents {
+		if empty(version) {
+			identifiers = append(identifiers, product)
+		} else {
+			identifiers = append(identifiers, product+"/"+version)
+		}
+	}
+
+	return strings.Join(identifiers, " ")
+}

--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -133,7 +133,7 @@ func (c *Connection) dial(proto string, u *url.URL) (conn conn, err error) {
 	if c.opts.Dial != nil {
 		conn, err = c.opts.Dial(proto, u, timeout)
 	} else {
-		conn, err = dialWebsocket(proto, u, timeout)
+		conn, err = dialWebsocket(proto, u, timeout, c.opts.Agents)
 	}
 	if err != nil {
 		c.log().Debugf("Dial Failed in %v with %v", time.Since(start), err)

--- a/ably/rest_client.go
+++ b/ably/rest_client.go
@@ -826,7 +826,7 @@ func (c *REST) newHTTPRequest(ctx context.Context, r *request) (*http.Request, e
 	}
 	req.Header.Set("Accept", protocol) //spec RSC19c
 	req.Header.Set(ablyVersionHeader, ablyVersion)
-	req.Header.Set(ablyAgentHeader, ablyAgentIdentifier)
+	req.Header.Set(ablyAgentHeader, ablyAgentIdentifier(c.opts.Agents))
 	if c.opts.ClientID != "" && c.Auth.method == authBasic {
 		// References RSA7e2
 		h := base64.StdEncoding.EncodeToString([]byte(c.opts.ClientID))

--- a/ably/websocket.go
+++ b/ably/websocket.go
@@ -77,7 +77,7 @@ func (ws *websocketConn) Close() error {
 	return ws.conn.Close(websocket.StatusNormalClosure, "")
 }
 
-func dialWebsocket(proto string, u *url.URL, timeout time.Duration) (*websocketConn, error) {
+func dialWebsocket(proto string, u *url.URL, timeout time.Duration, agents map[string]string) (*websocketConn, error) {
 	ws := &websocketConn{}
 	switch proto {
 	case "application/json":
@@ -88,7 +88,7 @@ func dialWebsocket(proto string, u *url.URL, timeout time.Duration) (*websocketC
 		return nil, errors.New(`invalid protocol "` + proto + `"`)
 	}
 	// Starts a raw websocket connection with server
-	conn, err := dialWebsocketTimeout(u.String(), "https://"+u.Host, timeout)
+	conn, err := dialWebsocketTimeout(u.String(), "https://"+u.Host, timeout, agents)
 	if err != nil {
 		return nil, err
 	}
@@ -97,13 +97,13 @@ func dialWebsocket(proto string, u *url.URL, timeout time.Duration) (*websocketC
 }
 
 // dialWebsocketTimeout dials the websocket with a timeout.
-func dialWebsocketTimeout(uri, origin string, timeout time.Duration) (*websocket.Conn, error) {
+func dialWebsocketTimeout(uri, origin string, timeout time.Duration, agents map[string]string) (*websocket.Conn, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	var ops websocket.DialOptions
 	ops.HTTPHeader = make(http.Header)
-	ops.HTTPHeader.Add(ablyAgentHeader, ablyAgentIdentifier)
+	ops.HTTPHeader.Add(ablyAgentHeader, ablyAgentIdentifier(agents))
 
 	c, _, err := websocket.Dial(ctx, uri, &ops)
 

--- a/ably/websocket_internal_test.go
+++ b/ably/websocket_internal_test.go
@@ -119,7 +119,7 @@ func TestWebsocketDial(t *testing.T) {
 	for testName, test := range tests {
 		t.Run(testName, func(t *testing.T) {
 
-			result, err := dialWebsocket(test.dialProtocol, testServerURL, timeout)
+			result, err := dialWebsocket(test.dialProtocol, testServerURL, timeout, nil)
 			assert.Equal(t, test.expectedErr, err)
 
 			if result != nil {
@@ -159,7 +159,7 @@ func TestWebsocketSendAndReceive(t *testing.T) {
 	for testName, test := range tests {
 		t.Run(testName, func(t *testing.T) {
 
-			ws, err := dialWebsocket(test.dialProtocol, testServerURL, timeout)
+			ws, err := dialWebsocket(test.dialProtocol, testServerURL, timeout, nil)
 			assert.NoError(t, err)
 			msg := protocolMessage{
 				Messages: []*Message{{Name: "temperature", Data: "22.7"}},


### PR DESCRIPTION
Add an optional agents option that includes product/version key-value pairs to include in the library agents identifier, as described by RSC7d6.

Note if the OS cannot be identified, instead of an empty string this uses `unknown` to ensure the agents are always 4th in the header.