### PR TITLE
Fix message extras unmarshaled to incompatible json type

### DIFF
--- a/ably/internal/ablyutil/msgpack.go
+++ b/ably/internal/ablyutil/msgpack.go
@@ -3,6 +3,7 @@ package ablyutil
 import (
 	"bytes"
 	"io"
+	"reflect"
 
 	"github.com/ugorji/go/codec"
 )
@@ -13,6 +14,7 @@ func init() {
 	handle.Raw = true
 	handle.WriteExt = true
 	handle.RawToString = true
+	handle.MapType = reflect.TypeOf(map[string]interface{}(nil))
 }
 
 // UnmarshalMsgpack decodes the MessagePack-encoded data and stores the result in the

--- a/ably/internal/ablyutil/msgpack_test.go
+++ b/ably/internal/ablyutil/msgpack_test.go
@@ -5,6 +5,7 @@ package ablyutil
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
 )
 
@@ -30,4 +31,29 @@ func TestMsgpack(t *testing.T) {
 			ts.Errorf("expected 12 got %v", b.Key)
 		}
 	})
+}
+
+func TestMsgpackJson(t *testing.T) {
+	extras := map[string]interface{}{
+		"headers": map[string]interface{}{
+			"version": 1,
+		},
+	}
+
+	b, err := MarshalMsgpack(extras)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got map[string]interface{}
+	err = UnmarshalMsgpack(b, &got)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buff := bytes.Buffer{}
+	err = json.NewEncoder(&buff).Encode(got)
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/ably/proto_message_decoding_test.go
+++ b/ably/proto_message_decoding_test.go
@@ -107,6 +107,34 @@ func loadMsgpackFixtures() ([]MsgpackTestFixture, error) {
 	return o, err
 }
 
+func TestMsgpackExtrasJsonCompatible(t *testing.T) {
+	p := protocolMessage{
+		Messages: []*Message{
+			{
+				Name: "my event",
+				Data: "hello world",
+				Extras: map[string]interface{}{
+					"headers": map[string]interface{}{
+						"version": 1,
+					},
+				},
+			},
+		},
+	}
+
+	b, err := ablyutil.MarshalMsgpack(p)
+	assert.NoError(t, err)
+
+	var got ProtocolMessage
+	assert.NoError(t, ablyutil.UnmarshalMsgpack(b, &got))
+
+	msg, err := got.Messages[0].withDecodedData(nil)
+	assert.NoError(t, err)
+
+	buff := bytes.Buffer{}
+	assert.NoError(t, json.NewEncoder(&buff).Encode(msg))
+}
+
 func TestMsgpackDecoding(t *testing.T) {
 	msgpackTestFixtures, err := loadMsgpackFixtures()
 	require.NoError(t, err)


### PR DESCRIPTION
Message extras should be a json compatible map[string]interface{}, but when marshalling to msgpack and back again, any nested objects become map[interface{}]interface{} which is incompatible with json marshalling.

Set the map type on the msgpack handle to map[string]interface{} so that nested objects are correctly unmarshaled.