### PR TITLE
[ECO-1780] Removes broken feature matrix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ Our [current approach to versioning](https://ably.com/documentation/client-lib-d
 
 ## Feature support
 
-This library targets the Ably 1.2 [client library specification](https://ably.com/docs/client-lib-development-guide/features). List of available features for our client library SDKs can be found on our [feature support matrix](https://ably.com/download/sdk-feature-support-matrix) page.
+This library targets the Ably 1.2 [client library specification](https://ably.com/docs/client-lib-development-guide/features).
 
 ## Known limitations
 


### PR DESCRIPTION
Removes broken feature matrix link - will be replaced in the future with an updated feature checklist.