### PR TITLE
Feature/filtered subscription

### DIFF
--- a/ably/internal/ablyutil/regex.go
+++ b/ably/internal/ablyutil/regex.go
@@ -1,0 +1,39 @@
+package ablyutil
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+// derivedChannelMatch provides the qualifyingParam and channelName from a channel regex match for derived channels
+type derivedChannelMatch struct {
+	QualifierParam string
+	ChannelName    string
+}
+
+// This regex check is to retain existing channel params if any e.g [?rewind=1]foo to
+// [filter=xyz?rewind=1]foo. This is to keep channel compatibility around use of
+// channel params that work with derived channels.
+func MatchDerivedChannel(name string) (*derivedChannelMatch, error) {
+	regex := `^(\[([^?]*)(?:(.*))\])?(.+)$`
+	r, _ := regexp.Compile(regex)
+	match := r.FindStringSubmatch(name)
+
+	if len(match) == 0 || len(match) < 5 {
+		err := errors.New("regex match failed")
+		return nil, err
+	}
+	// Fail if there is already a channel qualifier,
+	// eg [meta]foo should fail instead of just overriding with [filter=xyz]foo
+	if len(match[2]) > 0 {
+		err := fmt.Errorf("cannot use a derived option with a %s channel", match[2])
+		return nil, err
+	}
+
+	// Return match values to be added to derive channel quantifier.
+	return &derivedChannelMatch{
+		QualifierParam: match[3],
+		ChannelName:    match[4],
+	}, nil
+}

--- a/ably/internal/ablyutil/regex.go
+++ b/ably/internal/ablyutil/regex.go
@@ -19,6 +19,7 @@ func MatchDerivedChannel(name string) (*derivedChannelMatch, error) {
 	regex := `^(\[([^?]*)(?:(.*))\])?(.+)$`
 	r, err := regexp.Compile(regex)
 	if err != nil {
+		err := errors.New("regex compilation failed")
 		return nil, err
 	}
 	match := r.FindStringSubmatch(name)

--- a/ably/internal/ablyutil/regex.go
+++ b/ably/internal/ablyutil/regex.go
@@ -17,7 +17,10 @@ type derivedChannelMatch struct {
 // channel params that work with derived channels.
 func MatchDerivedChannel(name string) (*derivedChannelMatch, error) {
 	regex := `^(\[([^?]*)(?:(.*))\])?(.+)$`
-	r, _ := regexp.Compile(regex)
+	r, err := regexp.Compile(regex)
+	if err != nil {
+		return nil, err
+	}
 	match := r.FindStringSubmatch(name)
 
 	if len(match) == 0 || len(match) < 5 {

--- a/ably/internal/ablyutil/regex_test.go
+++ b/ably/internal/ablyutil/regex_test.go
@@ -1,0 +1,35 @@
+//go:build !integration
+// +build !integration
+
+package ablyutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchDerivedChannel(t *testing.T) {
+	var channels = []struct {
+		name  string
+		input string
+		want  *derivedChannelMatch
+	}{
+		{"valid with base channel name", "foo", &derivedChannelMatch{QualifierParam: "", ChannelName: "foo"}},
+		{"valid with base channel namespace", "foo:bar", &derivedChannelMatch{QualifierParam: "", ChannelName: "foo:bar"}},
+		{"valid with existing qualifying option", "[?rewind=1]foo", &derivedChannelMatch{QualifierParam: "?rewind=1", ChannelName: "foo"}},
+		{"fail with wrong channel option param", "[param=1]foo", nil},
+		{"fail with invalid qualifying option", "[meta]foo", nil},
+		{"fail with invalid regex match", "[failed-match]foo", nil},
+	}
+
+	for _, tt := range channels {
+		t.Run(tt.name, func(t *testing.T) {
+			match, err := MatchDerivedChannel(tt.input)
+			if err != nil {
+				assert.Error(t, err, "An error is expected for the regex match")
+			}
+			assert.Equal(t, tt.want, match, "invalid output received")
+		})
+	}
+}

--- a/ably/internal/ablyutil/regex_test.go
+++ b/ably/internal/ablyutil/regex_test.go
@@ -18,6 +18,8 @@ func TestMatchDerivedChannel(t *testing.T) {
 		{"valid with base channel name", "foo", &derivedChannelMatch{QualifierParam: "", ChannelName: "foo"}},
 		{"valid with base channel namespace", "foo:bar", &derivedChannelMatch{QualifierParam: "", ChannelName: "foo:bar"}},
 		{"valid with existing qualifying option", "[?rewind=1]foo", &derivedChannelMatch{QualifierParam: "?rewind=1", ChannelName: "foo"}},
+		{"valid with existing qualifying option with channel namespace", "[?rewind=1]foo:bar", &derivedChannelMatch{QualifierParam: "?rewind=1", ChannelName: "foo:bar"}},
+		{"fail with invalid param with channel namespace", "[param:invalid]foo:bar", nil},
 		{"fail with wrong channel option param", "[param=1]foo", nil},
 		{"fail with invalid qualifying option", "[meta]foo", nil},
 		{"fail with invalid regex match", "[failed-match]foo", nil},

--- a/ably/realtime_channel.go
+++ b/ably/realtime_channel.go
@@ -58,7 +58,7 @@ type DeriveOptions struct {
 
 type derivedChannelMatch struct {
 	qualifierParam string
-	chanelName     string
+	channelName    string
 }
 
 // ChannelWithCipherKey is a constructor that takes private key as a argument.
@@ -132,7 +132,7 @@ func (ch *RealtimeChannels) GetDerived(name string, deriveOptions DeriveOptions,
 			return nil, err
 		}
 		filter := url.PathEscape(deriveOptions.Filter)
-		name = fmt.Sprintf("[filter=%s%s]%s", filter, match.qualifierParam, match.chanelName)
+		name = fmt.Sprintf("[filter=%s%s]%s", filter, match.qualifierParam, match.channelName)
 	}
 	return ch.Get(name, options...), nil
 }
@@ -152,7 +152,7 @@ func matchDerivedChannel(name string) (*derivedChannelMatch, error) {
 	}
 	return &derivedChannelMatch{
 		qualifierParam: match[3],
-		chanelName:     match[4],
+		channelName:    match[4],
 	}, nil
 }
 

--- a/ably/realtime_channel.go
+++ b/ably/realtime_channel.go
@@ -2,11 +2,10 @@ package ably
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
-	"net/url"
 	"sort"
-	"strings"
 	"sync"
 
 	"github.com/ably/ably-go/ably/internal/ablyutil"
@@ -131,9 +130,7 @@ func (ch *RealtimeChannels) GetDerived(name string, deriveOptions DeriveOptions,
 		if err != nil {
 			return nil, newError(40010, err)
 		}
-		filter := url.PathEscape(deriveOptions.Filter)
-		// Replacing ":" with "%3A" because url.PathEscape doesn't decode ":" characters
-		filter = strings.Replace(filter, ":", "%3A", -1)
+		filter := base64.StdEncoding.EncodeToString([]byte(deriveOptions.Filter))
 		name = fmt.Sprintf("[filter=%s%s]%s", filter, match.QualifierParam, match.ChannelName)
 	}
 	return ch.Get(name, options...), nil

--- a/ably/realtime_channel_integration_test.go
+++ b/ably/realtime_channel_integration_test.go
@@ -112,24 +112,9 @@ func TestRealtimeChannel_SubscriptionFilters(t *testing.T) {
 				},
 			},
 		},
-		{
-			Name: "filtered",
-			Data: "A different data",
-			Extras: map[string]interface{}{
-				"headers": map[string]interface{}{
-					"name":   "random value",
-					"number": 6789,
-					"bool":   true,
-				},
-			},
-		},
-		{
-			Name: "filtered",
-			Data: "No extra data",
-		},
 	}
 	filter := ably.DeriveOptions{
-		Filter: "name == `'filtered'` && headers.number == `1234`",
+		Filter: "name == `\"filtered\"` && headers.number == `1234`",
 	}
 
 	realtimeClient := app.NewRealtime(ably.WithEchoMessages(false))
@@ -139,7 +124,8 @@ func TestRealtimeChannel_SubscriptionFilters(t *testing.T) {
 	assert.NoError(t, err)
 
 	restChannel := restClient.Channels.Get("test")
-	realtimeChannel, _ := realtimeClient.Channels.GetDerived("test", filter)
+	realtimeChannel, err := realtimeClient.Channels.GetDerived("test", filter)
+	assert.NoError(t, err, "realtimeChannel: GetDerived()=%v", err)
 
 	err = realtimeChannel.Attach(context.Background())
 	assert.NoError(t, err,
@@ -150,7 +136,7 @@ func TestRealtimeChannel_SubscriptionFilters(t *testing.T) {
 	defer unsub()
 
 	err = restChannel.PublishMultiple(context.Background(), msg)
-	assert.NoError(t, err, "restClient: Publish()=%v", err)
+	assert.NoError(t, err, "restClient: PublishMultiple()=%v", err)
 
 	timeout := 15 * time.Second
 

--- a/ably/realtime_channel_integration_test.go
+++ b/ably/realtime_channel_integration_test.go
@@ -103,7 +103,7 @@ func TestRealtimeChannel_SubscriptionFilters(t *testing.T) {
 	msg := []*ably.Message{
 		{
 			Name: "filtered",
-			Data: "This should be filtered",
+			Data: "This should not be filtered",
 			Extras: map[string]interface{}{
 				"headers": map[string]interface{}{
 					"name":   "value one",
@@ -114,11 +114,11 @@ func TestRealtimeChannel_SubscriptionFilters(t *testing.T) {
 		},
 		{
 			Name: "filtered",
-			Data: "No filtering here",
+			Data: "filtered messages",
 		},
 		{
 			Name: "filtered",
-			Data: "Another filtered message",
+			Data: "Another unfiltered message",
 			Extras: map[string]interface{}{
 				"headers": map[string]interface{}{
 					"name":   "value one",

--- a/ablytest/sandbox.go
+++ b/ablytest/sandbox.go
@@ -72,7 +72,9 @@ type Config struct {
 func DefaultConfig() *Config {
 	return &Config{
 		Keys: []Key{
-			{},
+			{
+				Capability: `{"[*]*":["*"]}`,
+			},
 		},
 		Namespaces: []Namespace{
 			{ID: "persisted", Persisted: true},


### PR DESCRIPTION
We are creating a new method called GetDerived so we can create derived/synthetic channels. Presently, we only have filter as an option. The filter option lets us implement filtered subscription on a channel.
DR can be found [here](https://ably.atlassian.net/wiki/spaces/product/pages/2560098305/DR2+Filtered+Subscription+SDK+Implementation+Decision)
Ticket: [DSC-54](https://ably.atlassian.net/browse/DSC-54)

(From https://github.com/ably/ably-go/pull/592 to PR against an integration branch).

[DSC-54]: https://ably.atlassian.net/browse/DSC-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ