### PR TITLE
Integration/subscription filters

### DIFF
--- a/ably/internal/ablyutil/regex.go
+++ b/ably/internal/ablyutil/regex.go
@@ -1,0 +1,43 @@
+package ablyutil
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+// derivedChannelMatch provides the qualifyingParam and channelName from a channel regex match for derived channels
+type derivedChannelMatch struct {
+	QualifierParam string
+	ChannelName    string
+}
+
+// This regex check is to retain existing channel params if any e.g [?rewind=1]foo to
+// [filter=xyz?rewind=1]foo. This is to keep channel compatibility around use of
+// channel params that work with derived channels.
+func MatchDerivedChannel(name string) (*derivedChannelMatch, error) {
+	regex := `^(\[([^?]*)(?:(.*))\])?(.+)$`
+	r, err := regexp.Compile(regex)
+	if err != nil {
+		err := errors.New("regex compilation failed")
+		return nil, err
+	}
+	match := r.FindStringSubmatch(name)
+
+	if len(match) == 0 || len(match) < 5 {
+		err := errors.New("regex match failed")
+		return nil, err
+	}
+	// Fail if there is already a channel qualifier,
+	// eg [meta]foo should fail instead of just overriding with [filter=xyz]foo
+	if len(match[2]) > 0 {
+		err := fmt.Errorf("cannot use a derived option with a %s channel", match[2])
+		return nil, err
+	}
+
+	// Return match values to be added to derive channel quantifier.
+	return &derivedChannelMatch{
+		QualifierParam: match[3],
+		ChannelName:    match[4],
+	}, nil
+}

--- a/ably/internal/ablyutil/regex_test.go
+++ b/ably/internal/ablyutil/regex_test.go
@@ -1,0 +1,37 @@
+//go:build !integration
+// +build !integration
+
+package ablyutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchDerivedChannel(t *testing.T) {
+	var channels = []struct {
+		name  string
+		input string
+		want  *derivedChannelMatch
+	}{
+		{"valid with base channel name", "foo", &derivedChannelMatch{QualifierParam: "", ChannelName: "foo"}},
+		{"valid with base channel namespace", "foo:bar", &derivedChannelMatch{QualifierParam: "", ChannelName: "foo:bar"}},
+		{"valid with existing qualifying option", "[?rewind=1]foo", &derivedChannelMatch{QualifierParam: "?rewind=1", ChannelName: "foo"}},
+		{"valid with existing qualifying option with channel namespace", "[?rewind=1]foo:bar", &derivedChannelMatch{QualifierParam: "?rewind=1", ChannelName: "foo:bar"}},
+		{"fail with invalid param with channel namespace", "[param:invalid]foo:bar", nil},
+		{"fail with wrong channel option param", "[param=1]foo", nil},
+		{"fail with invalid qualifying option", "[meta]foo", nil},
+		{"fail with invalid regex match", "[failed-match]foo", nil},
+	}
+
+	for _, tt := range channels {
+		t.Run(tt.name, func(t *testing.T) {
+			match, err := MatchDerivedChannel(tt.input)
+			if err != nil {
+				assert.Error(t, err, "An error is expected for the regex match")
+			}
+			assert.Equal(t, tt.want, match, "invalid output received")
+		})
+	}
+}

--- a/ably/realtime_channel.go
+++ b/ably/realtime_channel.go
@@ -122,8 +122,9 @@ func (ch *RealtimeChannels) Get(name string, options ...ChannelOption) *Realtime
 	return c
 }
 
-// GetDerived creates a new derived [ably.RealtimeChannel] object for given channel name, using the provided derive options and
-// channel options if any. Returns error if any occurs
+// GetDerived is a preview feature and may change in a future non-major release.
+// It creates a new derived [ably.RealtimeChannel] object for given channel name, using the provided derive options and
+// channel options if any. Returns error if any occurs.
 func (ch *RealtimeChannels) GetDerived(name string, deriveOptions DeriveOptions, options ...ChannelOption) (*RealtimeChannel, error) {
 	if deriveOptions.Filter != "" {
 		match, err := ablyutil.MatchDerivedChannel(name)

--- a/ably/realtime_channel.go
+++ b/ably/realtime_channel.go
@@ -2,10 +2,13 @@ package ably
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"sort"
 	"sync"
+
+	"github.com/ably/ably-go/ably/internal/ablyutil"
 )
 
 var (
@@ -49,6 +52,11 @@ type ChannelOption func(*channelOptions)
 
 // channelOptions wraps ChannelOptions. It exists so that users can't implement their own ChannelOption.
 type channelOptions protoChannelOptions
+
+// DeriveOptions allows options to be used in creating a derived channel
+type DeriveOptions struct {
+	Filter string
+}
 
 // ChannelWithCipherKey is a constructor that takes private key as a argument.
 // It is used to encrypt and decrypt payloads (TB3)
@@ -112,6 +120,20 @@ func (ch *RealtimeChannels) Get(name string, options ...ChannelOption) *Realtime
 	}
 	ch.mtx.Unlock()
 	return c
+}
+
+// GetDerived creates a new derived [ably.RealtimeChannel] object for given channel name, using the provided derive options and
+// channel options if any. Returns error if any occurs
+func (ch *RealtimeChannels) GetDerived(name string, deriveOptions DeriveOptions, options ...ChannelOption) (*RealtimeChannel, error) {
+	if deriveOptions.Filter != "" {
+		match, err := ablyutil.MatchDerivedChannel(name)
+		if err != nil {
+			return nil, newError(40010, err)
+		}
+		filter := base64.StdEncoding.EncodeToString([]byte(deriveOptions.Filter))
+		name = fmt.Sprintf("[filter=%s%s]%s", filter, match.QualifierParam, match.ChannelName)
+	}
+	return ch.Get(name, options...), nil
 }
 
 // Iterate returns a [ably.RealtimeChannel] for each iteration on existing channels.

--- a/ablytest/sandbox.go
+++ b/ablytest/sandbox.go
@@ -72,7 +72,9 @@ type Config struct {
 func DefaultConfig() *Config {
 	return &Config{
 		Keys: []Key{
-			{},
+			{
+				Capability: `{"[*]*":["*"]}`,
+			},
 		},
 		Namespaces: []Namespace{
 			{ID: "persisted", Persisted: true},


### PR DESCRIPTION
Adds a new **experimental** `GetDerived` method for obtaining an instance of a "derived
channel" which applies a filter to messages in the upstream channel.

The channel filter is specified via a base64 encoded JMESPath expression
which is given as the value of a new channel qualifier called "filter".