### PR TITLE
auth: Add option to allow basic auth for non-TLS requests

### DIFF
--- a/ably/auth.go
+++ b/ably/auth.go
@@ -545,7 +545,7 @@ func detectAuthMethod(opts *clientOptions) (int, error) {
 	if !isKeyValid {
 		return 0, newError(ErrInvalidCredential, errInvalidKey)
 	}
-	if opts.NoTLS {
+	if opts.NoTLS && !opts.InsecureAllowBasicAuthWithoutTLS {
 		return 0, newError(ErrInvalidUseOfBasicAuthOverNonTLSTransport, errInsecureBasicAuth)
 	}
 	return authBasic, nil

--- a/ably/options.go
+++ b/ably/options.go
@@ -408,6 +408,10 @@ type clientOptions struct {
 	// LogHandler controls the log output of the library. This is a function to handle each line of log output.
 	// platform specific (TO3c)
 	LogHandler Logger
+
+	// InsecureAllowBasicAuthWithoutTLS permits an API key to be used even if the connection
+	// will not use TLS, something which would otherwise not be permitted for security reasons.
+	InsecureAllowBasicAuthWithoutTLS bool
 }
 
 func (opts *clientOptions) validate() error {
@@ -1313,6 +1317,14 @@ func WithFallbackHostsUseDefault(fallbackHostsUseDefault bool) ClientOption {
 func WithDial(dial func(protocol string, u *url.URL, timeout time.Duration) (conn, error)) ClientOption {
 	return func(os *clientOptions) {
 		os.Dial = dial
+	}
+}
+
+// WithInsecureAllowBasicAuthWithoutTLS permits an API key to be used even if the connection
+// will not use TLS, something which would otherwise not be permitted for security reasons.
+func WithInsecureAllowBasicAuthWithoutTLS() ClientOption {
+	return func(opts *clientOptions) {
+		opts.InsecureAllowBasicAuthWithoutTLS = true
 	}
 }
 

--- a/ably/options_test.go
+++ b/ably/options_test.go
@@ -236,6 +236,28 @@ func TestScopeParams(t *testing.T) {
 	})
 }
 
+func TestOption_NoTLS(t *testing.T) {
+	t.Run("does not allow basic auth with no TLS", func(t *testing.T) {
+		_, err := ably.NewREST(
+			ably.WithKey("xxxxxx.yyyyyy:zzzzzz"),
+			ably.WithTLS(false),
+		)
+		assert.Error(t, err)
+		errInfo, ok := err.(*ably.ErrorInfo)
+		assert.True(t, ok)
+		assert.Equal(t, errInfo.Code, ably.ErrInvalidUseOfBasicAuthOverNonTLSTransport)
+	})
+
+	t.Run("allows basic auth with no TLS when InsecureAllowBasicAuthWithoutTLS is set", func(t *testing.T) {
+		_, err := ably.NewREST(
+			ably.WithKey("xxxxxx.yyyyyy:zzzzzz"),
+			ably.WithTLS(false),
+			ably.WithInsecureAllowBasicAuthWithoutTLS(),
+		)
+		assert.NoError(t, err)
+	})
+}
+
 func TestPaginateParams(t *testing.T) {
 	t.Run("returns nil with no values", func(t *testing.T) {
 


### PR DESCRIPTION
We internally often want to use the Go SDK in private environments (e.g. local development, or within virtual private networks), where we do not use TLS, but find it convenient to be able to use API keys rather than tokens.

This commit adds an `InsecureAllowBasicAuthWithoutTLS` option which permits the use of an API key when the `NoTLS` option is also set.

We only require this in the Go SDK, so there is no intention of adding this option to the feature spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new option allowing basic authentication without TLS for enhanced flexibility.
	- Added a method to easily configure the new authentication option.
- **Bug Fixes**
	- Improved security checks for basic authentication over non-TLS connections.
- **Tests**
	- Added tests to ensure correct behavior of basic authentication options with and without TLS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->