### PR TITLE
Removed use of deprecated ioutil

### DIFF
--- a/ably/auth.go
+++ b/ably/auth.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"net/http"
 	"net/url"
@@ -443,7 +442,7 @@ func (a *Auth) requestAuthURL(ctx context.Context, params *TokenParams, opts *au
 	case "POST":
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.Header.Set("Content-Length", strconv.Itoa(len(query)))
-		req.Body = ioutil.NopCloser(strings.NewReader(query))
+		req.Body = io.NopCloser(strings.NewReader(query))
 	default:
 		return nil, a.newError(40500, nil)
 	}
@@ -461,7 +460,7 @@ func (a *Auth) requestAuthURL(ctx context.Context, params *TokenParams, opts *au
 	}
 	switch typ {
 	case "text/plain":
-		token, err := ioutil.ReadAll(resp.Body)
+		token, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, a.newError(40000, err)
 		}

--- a/ably/error.go
+++ b/ably/error.go
@@ -3,7 +3,7 @@ package ably
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"mime"
 	"net"
 	"net/http"
@@ -140,7 +140,7 @@ func statusCode(err error) int {
 }
 
 func errFromUnprocessableBody(resp *http.Response) error {
-	errMsg, err := ioutil.ReadAll(resp.Body)
+	errMsg, err := io.ReadAll(resp.Body)
 	if err == nil {
 		err = errors.New(string(errMsg))
 	}

--- a/ably/rest_client.go
+++ b/ably/rest_client.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"mime"
 	"net"
@@ -841,13 +840,13 @@ func decode(typ string, r io.Reader, out interface{}) error {
 	case "application/json":
 		return json.NewDecoder(r).Decode(out)
 	case "application/x-msgpack":
-		b, err := ioutil.ReadAll(r)
+		b, err := io.ReadAll(r)
 		if err != nil {
 			return err
 		}
 		return ablyutil.UnmarshalMsgpack(b, out)
 	case "text/plain":
-		p, err := ioutil.ReadAll(r)
+		p, err := io.ReadAll(r)
 		if err != nil {
 			return err
 		}
@@ -864,7 +863,7 @@ func decodeResp(resp *http.Response, out interface{}) error {
 	if err != nil {
 		return err
 	}
-	b, _ := ioutil.ReadAll(resp.Body)
+	b, _ := io.ReadAll(resp.Body)
 
 	return decode(typ, bytes.NewReader(b), out)
 }

--- a/ably/rest_client_integration_test.go
+++ b/ably/rest_client_integration_test.go
@@ -10,7 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -48,7 +48,7 @@ func TestRestClient(t *testing.T) {
 			mockBody := []byte("{}")
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				var err error
-				buffer, err = ioutil.ReadAll(r.Body)
+				buffer, err = io.ReadAll(r.Body)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -77,7 +77,7 @@ func TestRestClient(t *testing.T) {
 			mockBody := []byte{0x80}
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				var err error
-				buffer, err = ioutil.ReadAll(r.Body)
+				buffer, err = io.ReadAll(r.Body)
 				assert.NoError(t, err)
 				w.Header().Set("Content-Type", mockType)
 				w.WriteHeader(200)

--- a/ablytest/proxies.go
+++ b/ablytest/proxies.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -47,7 +46,7 @@ func Query(req *http.Request) (url.Values, error) {
 	case "GET":
 		return req.URL.Query(), nil
 	case "POST":
-		p, err := ioutil.ReadAll(req.Body)
+		p, err := io.ReadAll(req.Body)
 		if err != nil {
 			return nil, err
 		}

--- a/ablytest/recorders.go
+++ b/ablytest/recorders.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -98,7 +97,7 @@ func (rec *RoundTripRecorder) Reset() {
 func (rec *RoundTripRecorder) roundTrip(req *http.Request) (*http.Response, error) {
 	var buf bytes.Buffer
 	if req.Body != nil {
-		req.Body = ioutil.NopCloser(io.TeeReader(req.Body, &buf))
+		req.Body = io.NopCloser(io.TeeReader(req.Body, &buf))
 	}
 	resp, err := rec.Transport.RoundTrip(req)
 	req.Body = body(buf.Bytes())
@@ -246,5 +245,5 @@ func (c realtimeIOCloser) Close() error {
 }
 
 func body(p []byte) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader(p))
+	return io.NopCloser(bytes.NewReader(p))
 }

--- a/ablytest/sandbox.go
+++ b/ablytest/sandbox.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -177,7 +177,7 @@ func NewSandboxWithEnv(config *Config, env string) (*Sandbox, error) {
 			defer resp.Body.Close()
 			if resp.StatusCode > 299 {
 				err := errors.New(http.StatusText(resp.StatusCode))
-				if p, e := ioutil.ReadAll(resp.Body); e == nil && len(p) != 0 {
+				if p, e := io.ReadAll(resp.Body); e == nil && len(p) != 0 {
 					err = fmt.Errorf("request error: %s (%q)", err, p)
 				}
 				return nil, err


### PR DESCRIPTION
- As per official doc, `ioutil` module is replaced by `io` or `os` since go 1.16
- Link -> https://pkg.go.dev/io/ioutil

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Replaced deprecated `ioutil` package functions with `io` package functions to enhance code stability and clarity across multiple components.
  
- **Refactor**
	- Streamlined code by removing dependencies on the deprecated `ioutil` package, improving adherence to current best practices in Go programming. 

These changes ensure better maintainability and performance of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->