### PR TITLE
[ECO-4550] Fix JWT authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,9 +490,6 @@ As of release 1.2.0, the following are not implemented and will be covered in fu
 
 - [Push notifications admin API](https://ably.com/docs/api/rest-sdk/push-admin) is not implemented.
 
-- [JWT authentication](https://ably.com/docs/auth/token?lang=javascript#jwt) using `auth-url` is not implemented.
-See [jwt auth issue](https://github.com/ably/ably-go/issues/569) for more details.
-
 ### Realtime API
 
 - Channel suspended state is partially implemented. See [suspended channel state](https://github.com/ably/ably-go/issues/568).

--- a/README.md
+++ b/README.md
@@ -345,15 +345,20 @@ func getToken(c *gin.Context) {
 }
 
 ```
-- You can also return JWT string token signed using `ABLY_KEY` as per [official ably JWT doc](https://ably.com/tutorials/jwt-authentication). When using `WithAuthURL` clientOption at client side, response contentType header should be set to either `text/plain` or `application/jwt`.
+
+- You can also return JWT string token signed using `ABLY_KEY` as per [official ably JWT doc](https://ably.com/tutorials/jwt-authentication).
+- When using `WithAuthURL` clientOption at client side, for JWT response, contentType header should be set to  `text/plain` or `application/jwt`. For `ably.TokenRequest`/ `ably.TokenDetails`, set it as  `application/json`.
 
 ### Using the Token auth at client side
 
-- You provide either `WithAuthCallback` or `WithAuthURL` as a clientOption to request token.
+- You can provide either `WithAuthCallback` or `WithAuthURL` as a clientOption to request token.
+- `WithAuthUrl` automatically decodes response based on response contentType.
 
 ```go
 authCallback := ably.WithAuthCallback(func(ctx context.Context, tp ably.TokenParams) (ably.Tokener, error) {
         // HTTP client impl. to fetch token, you can pass tokenParams based on your requirement
+        // Return token of type ably.TokenDetails, ably.TokenRequest or ably.TokenString
+        // This may need manually decoding tokens based on the response.
         token, err := requestTokenFrom(ctx, "/token");
         if err != nil {
                 return nil, err // You can also log error here
@@ -369,7 +374,7 @@ authCallback := ably.WithAuthCallback(func(ctx context.Context, tp ably.TokenPar
         if err != nil {
                 return nil, err // You can also log error here
         }
-        return jwtTokenString, err // return standard jwt base64 encoded token that starts with "ey"
+        return ably.TokenString(jwtTokenString), err // return jwt token that starts with "ey"
 })
 ```
 - Check [official token auth documentation](https://ably.com/docs/auth/token?lang=csharp) for more information.

--- a/ably/auth.go
+++ b/ably/auth.go
@@ -462,7 +462,7 @@ func (a *Auth) requestAuthURL(ctx context.Context, params *TokenParams, opts *au
 		return nil, a.newError(40004, err)
 	}
 	switch typ {
-	case "text/plain":
+	case "text/plain", "application/jwt":
 		token, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, a.newError(40000, err)

--- a/ably/auth_integration_test.go
+++ b/ably/auth_integration_test.go
@@ -449,6 +449,7 @@ func TestAuth_JWT_Token_RSA8c(t *testing.T) {
 			jwtTokenString, err := app.CreateJwt(time.Second*30, false)
 			jwtToken = jwtTokenString
 			if err != nil {
+				t.Fatalf("Error creating JWT: %v", err)
 				return nil, err
 			}
 			return ably.TokenString(jwtTokenString), nil

--- a/ably/auth_integration_test.go
+++ b/ably/auth_integration_test.go
@@ -344,9 +344,17 @@ func TestAuth_RequestToken(t *testing.T) {
 	}
 }
 
-func TestAuth_JWT_Token(t *testing.T) {
+func TestAuth_JWT_Token_RSA8c(t *testing.T) {
 
-	t.Run("Should be able to authenticate using authURL", func(t *testing.T) {
+	t.Run("Get JWT from echo server", func(t *testing.T) {
+		app := ablytest.MustSandbox(nil)
+		defer safeclose(t, app)
+		jwt, err := app.CreateJwt(3 * time.Second)
+		assert.NoError(t, err)
+		assert.True(t, strings.HasPrefix(jwt, "ey"))
+	})
+
+	t.Run("RSA8g, RSA3d: Should be able to authenticate using authURL", func(t *testing.T) {
 		app := ablytest.MustSandbox(nil)
 		defer safeclose(t, app)
 
@@ -382,7 +390,7 @@ func TestAuth_JWT_Token(t *testing.T) {
 		assert.Equal(t, "Bearer "+encodedToken, statsRequest.Header.Get("Authorization"))
 	})
 
-	t.Run("Should be able to authenticate using authCallback", func(t *testing.T) {
+	t.Run("RSA8g, RSA3d: Should be able to authenticate using authCallback", func(t *testing.T) {
 		app := ablytest.MustSandbox(nil)
 		defer safeclose(t, app)
 

--- a/ably/realtime_conn_spec_integration_test.go
+++ b/ably/realtime_conn_spec_integration_test.go
@@ -3027,17 +3027,10 @@ func TestRealtimeConn_RTC8a_ExplicitAuthorizeWhileConnected(t *testing.T) {
 		app := ablytest.MustSandbox(nil)
 		defer safeclose(t, app)
 
-		key, secret := app.KeyParts()
-		authParams := url.Values{}
-		authParams.Add("environment", app.Environment)
-		authParams.Add("returnType", "jwt")
-		authParams.Add("keyName", key)
-		authParams.Add("keySecret", secret)
-
 		rec, optn := ablytest.NewHttpRecorder()
 		rest, err := ably.NewREST(
-			ably.WithAuthURL("https://echo.ably.io/createJWT"),
-			ably.WithAuthParams(authParams),
+			ably.WithAuthURL(ablytest.CREATE_JWT_URL),
+			ably.WithAuthParams(app.GetJwtAuthParams(30*time.Second)),
 			ably.WithEnvironment(app.Environment),
 			ably.WithKey(""),
 			optn[0],
@@ -3052,7 +3045,7 @@ func TestRealtimeConn_RTC8a_ExplicitAuthorizeWhileConnected(t *testing.T) {
 
 		// first request is jwt request
 		jwtRequest := rec.Request(0).URL
-		assert.Equal(t, "echo.ably.io/createJWT", jwtRequest.Host+jwtRequest.Path)
+		assert.Equal(t, ablytest.CREATE_JWT_URL, "https://"+jwtRequest.Host+jwtRequest.Path)
 		// response is jwt token
 		jwtResponse, err := io.ReadAll(rec.Response(0).Body)
 		assert.NoError(t, err)

--- a/ably/realtime_conn_spec_integration_test.go
+++ b/ably/realtime_conn_spec_integration_test.go
@@ -5,6 +5,7 @@ package ably_test
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -3023,7 +3024,46 @@ func TestRealtimeConn_RTC8a_ExplicitAuthorizeWhileConnected(t *testing.T) {
 	})
 
 	t.Run("RTC8a4: reauthorize with JWT token", func(t *testing.T) {
-		t.Skip("not implemented")
+		app := ablytest.MustSandbox(nil)
+		defer safeclose(t, app)
+
+		key, secret := app.KeyParts()
+		authParams := url.Values{}
+		authParams.Add("environment", app.Environment)
+		authParams.Add("returnType", "jwt")
+		authParams.Add("keyName", key)
+		authParams.Add("keySecret", secret)
+
+		rec, optn := ablytest.NewHttpRecorder()
+		rest, err := ably.NewREST(
+			ably.WithAuthURL("https://echo.ably.io/createJWT"),
+			ably.WithAuthParams(authParams),
+			ably.WithEnvironment(app.Environment),
+			ably.WithKey(""),
+			optn[0],
+		)
+
+		assert.NoError(t, err, "rest()=%v", err)
+		_, err = rest.Stats().Pages(context.Background())
+		assert.NoError(t, err, "Stats()=%v", err)
+
+		assert.Len(t, rec.Requests(), 2)
+		assert.Len(t, rec.Responses(), 2)
+
+		// first request is jwt request
+		jwtRequest := rec.Request(0).URL
+		assert.Equal(t, "echo.ably.io/createJWT", jwtRequest.Host+jwtRequest.Path)
+		// response is jwt token
+		jwtResponse, err := io.ReadAll(rec.Response(0).Body)
+		assert.NoError(t, err)
+		assert.Subset(t, jwtResponse, []byte("ey")) // JWT starts with ey
+
+		// Second request is made to stats with given jwt token (base64 encoded)
+		statsRequest := rec.Request(1)
+		assert.Equal(t, "/stats", statsRequest.URL.Path)
+		encodedToken := base64.StdEncoding.EncodeToString(jwtResponse)
+		assert.NoError(t, err)
+		assert.Equal(t, "Bearer "+encodedToken, statsRequest.Header.Get("Authorization"))
 	})
 
 	t.Run("RTC8a2: Failed reauth moves connection to FAILED", func(t *testing.T) {

--- a/ably/realtime_conn_spec_integration_test.go
+++ b/ably/realtime_conn_spec_integration_test.go
@@ -3031,7 +3031,7 @@ func TestRealtimeConn_RTC8a_ExplicitAuthorizeWhileConnected(t *testing.T) {
 		tokenExpiry := 3 * time.Second
 		// Returns token that expires after 3 seconds causing disconnect every 3 seconds
 		authCallback := func(ctx context.Context, tp ably.TokenParams) (ably.Tokener, error) {
-			jwtTokenString, err := app.CreateJwt(tokenExpiry)
+			jwtTokenString, err := app.CreateJwt(tokenExpiry, false)
 			if err != nil {
 				return nil, err
 			}

--- a/ablytest/sandbox.go
+++ b/ablytest/sandbox.go
@@ -267,7 +267,7 @@ func (app *Sandbox) GetJwtAuthParams(expiresIn time.Duration) url.Values {
 	authParams.Add("returnType", "jwt")
 	authParams.Add("keyName", key)
 	authParams.Add("keySecret", secret)
-	authParams.Add("expiresIn", fmt.Sprint(expiresIn.Milliseconds()))
+	authParams.Add("expiresIn", fmt.Sprint(expiresIn.Seconds()))
 	return authParams
 }
 

--- a/ablytest/sandbox.go
+++ b/ablytest/sandbox.go
@@ -260,24 +260,28 @@ func (app *Sandbox) URL(paths ...string) string {
 var CREATE_JWT_URL string = "https://echo.ably.io/createJWT"
 
 // Returns authParams, required for authUrl as a mode of auth
-func (app *Sandbox) GetJwtAuthParams(expiresIn time.Duration) url.Values {
+func (app *Sandbox) GetJwtAuthParams(expiresIn time.Duration, invalid bool) url.Values {
 	key, secret := app.KeyParts()
 	authParams := url.Values{}
 	authParams.Add("environment", app.Environment)
 	authParams.Add("returnType", "jwt")
 	authParams.Add("keyName", key)
-	authParams.Add("keySecret", secret)
+	if invalid {
+		authParams.Add("keySecret", "invalid")
+	} else {
+		authParams.Add("keySecret", secret)
+	}
 	authParams.Add("expiresIn", fmt.Sprint(expiresIn.Seconds()))
 	return authParams
 }
 
 // Returns JWT with given expiry
-func (app *Sandbox) CreateJwt(expiresIn time.Duration) (string, error) {
+func (app *Sandbox) CreateJwt(expiresIn time.Duration, invalid bool) (string, error) {
 	u, err := url.Parse(CREATE_JWT_URL)
 	if err != nil {
 		return "", err
 	}
-	u.RawQuery = app.GetJwtAuthParams(expiresIn).Encode()
+	u.RawQuery = app.GetJwtAuthParams(expiresIn, invalid).Encode()
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
 		return "", fmt.Errorf("client: could not create request: %s", err)


### PR DESCRIPTION
- Added missing test as per #569 
- Fixed #569 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Enhanced the authentication section of the README to provide detailed guidance on using `ably.NewREST` with `ABLY_KEY` and implementing token authentication for both server and client-side applications.
	- Clarified the creation of secure endpoints for token generation and included practical examples for managing JWT tokens effectively.

- **New Features**
	- Introduced new methods for JWT generation in the Sandbox, allowing for configurable authentication parameters.

- **Tests**
	- Expanded test coverage for JWT authentication scenarios, including successful and erroneous handling of tokens.
	- Implemented a test for reauthorizing with a JWT token, ensuring robust connection state management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->