### PR TITLE
fix: keep client default client read limit when realtime doesn't specify

### DIFF
--- a/ably/ably_test.go
+++ b/ably/ably_test.go
@@ -492,6 +492,10 @@ type interceptConn struct {
 	active *activeIntercept
 }
 
+func (c interceptConn) Unwrap() ably.Conn {
+	return c.Conn
+}
+
 func (c interceptConn) Receive(deadline time.Time) (*ably.ProtocolMessage, error) {
 	msg, err := c.Conn.Receive(deadline)
 	if err != nil {

--- a/ably/realtime_channel_integration_test.go
+++ b/ably/realtime_channel_integration_test.go
@@ -305,7 +305,7 @@ func TestRealtimeChannel_SetDefaultLimitIfNoServerLimit(t *testing.T) {
 		ConnectionKey:      "foo",
 		MaxFrameSize:       12,
 		MaxInboundRate:     14,
-		MaxMessageSize:     0,
+		MaxMessageSize:     0,  // 0 represents no limit on message size
 		ConnectionStateTTL: ably.DurationFromMsecs(time.Minute * 2),
 		MaxIdleInterval:    ably.DurationFromMsecs(time.Second),
 	}

--- a/ably/realtime_channel_integration_test.go
+++ b/ably/realtime_channel_integration_test.go
@@ -317,7 +317,8 @@ func TestRealtimeChannel_SetsNoLimitIfServerNoLimits(t *testing.T) {
 	}
 
 	// Wait for a little bit for things to settle
-	time.Sleep(1 * time.Second)
+	err := ablytest.Wait(ablytest.ConnWaiter(c, c.Connect, ably.ConnectionEventConnected), nil)
+	assert.NoError(t, err)
 
 	// Check that the connection read limit is the default - due to websocket.go
 	// Only allowing the value to be set if the connection is a certain type

--- a/ably/realtime_channel_integration_test.go
+++ b/ably/realtime_channel_integration_test.go
@@ -295,36 +295,26 @@ func TestRealtimeChannel_ShouldSetProvidedReadLimit(t *testing.T) {
 }
 
 func TestRealtimeChannel_SetsNoLimitIfServerNoLimits(t *testing.T) {
-	// Mock out the dial
-	dial := DialFunc(func(p string, url *url.URL, timeout time.Duration) (ably.Conn, error) {
-		return connMock{
-			SendFunc: func(m *ably.ProtocolMessage) error {
-				return nil
-			},
-			ReceiveFunc: func(deadline time.Time) (*ably.ProtocolMessage, error) {
-				connDetails := ably.ConnectionDetails{
-					ClientID:           "id1",
-					ConnectionKey:      "foo",
-					MaxFrameSize:       12,
-					MaxInboundRate:     14,
-					MaxMessageSize:     0,
-					ConnectionStateTTL: ably.DurationFromMsecs(time.Minute * 2),
-					MaxIdleInterval:    ably.DurationFromMsecs(time.Second),
-				}
+	in := make(chan *ably.ProtocolMessage, 1)
+	out := make(chan *ably.ProtocolMessage, 16)
 
-				return &ably.ProtocolMessage{
-					Action:            ably.ActionConnected,
-					ConnectionID:      "connection-id-1",
-					ConnectionDetails: &connDetails,
-				}, nil
-			},
-			CloseFunc: func() error {
-				return nil
-			},
-		}, nil
-	})
+	_, c := ablytest.NewRealtime(ably.WithDial(MessagePipe(in, out)))
 
-	_, c := ablytest.NewRealtime(ably.WithDial(dial))
+	connDetails := ably.ConnectionDetails{
+		ClientID:           "id1",
+		ConnectionKey:      "foo",
+		MaxFrameSize:       12,
+		MaxInboundRate:     14,
+		MaxMessageSize:     0,
+		ConnectionStateTTL: ably.DurationFromMsecs(time.Minute * 2),
+		MaxIdleInterval:    ably.DurationFromMsecs(time.Second),
+	}
+
+	in <- &ably.ProtocolMessage{
+		Action:            ably.ActionConnected,
+		ConnectionID:      "connection-id-1",
+		ConnectionDetails: &connDetails,
+	}
 
 	// Wait for a little bit for things to settle
 	time.Sleep(1 * time.Second)

--- a/ably/realtime_channel_integration_test.go
+++ b/ably/realtime_channel_integration_test.go
@@ -294,7 +294,7 @@ func TestRealtimeChannel_ShouldSetProvidedReadLimit(t *testing.T) {
 	assert.Equal(t, int64(2048), client.Connection.ReadLimit())
 }
 
-func TestRealtimeChannel_SetsNoLimitIfServerNoLimits(t *testing.T) {
+func TestRealtimeChannel_SetDefaultLimitIfNoServerLimit(t *testing.T) {
 	in := make(chan *ably.ProtocolMessage, 1)
 	out := make(chan *ably.ProtocolMessage, 16)
 

--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -988,6 +988,10 @@ func (vc verboseConn) Close() error {
 	return vc.conn.Close()
 }
 
+func (vc verboseConn) Unwrap() conn {
+	return vc.conn
+}
+
 func (c *Connection) setState(state ConnectionState, err error, retryIn time.Duration) error {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()

--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -826,7 +826,7 @@ func (c *Connection) eventloop() {
 				c.connStateTTL = connDetails.ConnectionStateTTL
 				// Spec RSA7b3, RSA7b4, RSA12a
 				c.auth.updateClientID(connDetails.ClientID)
-				if !c.isReadLimitSetExternally {
+				if !c.isReadLimitSetExternally && connDetails.MaxMessageSize > 0 {
 					c.readLimit = connDetails.MaxMessageSize // set MaxMessageSize limit as per TO3l8
 				}
 			}


### PR DESCRIPTION
This is mostly for internal purposes, where we have MaxMessageSize set to 0 (read: unlimited). When this happens, the SDK should keep whatever limit it currently has set.

Previously it was trying to set 0 which prevented anything from being read from the connection/