### PR TITLE
Fix presence newness check and flaky tests

### DIFF
--- a/ably/proto_presence_message.go
+++ b/ably/proto_presence_message.go
@@ -98,7 +98,7 @@ func (msg1 *PresenceMessage) IsNewerThan(msg2 *PresenceMessage) (bool, error) {
 		return true, err
 	}
 	if msg1Serial == msg2Serial {
-		return msg1Index >= msg2Index, nil
+		return msg1Index > msg2Index, nil
 	}
 	return msg1Serial > msg2Serial, nil
 }

--- a/ably/realtime_presence_integration_test.go
+++ b/ably/realtime_presence_integration_test.go
@@ -141,7 +141,7 @@ func TestRealtimePresence_EnsureChannelIsAttached(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func SkipTestRealtimePresence_Presence_Enter_Update_Leave(t *testing.T) {
+func TestRealtimePresence_Presence_Enter_Update_Leave(t *testing.T) {
 	app, client1 := ablytest.NewRealtime(nil...)
 	defer safeclose(t, ablytest.FullRealtimeCloser(client1), app)
 
@@ -199,7 +199,7 @@ func SkipTestRealtimePresence_Presence_Enter_Update_Leave(t *testing.T) {
 	assert.Equal(t, "leave client2", member_received.Data)
 }
 
-func SkipTestRealtimePresence_ServerSynthesized_Leave(t *testing.T) {
+func TestRealtimePresence_ServerSynthesized_Leave(t *testing.T) {
 	app, client1 := ablytest.NewRealtime(nil...)
 	defer safeclose(t, ablytest.FullRealtimeCloser(client1), app)
 
@@ -252,47 +252,6 @@ func SkipTestRealtimePresence_ServerSynthesized_Leave(t *testing.T) {
 	members, err = client1Channel.Presence.Get(context.Background())
 	assert.NoError(t, err)
 	assert.Empty(t, members)
-}
-
-func TestRealtimePresence_ServerSynthesized_Leave(t *testing.T) {
-	app, client1 := ablytest.NewRealtime(nil...)
-	defer safeclose(t, ablytest.FullRealtimeCloser(client1), app)
-
-	client2 := app.NewRealtime(ably.WithClientID("client2"))
-	defer safeclose(t, ablytest.FullRealtimeCloser(client2))
-
-	err := ablytest.Wait(ablytest.ConnWaiter(client1, client1.Connect, ably.ConnectionEventConnected), nil)
-	assert.NoError(t, err)
-
-	err = ablytest.Wait(ablytest.ConnWaiter(client2, client2.Connect, ably.ConnectionEventConnected), nil)
-	assert.NoError(t, err)
-
-	client1Channel := client1.Channels.Get("channel")
-	err = client1Channel.Attach(context.Background())
-
-	assert.NoError(t, err)
-
-	client2Channel := client2.Channels.Get("channel")
-	err = client2Channel.Attach(context.Background())
-	assert.NoError(t, err)
-
-	// ENTER
-	err = client2Channel.Presence.Enter(context.Background(), "enter client2")
-	assert.NoError(t, err)
-
-	leaveAction := ably.PresenceActionLeave
-	subCh1, unsub1, err := ablytest.ReceivePresenceMessages(client1Channel, &leaveAction)
-	assert.NoError(t, err)
-	defer unsub1()
-
-	// Server Synthesized Leave when client2 disconnects
-	client2.Close()
-
-	member_received := <-subCh1
-	assert.Len(t, subCh1, 0) // Ensure no more updates received
-
-	assert.Equal(t, ably.PresenceActionLeave, member_received.Action)
-	assert.Equal(t, "client2", member_received.ClientID)
 }
 
 // When a client is created with a ClientID, Enter is used to announce the client's presence.


### PR DESCRIPTION
- As per https://sdk.ably.com/builds/ably/specification/main/features/#RTP2b2, newer message should have msgIndex bigger than other.
- Fixed flaky presence tests
- Avoids duplicate presence messages being emitted when server periodically sends `SYNC` message containing all presence messages.