### PR TITLE
add publish async method

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,9 +341,6 @@ As of release 1.2.0, the following are not implemented and will be covered in fu
   connection becomes `suspended` and then resumes, and presence members associated with the client will not be
   automatically re-entered.
 
-- Transient realtime publishing is not supported, so a call to `publish()` on a realtime channel will trigger attachment
-  of the channel.
-
 - Inband reauthentication is not supported; expiring tokens will trigger a disconnection and resume of a realtime
   connection.
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,23 @@ if err != nil {
 }
 ```
 
+`Publish` will block until either the publish is acknowledged or failed to
+deliver.
+
+Alternatively you can use `PublishAsync` which does not block:
+
+```go
+channel.PublishAsync("EventName1", "EventData11", func(err error) {
+	if err != nil {
+		fmt.Println("failed to publish", err)
+	} else {
+		fmt.Println("publish ok")
+	}
+})
+```
+
+Note the `onAck` callback must not block as it would block the internal client.
+
 #### Handling errors
 
 Errors returned by this library may have an underlying `*ErrorInfo` type.

--- a/ably/realtime_channel.go
+++ b/ably/realtime_channel.go
@@ -585,24 +585,15 @@ func (em ChannelEventEmitter) OffAll() {
 }
 
 // Publish publishes a single message to the channel with the given event name and message payload.
-// A callback may optionally be passed in to this call to be notified of success or failure of the operation.
-// When publish is called with this client library, it won't attempt to implicitly attach to the channel,
-// so long as transient publishing is available in the library. Otherwise, the client will implicitly attach (RTL6i).
-//
-// This implicitly attaches the channel if it's not already attached. If the
-// context is canceled before the attach operation finishes, the call
-// returns with an error, but the operation carries on in the background and
-// the channel may eventually be attached and the message published anyway.
 func (c *RealtimeChannel) Publish(ctx context.Context, name string, data interface{}) error {
 	return c.PublishMultiple(ctx, []*Message{{Name: name, Data: data}})
 }
 
 // PublishMultiple publishes all given messages on the channel at once.
 //
-// This implicitly attaches the channel if it's not already attached. If the
-// context is canceled before the attach operation finishes, the call
-// returns with an error, but the operation carries on in the background and
-// the channel may eventually be attached and the message published anyway (RTL6i).
+// If the context is cancelled before the attach operation finishes, the call
+// returns an error but the publish will carry on in the background and may
+// eventually be published anyway.
 func (c *RealtimeChannel) PublishMultiple(ctx context.Context, messages []*Message) error {
 	id := c.client.Auth.clientIDForCheck()
 	for _, v := range messages {

--- a/ably/realtime_channel_integration_test.go
+++ b/ably/realtime_channel_integration_test.go
@@ -49,6 +49,20 @@ func TestRealtimeChannel_Publish(t *testing.T) {
 	assert.NoError(t, err, "Publish()=%v", err)
 }
 
+func TestRealtimeChannel_PublishAsync(t *testing.T) {
+	app, client := ablytest.NewRealtime(nil...)
+	defer safeclose(t, ablytest.FullRealtimeCloser(client), app)
+	err := ablytest.Wait(ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected), nil)
+	assert.NoError(t, err)
+	channel := client.Channels.Get("test")
+	listen := make(chan error, 1)
+	err = channel.PublishAsync("hello", "world", func(err error) {
+		listen <- err
+	})
+	assert.NoError(t, err, "PublishAsync()=%v", err)
+	assert.NoError(t, <-listen, "onAck=%v", err)
+}
+
 func TestRealtimeChannel_Subscribe(t *testing.T) {
 	app, client1 := ablytest.NewRealtime(nil...)
 	defer safeclose(t, ablytest.FullRealtimeCloser(client1), app)


### PR DESCRIPTION
Adds a `PublishAsync` method by replacing `chan error` with a callback

See https://ably-real-time.slack.com/archives/C0114KK7S6R/p1685622657245009 for context

Depends on https://github.com/ably/ably-go/pull/595