### PR TITLE
Add support for go1.23 and drop versions before 1.22

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.19', '1.20', '1.21', '1.22']
+        go-version: ['1.19', '1.22', '1.23']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.19', '1.20', '1.21', '1.22']
+        go-version: ['1.19', '1.22', '1.23']
         protocol: ['json', 'msgpack']
 
     steps:


### PR DESCRIPTION
Go 1.23 was released last week.
We follow the Go release policy of supporting the last two versions of Go.

See https://github.com/ably/ably-go#supported-versions-of-go
