### PR TITLE
[ClientOption] Add support for endpoint according to new routing policy

### DIFF
--- a/ably/ably_test.go
+++ b/ably/ably_test.go
@@ -356,7 +356,7 @@ func NewRecorder(httpClient *http.Client) *HostRecorder {
 
 func (hr *HostRecorder) Options(host string, opts ...ably.ClientOption) []ably.ClientOption {
 	return append(opts,
-		ably.WithRealtimeHost(host),
+		ably.WithEndpoint(host),
 		ably.WithAutoConnect(false),
 		ably.WithDial(hr.dialWS),
 		ably.WithHTTPClient(hr.httpClient),

--- a/ably/auth_integration_test.go
+++ b/ably/auth_integration_test.go
@@ -389,7 +389,7 @@ func TestAuth_JWT_Token_RSA8c(t *testing.T) {
 		rec, optn := ablytest.NewHttpRecorder()
 		rest, err := ably.NewREST(
 			ably.WithToken(jwt),
-			ably.WithEnvironment(app.Environment),
+			ably.WithEndpoint(app.Endpoint),
 			optn[0],
 		)
 		assert.NoError(t, err, "rest()=%v", err)
@@ -414,7 +414,7 @@ func TestAuth_JWT_Token_RSA8c(t *testing.T) {
 		rest, err := ably.NewREST(
 			ably.WithAuthURL(ablytest.CREATE_JWT_URL),
 			ably.WithAuthParams(app.GetJwtAuthParams(30*time.Second, false)),
-			ably.WithEnvironment(app.Environment),
+			ably.WithEndpoint(app.Endpoint),
 			optn[0],
 		)
 		assert.NoError(t, err, "rest()=%v", err)
@@ -457,7 +457,7 @@ func TestAuth_JWT_Token_RSA8c(t *testing.T) {
 
 		rec, optn := ablytest.NewHttpRecorder()
 		rest, err := ably.NewREST(
-			ably.WithEnvironment(app.Environment),
+			ably.WithEndpoint(app.Endpoint),
 			authCallback,
 			optn[0],
 		)
@@ -485,7 +485,7 @@ func TestAuth_JWT_Token_RSA8c(t *testing.T) {
 		rest, err := ably.NewREST(
 			ably.WithAuthURL(ablytest.CREATE_JWT_URL),
 			ably.WithAuthParams(app.GetJwtAuthParams(30*time.Second, true)),
-			ably.WithEnvironment(app.Environment),
+			ably.WithEndpoint(app.Endpoint),
 			optn[0],
 		)
 		assert.NoError(t, err, "rest()=%v", err)

--- a/ably/error_test.go
+++ b/ably/error_test.go
@@ -54,7 +54,7 @@ func TestIssue127ErrorResponse(t *testing.T) {
 		ably.WithKey("xxxxxxx.yyyyyyy:zzzzzzz"),
 		ably.WithTLS(false),
 		ably.WithUseTokenAuth(true),
-		ably.WithRESTHost(endpointURL.Hostname()),
+		ably.WithEndpoint(endpointURL.Hostname()),
 	}
 	port, _ := strconv.ParseInt(endpointURL.Port(), 10, 0)
 	opts = append(opts, ably.WithPort(int(port)))
@@ -134,7 +134,7 @@ func TestIssue_154(t *testing.T) {
 		ably.WithKey("xxxxxxx.yyyyyyy:zzzzzzz"),
 		ably.WithTLS(false),
 		ably.WithUseTokenAuth(true),
-		ably.WithRESTHost(endpointURL.Hostname()),
+		ably.WithEndpoint(endpointURL.Hostname()),
 	}
 	port, _ := strconv.ParseInt(endpointURL.Port(), 10, 0)
 	opts = append(opts, ably.WithPort(int(port)))

--- a/ably/export_test.go
+++ b/ably/export_test.go
@@ -24,6 +24,10 @@ func (opts *clientOptions) GetRealtimeHost() string {
 	return opts.getRealtimeHost()
 }
 
+func (opts *clientOptions) Validate() error {
+	return opts.validate()
+}
+
 func (opts *clientOptions) GetHostnameFromEndpoint() string {
 	return opts.getHostnameFromEndpoint()
 }

--- a/ably/export_test.go
+++ b/ably/export_test.go
@@ -16,8 +16,16 @@ func GetEndpointFallbackHosts(endpoint string) []string {
 	return getEndpointFallbackHosts(endpoint)
 }
 
-func (opts *clientOptions) GetHostname() string {
-	return opts.getHostname()
+func (opts *clientOptions) GetRestHost() string {
+	return opts.getRestHost()
+}
+
+func (opts *clientOptions) GetRealtimeHost() string {
+	return opts.getRealtimeHost()
+}
+
+func (opts *clientOptions) GetHostnameFromEndpoint() string {
+	return opts.getHostnameFromEndpoint()
 }
 
 func (opts *clientOptions) ActivePort() (int, bool) {
@@ -199,7 +207,7 @@ type ChannelStateChanges = channelStateChanges
 const ConnectionStateTTLErrFmt = connectionStateTTLErrFmt
 
 func DefaultFallbackHosts() []string {
-	return defaultFallbackHosts()
+	return defaultOptions.FallbackHosts
 }
 
 // PendingItems returns the number of messages waiting for Ack/Nack

--- a/ably/export_test.go
+++ b/ably/export_test.go
@@ -12,16 +12,12 @@ func NewClientOptions(os ...ClientOption) *clientOptions {
 	return applyOptionsWithDefaults(os...)
 }
 
-func GetEnvFallbackHosts(env string) []string {
-	return getEnvFallbackHosts(env)
+func GetEndpointFallbackHosts(endpoint string) []string {
+	return getEndpointFallbackHosts(endpoint)
 }
 
-func (opts *clientOptions) GetRestHost() string {
-	return opts.getRestHost()
-}
-
-func (opts *clientOptions) GetRealtimeHost() string {
-	return opts.getRealtimeHost()
+func (opts *clientOptions) GetHostname() string {
+	return opts.getHostname()
 }
 
 func (opts *clientOptions) ActivePort() (int, bool) {
@@ -190,6 +186,10 @@ func WithConnectionStateTTL(d time.Duration) ClientOption {
 
 func ApplyOptionsWithDefaults(o ...ClientOption) *clientOptions {
 	return applyOptionsWithDefaults(o...)
+}
+
+func IsEndpointFQDN(endpoint string) bool {
+	return isEndpointFQDN(endpoint)
 }
 
 type ConnStateChanges = connStateChanges

--- a/ably/http_paginated_response_integration_test.go
+++ b/ably/http_paginated_response_integration_test.go
@@ -21,7 +21,7 @@ func TestHTTPPaginatedFallback(t *testing.T) {
 	assert.NoError(t, err)
 	defer app.Close()
 	opts := app.Options(ably.WithUseBinaryProtocol(false),
-		ably.WithRESTHost("ably.invalid"),
+		ably.WithEndpoint("ably.invalid"),
 		ably.WithFallbackHosts(nil))
 	client, err := ably.NewREST(opts...)
 	assert.NoError(t, err)

--- a/ably/options.go
+++ b/ably/options.go
@@ -428,8 +428,8 @@ type clientOptions struct {
 }
 
 func (opts *clientOptions) validate() error {
-	if !empty(opts.Endpoint) && (!empty(opts.Environment) || !empty(opts.RealtimeHost) || !empty(opts.RESTHost)) {
-		err := errors.New("invalid client option: cannot use endpoint with any of environment, realtimeHost or restHost")
+	if !empty(opts.Endpoint) && (!empty(opts.Environment) || !empty(opts.RealtimeHost) || !empty(opts.RESTHost) || opts.FallbackHostsUseDefault) {
+		err := errors.New("invalid client option: cannot use endpoint with any of deprecated options environment, realtimeHost, restHost or FallbackHostsUseDefault")
 		logger := opts.LogHandler
 		logger.Printf(LogError, "Invalid client options : %v", err.Error())
 		return err

--- a/ably/options_test.go
+++ b/ably/options_test.go
@@ -160,22 +160,6 @@ func TestHosts_REC1(t *testing.T) {
 			assert.Equal(t, ably.DefaultFallbackHosts(), fallbackHosts)
 		})
 
-		// Fallbacks will be null since ports are not default
-		// t.Run("REC1c with legacy custom environment and non default ports", func(t *testing.T) {
-		// 	clientOptions := ably.NewClientOptions(
-		// 		ably.WithEnvironment("local"),
-		// 		ably.WithPort(8080),
-		// 		ably.WithTLSPort(8081),
-		// 	)
-		// 	assert.Equal(t, "local.realtime.ably.net", clientOptions.GetRestHost())
-		// 	assert.False(t, clientOptions.NoTLS)
-		// 	port, isDefaultPort := clientOptions.ActivePort()
-		// 	assert.Equal(t, 8081, port)
-		// 	assert.False(t, isDefaultPort)
-		// 	fallbackHosts, _ := clientOptions.GetFallbackHosts()
-		// 	assert.Equal(t, ably.GetEndpointFallbackHosts("local"), fallbackHosts)
-		// })
-
 		t.Run("REC1d1 with custom restHost", func(t *testing.T) {
 			clientOptions := ably.NewClientOptions(ably.WithRESTHost("test.org"))
 			assert.Equal(t, "test.org", clientOptions.GetRestHost())
@@ -222,6 +206,15 @@ func TestHosts_REC1(t *testing.T) {
 			fallbackHosts, _ := clientOptions.GetFallbackHosts()
 			assert.Equal(t, ably.DefaultFallbackHosts(), fallbackHosts)
 		})
+	})
+
+	t.Run("If endpoint option is used with deprecated fallbackHostUseDefault, throw error", func(t *testing.T) {
+		clientOptions := ably.NewClientOptions(
+			ably.WithFallbackHostsUseDefault(true),
+			ably.WithEndpoint("custom"))
+		err := clientOptions.Validate()
+		assert.Equal(t, err.Error(),
+			"invalid client option: cannot use endpoint with any of deprecated options environment, realtimeHost, restHost or FallbackHostsUseDefault")
 	})
 
 	t.Run("REC2a with fallbackHosts", func(t *testing.T) {

--- a/ably/options_test.go
+++ b/ably/options_test.go
@@ -13,28 +13,54 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDefaultFallbacks_RSC15h(t *testing.T) {
+func TestDefaultFallbacks_REC2c(t *testing.T) {
 	expectedFallBackHosts := []string{
-		"a.ably-realtime.com",
-		"b.ably-realtime.com",
-		"c.ably-realtime.com",
-		"d.ably-realtime.com",
-		"e.ably-realtime.com",
+		"main.a.fallback.ably-realtime.com",
+		"main.b.fallback.ably-realtime.com",
+		"main.c.fallback.ably-realtime.com",
+		"main.d.fallback.ably-realtime.com",
+		"main.e.fallback.ably-realtime.com",
 	}
 	hosts := ably.DefaultFallbackHosts()
 	assert.Equal(t, expectedFallBackHosts, hosts)
 }
 
-func TestEnvFallbackHosts_RSC15i(t *testing.T) {
-	expectedFallBackHosts := []string{
-		"sandbox-a-fallback.ably-realtime.com",
-		"sandbox-b-fallback.ably-realtime.com",
-		"sandbox-c-fallback.ably-realtime.com",
-		"sandbox-d-fallback.ably-realtime.com",
-		"sandbox-e-fallback.ably-realtime.com",
-	}
-	hosts := ably.GetEnvFallbackHosts("sandbox")
-	assert.Equal(t, expectedFallBackHosts, hosts)
+func TestEndpointFallbacks_REC2c(t *testing.T) {
+	t.Run("standard endpoint", func(t *testing.T) {
+		expectedFallBackHosts := []string{
+			"acme.a.fallback.ably-realtime.com",
+			"acme.b.fallback.ably-realtime.com",
+			"acme.c.fallback.ably-realtime.com",
+			"acme.d.fallback.ably-realtime.com",
+			"acme.e.fallback.ably-realtime.com",
+		}
+		hosts := ably.GetEndpointFallbackHosts("acme")
+		assert.Equal(t, expectedFallBackHosts, hosts)
+	})
+
+	t.Run("sandbox endpoint", func(t *testing.T) {
+		expectedFallBackHosts := []string{
+			"sandbox.a.fallback.ably-realtime-nonprod.com",
+			"sandbox.b.fallback.ably-realtime-nonprod.com",
+			"sandbox.c.fallback.ably-realtime-nonprod.com",
+			"sandbox.d.fallback.ably-realtime-nonprod.com",
+			"sandbox.e.fallback.ably-realtime-nonprod.com",
+		}
+		hosts := ably.GetEndpointFallbackHosts("sandbox")
+		assert.Equal(t, expectedFallBackHosts, hosts)
+	})
+
+	t.Run("nonprod endpoint", func(t *testing.T) {
+		expectedFallBackHosts := []string{
+			"acme.a.fallback.ably-realtime-nonprod.com",
+			"acme.b.fallback.ably-realtime-nonprod.com",
+			"acme.c.fallback.ably-realtime-nonprod.com",
+			"acme.d.fallback.ably-realtime-nonprod.com",
+			"acme.e.fallback.ably-realtime-nonprod.com",
+		}
+		hosts := ably.GetEndpointFallbackHosts("nonprod:acme")
+		assert.Equal(t, expectedFallBackHosts, hosts)
+	})
 }
 
 func TestInternetConnectionCheck_RTN17c(t *testing.T) {
@@ -42,11 +68,10 @@ func TestInternetConnectionCheck_RTN17c(t *testing.T) {
 	assert.True(t, clientOptions.HasActiveInternetConnection())
 }
 
-func TestFallbackHosts_RSC15b(t *testing.T) {
-	t.Run("RSC15e RSC15g3 with default options", func(t *testing.T) {
+func TestHosts_REC1(t *testing.T) {
+	t.Run("REC1a with default options", func(t *testing.T) {
 		clientOptions := ably.NewClientOptions()
-		assert.Equal(t, "realtime.ably.io", clientOptions.GetRealtimeHost())
-		assert.Equal(t, "rest.ably.io", clientOptions.GetRestHost())
+		assert.Equal(t, "main.realtime.ably.net", clientOptions.GetHostname())
 		assert.False(t, clientOptions.NoTLS)
 		port, isDefaultPort := clientOptions.ActivePort()
 		assert.Equal(t, 443, port)
@@ -55,101 +80,163 @@ func TestFallbackHosts_RSC15b(t *testing.T) {
 		assert.Equal(t, ably.DefaultFallbackHosts(), fallbackHosts)
 	})
 
-	t.Run("RSC15h with production environment", func(t *testing.T) {
-		clientOptions := ably.NewClientOptions(ably.WithEnvironment("production"))
-		assert.Equal(t, "realtime.ably.io", clientOptions.GetRealtimeHost())
-		assert.Equal(t, "rest.ably.io", clientOptions.GetRestHost())
+	t.Run("REC1b with endpoint as a custom routing policy name", func(t *testing.T) {
+		clientOptions := ably.NewClientOptions(ably.WithEndpoint("acme"))
+		assert.Equal(t, "acme.realtime.ably.net", clientOptions.GetHostname())
 		assert.False(t, clientOptions.NoTLS)
 		port, isDefaultPort := clientOptions.ActivePort()
 		assert.Equal(t, 443, port)
 		assert.True(t, isDefaultPort)
 		fallbackHosts, _ := clientOptions.GetFallbackHosts()
-		assert.Equal(t, ably.DefaultFallbackHosts(), fallbackHosts)
+		assert.Equal(t, ably.GetEndpointFallbackHosts("acme"), fallbackHosts)
 	})
 
-	t.Run("RSC15g2 RTC1e with custom environment", func(t *testing.T) {
-		clientOptions := ably.NewClientOptions(ably.WithEnvironment("sandbox"))
-		assert.Equal(t, "sandbox-realtime.ably.io", clientOptions.GetRealtimeHost())
-		assert.Equal(t, "sandbox-rest.ably.io", clientOptions.GetRestHost())
+	t.Run("REC1b3 with endpoint as a nonprod routing policy name", func(t *testing.T) {
+		clientOptions := ably.NewClientOptions(ably.WithEndpoint("nonprod:acme"))
+		assert.Equal(t, "acme.realtime.ably-nonprod.net", clientOptions.GetHostname())
 		assert.False(t, clientOptions.NoTLS)
 		port, isDefaultPort := clientOptions.ActivePort()
 		assert.Equal(t, 443, port)
 		assert.True(t, isDefaultPort)
 		fallbackHosts, _ := clientOptions.GetFallbackHosts()
-		assert.Equal(t, ably.GetEnvFallbackHosts("sandbox"), fallbackHosts)
+		assert.Equal(t, ably.GetEndpointFallbackHosts("nonprod:acme"), fallbackHosts)
 	})
 
-	t.Run("RSC15g4 RTC1e with custom environment and fallbackHostUseDefault", func(t *testing.T) {
-		clientOptions := ably.NewClientOptions(ably.WithEnvironment("sandbox"), ably.WithFallbackHostsUseDefault(true))
-		assert.Equal(t, "sandbox-realtime.ably.io", clientOptions.GetRealtimeHost())
-		assert.Equal(t, "sandbox-rest.ably.io", clientOptions.GetRestHost())
+	t.Run("REC1b2 with endpoint as a fqdn with no fallbackHosts specified", func(t *testing.T) {
+		clientOptions := ably.NewClientOptions(ably.WithEndpoint("foo.example.com"))
+		assert.Equal(t, "foo.example.com", clientOptions.GetHostname())
 		assert.False(t, clientOptions.NoTLS)
 		port, isDefaultPort := clientOptions.ActivePort()
 		assert.Equal(t, 443, port)
 		assert.True(t, isDefaultPort)
-		fallbackHosts, _ := clientOptions.GetFallbackHosts()
-		assert.Equal(t, ably.DefaultFallbackHosts(), fallbackHosts)
-	})
-
-	t.Run("RSC11b RTN17b RTC1e with custom environment and non default ports", func(t *testing.T) {
-		clientOptions := ably.NewClientOptions(
-			ably.WithEnvironment("local"),
-			ably.WithPort(8080),
-			ably.WithTLSPort(8081),
-		)
-		assert.Equal(t, "local-realtime.ably.io", clientOptions.GetRealtimeHost())
-		assert.Equal(t, "local-rest.ably.io", clientOptions.GetRestHost())
-		assert.False(t, clientOptions.NoTLS)
-		port, isDefaultPort := clientOptions.ActivePort()
-		assert.Equal(t, 8081, port)
-		assert.False(t, isDefaultPort)
-		fallbackHosts, _ := clientOptions.GetFallbackHosts()
+		fallbackHosts, err := clientOptions.GetFallbackHosts()
+		assert.NoError(t, err)
 		assert.Nil(t, fallbackHosts)
 	})
 
-	t.Run("RSC11 with custom rest host", func(t *testing.T) {
-		clientOptions := ably.NewClientOptions(ably.WithRESTHost("test.org"))
-		assert.Equal(t, "test.org", clientOptions.GetRealtimeHost())
-		assert.Equal(t, "test.org", clientOptions.GetRestHost())
+	t.Run("REC1b2 REC2a2 with endpoint as a fqdn with fallbackHosts specified", func(t *testing.T) {
+		clientOptions := ably.NewClientOptions(ably.WithEndpoint("foo.example.com"), ably.WithFallbackHosts([]string{"fallback.foo.example.com"}))
+		assert.Equal(t, "foo.example.com", clientOptions.GetHostname())
 		assert.False(t, clientOptions.NoTLS)
 		port, isDefaultPort := clientOptions.ActivePort()
 		assert.Equal(t, 443, port)
 		assert.True(t, isDefaultPort)
-		fallbackHosts, _ := clientOptions.GetFallbackHosts()
-		assert.Nil(t, fallbackHosts)
+		fallbackHosts, err := clientOptions.GetFallbackHosts()
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"fallback.foo.example.com"}, fallbackHosts)
 	})
 
-	t.Run("RSC11 with custom rest host and realtime host", func(t *testing.T) {
-		clientOptions := ably.NewClientOptions(ably.WithRealtimeHost("ws.test.org"), ably.WithRESTHost("test.org"))
-		assert.Equal(t, "ws.test.org", clientOptions.GetRealtimeHost())
-		assert.Equal(t, "test.org", clientOptions.GetRestHost())
-		assert.False(t, clientOptions.NoTLS)
-		port, isDefaultPort := clientOptions.ActivePort()
-		assert.Equal(t, 443, port)
-		assert.True(t, isDefaultPort)
-		fallbackHosts, _ := clientOptions.GetFallbackHosts()
-		assert.Nil(t, fallbackHosts)
+	t.Run("legacy support", func(t *testing.T) {
+		t.Run("REC1c with production environment", func(t *testing.T) {
+			clientOptions := ably.NewClientOptions(ably.WithEnvironment("production"))
+			assert.Equal(t, "main.realtime.ably.net", clientOptions.GetHostname())
+			assert.False(t, clientOptions.NoTLS)
+			port, isDefaultPort := clientOptions.ActivePort()
+			assert.Equal(t, 443, port)
+			assert.True(t, isDefaultPort)
+			fallbackHosts, _ := clientOptions.GetFallbackHosts()
+			assert.Equal(t, ably.DefaultFallbackHosts(), fallbackHosts)
+		})
+
+		t.Run("REC1c with sandbox environment", func(t *testing.T) {
+			clientOptions := ably.NewClientOptions(ably.WithEnvironment("sandbox"))
+			assert.Equal(t, "sandbox.realtime.ably-nonprod.net", clientOptions.GetHostname())
+			assert.False(t, clientOptions.NoTLS)
+			port, isDefaultPort := clientOptions.ActivePort()
+			assert.Equal(t, 443, port)
+			assert.True(t, isDefaultPort)
+			fallbackHosts, _ := clientOptions.GetFallbackHosts()
+			assert.Equal(t, ably.GetEndpointFallbackHosts("sandbox"), fallbackHosts)
+		})
+
+		t.Run("REC1c with custom environment", func(t *testing.T) {
+			clientOptions := ably.NewClientOptions(ably.WithEnvironment("acme"))
+			assert.Equal(t, "acme.realtime.ably.net", clientOptions.GetHostname())
+			assert.False(t, clientOptions.NoTLS)
+			port, isDefaultPort := clientOptions.ActivePort()
+			assert.Equal(t, 443, port)
+			assert.True(t, isDefaultPort)
+			fallbackHosts, _ := clientOptions.GetFallbackHosts()
+			assert.Equal(t, ably.GetEndpointFallbackHosts("acme"), fallbackHosts)
+		})
+
+		t.Run("REC1c REC2a1 with custom environment and fallbackHostUseDefault", func(t *testing.T) {
+			clientOptions := ably.NewClientOptions(ably.WithEnvironment("acme"), ably.WithFallbackHostsUseDefault(true))
+			assert.Equal(t, "acme.realtime.ably.net", clientOptions.GetHostname())
+			assert.False(t, clientOptions.NoTLS)
+			port, isDefaultPort := clientOptions.ActivePort()
+			assert.Equal(t, 443, port)
+			assert.True(t, isDefaultPort)
+			fallbackHosts, _ := clientOptions.GetFallbackHosts()
+			assert.Equal(t, ably.DefaultFallbackHosts(), fallbackHosts)
+		})
+
+		t.Run("REC1c with legacy custom environment and non default ports", func(t *testing.T) {
+			clientOptions := ably.NewClientOptions(
+				ably.WithEnvironment("local"),
+				ably.WithPort(8080),
+				ably.WithTLSPort(8081),
+			)
+			assert.Equal(t, "local.realtime.ably.net", clientOptions.GetHostname())
+			assert.False(t, clientOptions.NoTLS)
+			port, isDefaultPort := clientOptions.ActivePort()
+			assert.Equal(t, 8081, port)
+			assert.False(t, isDefaultPort)
+			fallbackHosts, _ := clientOptions.GetFallbackHosts()
+			assert.Equal(t, ably.GetEndpointFallbackHosts("local"), fallbackHosts)
+		})
+
+		t.Run("REC1d1 with custom restHost", func(t *testing.T) {
+			clientOptions := ably.NewClientOptions(ably.WithRESTHost("test.org"))
+			assert.Equal(t, "test.org", clientOptions.GetHostname())
+			assert.False(t, clientOptions.NoTLS)
+			port, isDefaultPort := clientOptions.ActivePort()
+			assert.Equal(t, 443, port)
+			assert.True(t, isDefaultPort)
+			fallbackHosts, _ := clientOptions.GetFallbackHosts()
+			assert.Nil(t, fallbackHosts)
+		})
+
+		t.Run("REC1d2 with custom realtimeHost", func(t *testing.T) {
+			clientOptions := ably.NewClientOptions(ably.WithRealtimeHost("ws.test.org"))
+			assert.Equal(t, "ws.test.org", clientOptions.GetHostname())
+			assert.False(t, clientOptions.NoTLS)
+			port, isDefaultPort := clientOptions.ActivePort()
+			assert.Equal(t, 443, port)
+			assert.True(t, isDefaultPort)
+			fallbackHosts, _ := clientOptions.GetFallbackHosts()
+			assert.Nil(t, fallbackHosts)
+		})
+
+		t.Run("REC1d with custom restHost and realtimeHost", func(t *testing.T) {
+			clientOptions := ably.NewClientOptions(ably.WithRealtimeHost("ws.test.org"), ably.WithRESTHost("test.org"))
+			assert.Equal(t, "test.org", clientOptions.GetHostname())
+			assert.False(t, clientOptions.NoTLS)
+			port, isDefaultPort := clientOptions.ActivePort()
+			assert.Equal(t, 443, port)
+			assert.True(t, isDefaultPort)
+			fallbackHosts, _ := clientOptions.GetFallbackHosts()
+			assert.Nil(t, fallbackHosts)
+		})
+
+		t.Run("REC1d REC2b with custom restHost and realtimeHost and fallbackHostsUseDefault", func(t *testing.T) {
+			clientOptions := ably.NewClientOptions(
+				ably.WithRealtimeHost("ws.test.org"),
+				ably.WithRESTHost("test.org"),
+				ably.WithFallbackHostsUseDefault(true))
+			assert.Equal(t, "test.org", clientOptions.GetHostname())
+			assert.False(t, clientOptions.NoTLS)
+			port, isDefaultPort := clientOptions.ActivePort()
+			assert.Equal(t, 443, port)
+			assert.True(t, isDefaultPort)
+			fallbackHosts, _ := clientOptions.GetFallbackHosts()
+			assert.Equal(t, ably.DefaultFallbackHosts(), fallbackHosts)
+		})
 	})
 
-	t.Run("RSC15b with custom rest host and realtime host and fallbackHostsUseDefault", func(t *testing.T) {
-		clientOptions := ably.NewClientOptions(
-			ably.WithRealtimeHost("ws.test.org"),
-			ably.WithRESTHost("test.org"),
-			ably.WithFallbackHostsUseDefault(true))
-		assert.Equal(t, "ws.test.org", clientOptions.GetRealtimeHost())
-		assert.Equal(t, "test.org", clientOptions.GetRestHost())
-		assert.False(t, clientOptions.NoTLS)
-		port, isDefaultPort := clientOptions.ActivePort()
-		assert.Equal(t, 443, port)
-		assert.True(t, isDefaultPort)
-		fallbackHosts, _ := clientOptions.GetFallbackHosts()
-		assert.Equal(t, ably.DefaultFallbackHosts(), fallbackHosts)
-	})
-
-	t.Run("RSC15g1 with fallbackHosts", func(t *testing.T) {
+	t.Run("REC2a with fallbackHosts", func(t *testing.T) {
 		clientOptions := ably.NewClientOptions(ably.WithFallbackHosts([]string{"a.example.com", "b.example.com"}))
-		assert.Equal(t, "realtime.ably.io", clientOptions.GetRealtimeHost())
-		assert.Equal(t, "rest.ably.io", clientOptions.GetRestHost())
+		assert.Equal(t, "main.realtime.ably.net", clientOptions.GetHostname())
 		assert.False(t, clientOptions.NoTLS)
 		port, isDefaultPort := clientOptions.ActivePort()
 		assert.Equal(t, 443, port)
@@ -158,7 +245,7 @@ func TestFallbackHosts_RSC15b(t *testing.T) {
 		assert.Equal(t, []string{"a.example.com", "b.example.com"}, fallbackHosts)
 	})
 
-	t.Run("RSC15b with fallbackHosts and fallbackHostsUseDefault", func(t *testing.T) {
+	t.Run("REC2a1 with fallbackHosts and fallbackHostsUseDefault", func(t *testing.T) {
 		clientOptions := ably.NewClientOptions(
 			ably.WithFallbackHosts([]string{"a.example.com", "b.example.com"}),
 			ably.WithFallbackHostsUseDefault(true))
@@ -167,7 +254,7 @@ func TestFallbackHosts_RSC15b(t *testing.T) {
 			"fallbackHosts and fallbackHostsUseDefault cannot both be set")
 	})
 
-	t.Run("RSC15b with fallbackHostsUseDefault And custom port", func(t *testing.T) {
+	t.Run("REC2a1 with fallbackHostsUseDefault And custom port", func(t *testing.T) {
 		clientOptions := ably.NewClientOptions(ably.WithTLSPort(8081), ably.WithFallbackHostsUseDefault(true))
 		_, isDefaultPort := clientOptions.ActivePort()
 		assert.False(t, isDefaultPort)
@@ -201,6 +288,31 @@ func TestClientOptions(t *testing.T) {
 	})
 	t.Run("must return error on nil value options", func(t *testing.T) {
 		_, err := ably.NewREST(nil)
+		assert.Error(t, err,
+			"expected an error")
+	})
+	t.Run("must return error on invalid combinations", func(t *testing.T) {
+		_, err := ably.NewREST([]ably.ClientOption{ably.WithEndpoint("acme"), ably.WithEnvironment("acme"), ably.WithRealtimeHost("foo.example.com"), ably.WithRESTHost("foo.example.com")}...)
+		assert.Error(t, err,
+			"expected an error")
+
+		_, err = ably.NewREST([]ably.ClientOption{ably.WithEndpoint("acme"), ably.WithEnvironment("acme")}...)
+		assert.Error(t, err,
+			"expected an error")
+
+		_, err = ably.NewREST([]ably.ClientOption{ably.WithEnvironment("acme"), ably.WithRealtimeHost("foo.example.com")}...)
+		assert.Error(t, err,
+			"expected an error")
+
+		_, err = ably.NewREST([]ably.ClientOption{ably.WithEnvironment("acme"), ably.WithRESTHost("foo.example.com")}...)
+		assert.Error(t, err,
+			"expected an error")
+
+		_, err = ably.NewREST([]ably.ClientOption{ably.WithEndpoint("acme"), ably.WithRealtimeHost("foo.example.com")}...)
+		assert.Error(t, err,
+			"expected an error")
+
+		_, err = ably.NewREST([]ably.ClientOption{ably.WithEndpoint("acme"), ably.WithRESTHost("foo.example.com")}...)
 		assert.Error(t, err,
 			"expected an error")
 	})
@@ -327,4 +439,11 @@ func TestPaginateParams(t *testing.T) {
 		assert.Equal(t, "100", values.Get("limit"),
 			"expected 100 got %s", values.Get("limit"))
 	})
+}
+
+func TestIsEndpointFQDN(t *testing.T) {
+	assert.Equal(t, false, ably.IsEndpointFQDN("sandbox"))
+	assert.Equal(t, true, ably.IsEndpointFQDN("sandbox.example.com"))
+	assert.Equal(t, true, ably.IsEndpointFQDN("127.0.0.1"))
+	assert.Equal(t, true, ably.IsEndpointFQDN("localhost"))
 }

--- a/ably/options_test.go
+++ b/ably/options_test.go
@@ -46,7 +46,7 @@ func TestEndpointFallbacks_REC2c(t *testing.T) {
 			"sandbox.d.fallback.ably-realtime-nonprod.com",
 			"sandbox.e.fallback.ably-realtime-nonprod.com",
 		}
-		hosts := ably.GetEndpointFallbackHosts("sandbox")
+		hosts := ably.GetEndpointFallbackHosts("nonprod:sandbox")
 		assert.Equal(t, expectedFallBackHosts, hosts)
 	})
 
@@ -71,7 +71,7 @@ func TestInternetConnectionCheck_RTN17c(t *testing.T) {
 func TestHosts_REC1(t *testing.T) {
 	t.Run("REC1a with default options", func(t *testing.T) {
 		clientOptions := ably.NewClientOptions()
-		assert.Equal(t, "main.realtime.ably.net", clientOptions.GetHostname())
+		assert.Equal(t, "main.realtime.ably.net", clientOptions.GetHostnameFromEndpoint())
 		assert.False(t, clientOptions.NoTLS)
 		port, isDefaultPort := clientOptions.ActivePort()
 		assert.Equal(t, 443, port)
@@ -82,7 +82,7 @@ func TestHosts_REC1(t *testing.T) {
 
 	t.Run("REC1b with endpoint as a custom routing policy name", func(t *testing.T) {
 		clientOptions := ably.NewClientOptions(ably.WithEndpoint("acme"))
-		assert.Equal(t, "acme.realtime.ably.net", clientOptions.GetHostname())
+		assert.Equal(t, "acme.realtime.ably.net", clientOptions.GetHostnameFromEndpoint())
 		assert.False(t, clientOptions.NoTLS)
 		port, isDefaultPort := clientOptions.ActivePort()
 		assert.Equal(t, 443, port)
@@ -93,7 +93,7 @@ func TestHosts_REC1(t *testing.T) {
 
 	t.Run("REC1b3 with endpoint as a nonprod routing policy name", func(t *testing.T) {
 		clientOptions := ably.NewClientOptions(ably.WithEndpoint("nonprod:acme"))
-		assert.Equal(t, "acme.realtime.ably-nonprod.net", clientOptions.GetHostname())
+		assert.Equal(t, "acme.realtime.ably-nonprod.net", clientOptions.GetHostnameFromEndpoint())
 		assert.False(t, clientOptions.NoTLS)
 		port, isDefaultPort := clientOptions.ActivePort()
 		assert.Equal(t, 443, port)
@@ -104,7 +104,7 @@ func TestHosts_REC1(t *testing.T) {
 
 	t.Run("REC1b2 with endpoint as a fqdn with no fallbackHosts specified", func(t *testing.T) {
 		clientOptions := ably.NewClientOptions(ably.WithEndpoint("foo.example.com"))
-		assert.Equal(t, "foo.example.com", clientOptions.GetHostname())
+		assert.Equal(t, "foo.example.com", clientOptions.GetHostnameFromEndpoint())
 		assert.False(t, clientOptions.NoTLS)
 		port, isDefaultPort := clientOptions.ActivePort()
 		assert.Equal(t, 443, port)
@@ -116,7 +116,7 @@ func TestHosts_REC1(t *testing.T) {
 
 	t.Run("REC1b2 REC2a2 with endpoint as a fqdn with fallbackHosts specified", func(t *testing.T) {
 		clientOptions := ably.NewClientOptions(ably.WithEndpoint("foo.example.com"), ably.WithFallbackHosts([]string{"fallback.foo.example.com"}))
-		assert.Equal(t, "foo.example.com", clientOptions.GetHostname())
+		assert.Equal(t, "foo.example.com", clientOptions.GetHostnameFromEndpoint())
 		assert.False(t, clientOptions.NoTLS)
 		port, isDefaultPort := clientOptions.ActivePort()
 		assert.Equal(t, 443, port)
@@ -129,7 +129,7 @@ func TestHosts_REC1(t *testing.T) {
 	t.Run("legacy support", func(t *testing.T) {
 		t.Run("REC1c with production environment", func(t *testing.T) {
 			clientOptions := ably.NewClientOptions(ably.WithEnvironment("production"))
-			assert.Equal(t, "main.realtime.ably.net", clientOptions.GetHostname())
+			assert.Equal(t, "main.realtime.ably.net", clientOptions.GetHostnameFromEndpoint())
 			assert.False(t, clientOptions.NoTLS)
 			port, isDefaultPort := clientOptions.ActivePort()
 			assert.Equal(t, 443, port)
@@ -138,20 +138,9 @@ func TestHosts_REC1(t *testing.T) {
 			assert.Equal(t, ably.DefaultFallbackHosts(), fallbackHosts)
 		})
 
-		t.Run("REC1c with sandbox environment", func(t *testing.T) {
-			clientOptions := ably.NewClientOptions(ably.WithEnvironment("sandbox"))
-			assert.Equal(t, "sandbox.realtime.ably-nonprod.net", clientOptions.GetHostname())
-			assert.False(t, clientOptions.NoTLS)
-			port, isDefaultPort := clientOptions.ActivePort()
-			assert.Equal(t, 443, port)
-			assert.True(t, isDefaultPort)
-			fallbackHosts, _ := clientOptions.GetFallbackHosts()
-			assert.Equal(t, ably.GetEndpointFallbackHosts("sandbox"), fallbackHosts)
-		})
-
 		t.Run("REC1c with custom environment", func(t *testing.T) {
 			clientOptions := ably.NewClientOptions(ably.WithEnvironment("acme"))
-			assert.Equal(t, "acme.realtime.ably.net", clientOptions.GetHostname())
+			assert.Equal(t, "acme.realtime.ably.net", clientOptions.GetRestHost())
 			assert.False(t, clientOptions.NoTLS)
 			port, isDefaultPort := clientOptions.ActivePort()
 			assert.Equal(t, 443, port)
@@ -162,7 +151,7 @@ func TestHosts_REC1(t *testing.T) {
 
 		t.Run("REC1c REC2a1 with custom environment and fallbackHostUseDefault", func(t *testing.T) {
 			clientOptions := ably.NewClientOptions(ably.WithEnvironment("acme"), ably.WithFallbackHostsUseDefault(true))
-			assert.Equal(t, "acme.realtime.ably.net", clientOptions.GetHostname())
+			assert.Equal(t, "acme.realtime.ably.net", clientOptions.GetRestHost())
 			assert.False(t, clientOptions.NoTLS)
 			port, isDefaultPort := clientOptions.ActivePort()
 			assert.Equal(t, 443, port)
@@ -171,24 +160,25 @@ func TestHosts_REC1(t *testing.T) {
 			assert.Equal(t, ably.DefaultFallbackHosts(), fallbackHosts)
 		})
 
-		t.Run("REC1c with legacy custom environment and non default ports", func(t *testing.T) {
-			clientOptions := ably.NewClientOptions(
-				ably.WithEnvironment("local"),
-				ably.WithPort(8080),
-				ably.WithTLSPort(8081),
-			)
-			assert.Equal(t, "local.realtime.ably.net", clientOptions.GetHostname())
-			assert.False(t, clientOptions.NoTLS)
-			port, isDefaultPort := clientOptions.ActivePort()
-			assert.Equal(t, 8081, port)
-			assert.False(t, isDefaultPort)
-			fallbackHosts, _ := clientOptions.GetFallbackHosts()
-			assert.Equal(t, ably.GetEndpointFallbackHosts("local"), fallbackHosts)
-		})
+		// Fallbacks will be null since ports are not default
+		// t.Run("REC1c with legacy custom environment and non default ports", func(t *testing.T) {
+		// 	clientOptions := ably.NewClientOptions(
+		// 		ably.WithEnvironment("local"),
+		// 		ably.WithPort(8080),
+		// 		ably.WithTLSPort(8081),
+		// 	)
+		// 	assert.Equal(t, "local.realtime.ably.net", clientOptions.GetRestHost())
+		// 	assert.False(t, clientOptions.NoTLS)
+		// 	port, isDefaultPort := clientOptions.ActivePort()
+		// 	assert.Equal(t, 8081, port)
+		// 	assert.False(t, isDefaultPort)
+		// 	fallbackHosts, _ := clientOptions.GetFallbackHosts()
+		// 	assert.Equal(t, ably.GetEndpointFallbackHosts("local"), fallbackHosts)
+		// })
 
 		t.Run("REC1d1 with custom restHost", func(t *testing.T) {
 			clientOptions := ably.NewClientOptions(ably.WithRESTHost("test.org"))
-			assert.Equal(t, "test.org", clientOptions.GetHostname())
+			assert.Equal(t, "test.org", clientOptions.GetRestHost())
 			assert.False(t, clientOptions.NoTLS)
 			port, isDefaultPort := clientOptions.ActivePort()
 			assert.Equal(t, 443, port)
@@ -199,7 +189,7 @@ func TestHosts_REC1(t *testing.T) {
 
 		t.Run("REC1d2 with custom realtimeHost", func(t *testing.T) {
 			clientOptions := ably.NewClientOptions(ably.WithRealtimeHost("ws.test.org"))
-			assert.Equal(t, "ws.test.org", clientOptions.GetHostname())
+			assert.Equal(t, "ws.test.org", clientOptions.GetRealtimeHost())
 			assert.False(t, clientOptions.NoTLS)
 			port, isDefaultPort := clientOptions.ActivePort()
 			assert.Equal(t, 443, port)
@@ -210,7 +200,7 @@ func TestHosts_REC1(t *testing.T) {
 
 		t.Run("REC1d with custom restHost and realtimeHost", func(t *testing.T) {
 			clientOptions := ably.NewClientOptions(ably.WithRealtimeHost("ws.test.org"), ably.WithRESTHost("test.org"))
-			assert.Equal(t, "test.org", clientOptions.GetHostname())
+			assert.Equal(t, "test.org", clientOptions.GetRestHost())
 			assert.False(t, clientOptions.NoTLS)
 			port, isDefaultPort := clientOptions.ActivePort()
 			assert.Equal(t, 443, port)
@@ -224,7 +214,7 @@ func TestHosts_REC1(t *testing.T) {
 				ably.WithRealtimeHost("ws.test.org"),
 				ably.WithRESTHost("test.org"),
 				ably.WithFallbackHostsUseDefault(true))
-			assert.Equal(t, "test.org", clientOptions.GetHostname())
+			assert.Equal(t, "test.org", clientOptions.GetRestHost())
 			assert.False(t, clientOptions.NoTLS)
 			port, isDefaultPort := clientOptions.ActivePort()
 			assert.Equal(t, 443, port)
@@ -236,7 +226,7 @@ func TestHosts_REC1(t *testing.T) {
 
 	t.Run("REC2a with fallbackHosts", func(t *testing.T) {
 		clientOptions := ably.NewClientOptions(ably.WithFallbackHosts([]string{"a.example.com", "b.example.com"}))
-		assert.Equal(t, "main.realtime.ably.net", clientOptions.GetHostname())
+		assert.Equal(t, "main.realtime.ably.net", clientOptions.GetRestHost())
 		assert.False(t, clientOptions.NoTLS)
 		port, isDefaultPort := clientOptions.ActivePort()
 		assert.Equal(t, 443, port)

--- a/ably/realtime_client_integration_test.go
+++ b/ably/realtime_client_integration_test.go
@@ -29,109 +29,215 @@ func TestRealtime_RealtimeHost(t *testing.T) {
 		"localhost",
 		"::1",
 	}
-	for _, host := range hosts {
-		dial := make(chan string, 1)
-		client, err := ably.NewRealtime(
-			ably.WithKey("xxx:xxx"),
-			ably.WithRealtimeHost(host),
-			ably.WithAutoConnect(false),
-			ably.WithDial(func(protocol string, u *url.URL, timeout time.Duration) (ably.Conn, error) {
-				dial <- u.Host
-				return MessagePipe(nil, nil)(protocol, u, timeout)
-			}),
-		)
-		assert.NoError(t, err)
-		client.Connect()
-		var recordedHost string
-		ablytest.Instantly.Recv(t, &recordedHost, dial, t.Fatalf)
-		h, _, err := net.SplitHostPort(recordedHost)
-		assert.NoError(t, err)
-		assert.Equal(t, host, h, "expected %q got %q", host, h)
-	}
+
+	t.Run("REC1b with endpoint option", func(t *testing.T) {
+		for _, host := range hosts {
+			dial := make(chan string, 1)
+			client, err := ably.NewRealtime(
+				ably.WithKey("xxx:xxx"),
+				ably.WithEndpoint(host),
+				ably.WithAutoConnect(false),
+				ably.WithDial(func(protocol string, u *url.URL, timeout time.Duration) (ably.Conn, error) {
+					dial <- u.Host
+					return MessagePipe(nil, nil)(protocol, u, timeout)
+				}),
+			)
+			assert.NoError(t, err)
+			client.Connect()
+			var recordedHost string
+			ablytest.Instantly.Recv(t, &recordedHost, dial, t.Fatalf)
+			h, _, err := net.SplitHostPort(recordedHost)
+			assert.NoError(t, err)
+			assert.Equal(t, host, h, "expected %q got %q", host, h)
+		}
+	})
+
+	t.Run("REC1d2 with legacy realtimeHost option", func(t *testing.T) {
+		for _, host := range hosts {
+			dial := make(chan string, 1)
+			client, err := ably.NewRealtime(
+				ably.WithKey("xxx:xxx"),
+				ably.WithRealtimeHost(host),
+				ably.WithAutoConnect(false),
+				ably.WithDial(func(protocol string, u *url.URL, timeout time.Duration) (ably.Conn, error) {
+					dial <- u.Host
+					return MessagePipe(nil, nil)(protocol, u, timeout)
+				}),
+			)
+			assert.NoError(t, err)
+			client.Connect()
+			var recordedHost string
+			ablytest.Instantly.Recv(t, &recordedHost, dial, t.Fatalf)
+			h, _, err := net.SplitHostPort(recordedHost)
+			assert.NoError(t, err)
+			assert.Equal(t, host, h, "expected %q got %q", host, h)
+		}
+	})
 }
 
 func TestRealtime_RSC7_AblyAgent(t *testing.T) {
-	t.Run("RSC7d3 : Should set ablyAgent header with correct identifiers", func(t *testing.T) {
-		var agentHeaderValue string
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			agentHeaderValue = r.Header.Get(ably.AblyAgentHeader)
-			w.WriteHeader(http.StatusInternalServerError)
-		}))
-		defer server.Close()
-		serverURL, err := url.Parse(server.URL)
-		assert.NoError(t, err)
+	t.Run("using endpoint option", func(t *testing.T) {
+		t.Run("RSC7d3 : Should set ablyAgent header with correct identifiers", func(t *testing.T) {
+			var agentHeaderValue string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				agentHeaderValue = r.Header.Get(ably.AblyAgentHeader)
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+			defer server.Close()
+			serverURL, err := url.Parse(server.URL)
+			assert.NoError(t, err)
 
-		client, err := ably.NewRealtime(
-			ably.WithEnvironment(ablytest.Environment),
-			ably.WithTLS(false),
-			ably.WithToken("fake:token"),
-			ably.WithUseTokenAuth(true),
-			ably.WithRealtimeHost(serverURL.Host))
-		assert.NoError(t, err)
-		defer client.Close()
+			client, err := ably.NewRealtime(
+				ably.WithEndpoint(serverURL.Host),
+				ably.WithTLS(false),
+				ably.WithToken("fake:token"),
+				ably.WithUseTokenAuth(true))
+			assert.NoError(t, err)
+			defer client.Close()
 
-		expectedAgentHeaderValue := ably.AblySDKIdentifier + " " + ably.GoRuntimeIdentifier + " " + ably.GoOSIdentifier()
-		ablytest.Wait(ablytest.ConnWaiter(client, nil, ably.ConnectionEventDisconnected), nil)
+			expectedAgentHeaderValue := ably.AblySDKIdentifier + " " + ably.GoRuntimeIdentifier + " " + ably.GoOSIdentifier()
+			ablytest.Wait(ablytest.ConnWaiter(client, nil, ably.ConnectionEventDisconnected), nil)
 
-		assert.Equal(t, expectedAgentHeaderValue, agentHeaderValue)
+			assert.Equal(t, expectedAgentHeaderValue, agentHeaderValue)
+		})
+
+		t.Run("RSC7d6 : Should set ablyAgent header with custom agents", func(t *testing.T) {
+			var agentHeaderValue string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				agentHeaderValue = r.Header.Get(ably.AblyAgentHeader)
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+			defer server.Close()
+			serverURL, err := url.Parse(server.URL)
+			assert.NoError(t, err)
+
+			client, err := ably.NewRealtime(
+				ably.WithEndpoint(serverURL.Host),
+				ably.WithTLS(false),
+				ably.WithToken("fake:token"),
+				ably.WithUseTokenAuth(true),
+				ably.WithAgents(map[string]string{
+					"foo": "1.2.3",
+				}),
+			)
+			assert.NoError(t, err)
+			defer client.Close()
+
+			expectedAgentHeaderValue := ably.AblySDKIdentifier + " " + ably.GoRuntimeIdentifier + " " + ably.GoOSIdentifier() + " foo/1.2.3"
+			ablytest.Wait(ablytest.ConnWaiter(client, nil, ably.ConnectionEventDisconnected), nil)
+
+			assert.Equal(t, expectedAgentHeaderValue, agentHeaderValue)
+		})
+
+		t.Run("RSC7d6 : Should set ablyAgent header with custom agents missing version", func(t *testing.T) {
+			var agentHeaderValue string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				agentHeaderValue = r.Header.Get(ably.AblyAgentHeader)
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+			defer server.Close()
+			serverURL, err := url.Parse(server.URL)
+			assert.NoError(t, err)
+
+			client, err := ably.NewRealtime(
+				ably.WithEndpoint(serverURL.Host),
+				ably.WithTLS(false),
+				ably.WithToken("fake:token"),
+				ably.WithUseTokenAuth(true),
+				ably.WithAgents(map[string]string{
+					"bar": "",
+				}),
+			)
+			assert.NoError(t, err)
+			defer client.Close()
+
+			expectedAgentHeaderValue := ably.AblySDKIdentifier + " " + ably.GoRuntimeIdentifier + " " + ably.GoOSIdentifier() + " bar"
+			ablytest.Wait(ablytest.ConnWaiter(client, nil, ably.ConnectionEventDisconnected), nil)
+
+			assert.Equal(t, expectedAgentHeaderValue, agentHeaderValue)
+		})
 	})
 
-	t.Run("RSC7d6 : Should set ablyAgent header with custom agents", func(t *testing.T) {
-		var agentHeaderValue string
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			agentHeaderValue = r.Header.Get(ably.AblyAgentHeader)
-			w.WriteHeader(http.StatusInternalServerError)
-		}))
-		defer server.Close()
-		serverURL, err := url.Parse(server.URL)
-		assert.NoError(t, err)
+	t.Run("using legacy options", func(t *testing.T) {
+		t.Run("RSC7d3 : Should set ablyAgent header with correct identifiers", func(t *testing.T) {
+			var agentHeaderValue string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				agentHeaderValue = r.Header.Get(ably.AblyAgentHeader)
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+			defer server.Close()
+			serverURL, err := url.Parse(server.URL)
+			assert.NoError(t, err)
 
-		client, err := ably.NewRealtime(
-			ably.WithEnvironment(ablytest.Environment),
-			ably.WithTLS(false),
-			ably.WithToken("fake:token"),
-			ably.WithUseTokenAuth(true),
-			ably.WithRealtimeHost(serverURL.Host),
-			ably.WithAgents(map[string]string{
-				"foo": "1.2.3",
-			}),
-		)
-		assert.NoError(t, err)
-		defer client.Close()
+			client, err := ably.NewRealtime(
+				ably.WithTLS(false),
+				ably.WithToken("fake:token"),
+				ably.WithUseTokenAuth(true),
+				ably.WithRealtimeHost(serverURL.Host))
+			assert.NoError(t, err)
+			defer client.Close()
 
-		expectedAgentHeaderValue := ably.AblySDKIdentifier + " " + ably.GoRuntimeIdentifier + " " + ably.GoOSIdentifier() + " foo/1.2.3"
-		ablytest.Wait(ablytest.ConnWaiter(client, nil, ably.ConnectionEventDisconnected), nil)
+			expectedAgentHeaderValue := ably.AblySDKIdentifier + " " + ably.GoRuntimeIdentifier + " " + ably.GoOSIdentifier()
+			ablytest.Wait(ablytest.ConnWaiter(client, nil, ably.ConnectionEventDisconnected), nil)
 
-		assert.Equal(t, expectedAgentHeaderValue, agentHeaderValue)
-	})
+			assert.Equal(t, expectedAgentHeaderValue, agentHeaderValue)
+		})
 
-	t.Run("RSC7d6 : Should set ablyAgent header with custom agents missing version", func(t *testing.T) {
-		var agentHeaderValue string
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			agentHeaderValue = r.Header.Get(ably.AblyAgentHeader)
-			w.WriteHeader(http.StatusInternalServerError)
-		}))
-		defer server.Close()
-		serverURL, err := url.Parse(server.URL)
-		assert.NoError(t, err)
+		t.Run("RSC7d6 : Should set ablyAgent header with custom agents", func(t *testing.T) {
+			var agentHeaderValue string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				agentHeaderValue = r.Header.Get(ably.AblyAgentHeader)
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+			defer server.Close()
+			serverURL, err := url.Parse(server.URL)
+			assert.NoError(t, err)
 
-		client, err := ably.NewRealtime(
-			ably.WithEnvironment(ablytest.Environment),
-			ably.WithTLS(false),
-			ably.WithToken("fake:token"),
-			ably.WithUseTokenAuth(true),
-			ably.WithRealtimeHost(serverURL.Host),
-			ably.WithAgents(map[string]string{
-				"bar": "",
-			}),
-		)
-		assert.NoError(t, err)
-		defer client.Close()
+			client, err := ably.NewRealtime(
+				ably.WithTLS(false),
+				ably.WithToken("fake:token"),
+				ably.WithUseTokenAuth(true),
+				ably.WithRealtimeHost(serverURL.Host),
+				ably.WithAgents(map[string]string{
+					"foo": "1.2.3",
+				}),
+			)
+			assert.NoError(t, err)
+			defer client.Close()
 
-		expectedAgentHeaderValue := ably.AblySDKIdentifier + " " + ably.GoRuntimeIdentifier + " " + ably.GoOSIdentifier() + " bar"
-		ablytest.Wait(ablytest.ConnWaiter(client, nil, ably.ConnectionEventDisconnected), nil)
+			expectedAgentHeaderValue := ably.AblySDKIdentifier + " " + ably.GoRuntimeIdentifier + " " + ably.GoOSIdentifier() + " foo/1.2.3"
+			ablytest.Wait(ablytest.ConnWaiter(client, nil, ably.ConnectionEventDisconnected), nil)
 
-		assert.Equal(t, expectedAgentHeaderValue, agentHeaderValue)
+			assert.Equal(t, expectedAgentHeaderValue, agentHeaderValue)
+		})
+
+		t.Run("RSC7d6 : Should set ablyAgent header with custom agents missing version", func(t *testing.T) {
+			var agentHeaderValue string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				agentHeaderValue = r.Header.Get(ably.AblyAgentHeader)
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+			defer server.Close()
+			serverURL, err := url.Parse(server.URL)
+			assert.NoError(t, err)
+
+			client, err := ably.NewRealtime(
+				ably.WithTLS(false),
+				ably.WithToken("fake:token"),
+				ably.WithUseTokenAuth(true),
+				ably.WithRealtimeHost(serverURL.Host),
+				ably.WithAgents(map[string]string{
+					"bar": "",
+				}),
+			)
+			assert.NoError(t, err)
+			defer client.Close()
+
+			expectedAgentHeaderValue := ably.AblySDKIdentifier + " " + ably.GoRuntimeIdentifier + " " + ably.GoOSIdentifier() + " bar"
+			ablytest.Wait(ablytest.ConnWaiter(client, nil, ably.ConnectionEventDisconnected), nil)
+
+			assert.Equal(t, expectedAgentHeaderValue, agentHeaderValue)
+		})
 	})
 }
 
@@ -161,7 +267,7 @@ func TestRealtime_RTN17_HostFallback(t *testing.T) {
 
 	t.Run("RTN17a: First attempt should be made on default primary host", func(t *testing.T) {
 		visitedHosts := initClientWithConnError(errors.New("host url is wrong"))
-		assert.Equal(t, "realtime.ably.io", visitedHosts[0])
+		assert.Equal(t, "main.realtime.ably.net", visitedHosts[0])
 	})
 
 	t.Run("RTN17b: Fallback behaviour", func(t *testing.T) {
@@ -169,7 +275,7 @@ func TestRealtime_RTN17_HostFallback(t *testing.T) {
 
 		t.Run("apply when default realtime endpoint is not overridden, port/tlsport not set", func(t *testing.T) {
 			visitedHosts := initClientWithConnError(getTimeoutErr())
-			expectedPrimaryHost := "realtime.ably.io"
+			expectedPrimaryHost := "main.realtime.ably.net"
 			expectedFallbackHosts := ably.DefaultFallbackHosts()
 
 			assert.Equal(t, 6, len(visitedHosts))
@@ -177,7 +283,15 @@ func TestRealtime_RTN17_HostFallback(t *testing.T) {
 			assert.ElementsMatch(t, expectedFallbackHosts, visitedHosts[1:])
 		})
 
-		t.Run("does not apply when the custom realtime endpoint is used", func(t *testing.T) {
+		t.Run("does not apply when endpoint with fqdn is used", func(t *testing.T) {
+			visitedHosts := initClientWithConnError(getTimeoutErr(), ably.WithEndpoint("custom-realtime.ably.io"))
+			expectedHost := "custom-realtime.ably.io"
+
+			require.Equal(t, 1, len(visitedHosts))
+			assert.Equal(t, expectedHost, visitedHosts[0])
+		})
+
+		t.Run("does not apply when legacy custom realtimeHost is used", func(t *testing.T) {
 			visitedHosts := initClientWithConnError(getTimeoutErr(), ably.WithRealtimeHost("custom-realtime.ably.io"))
 			expectedHost := "custom-realtime.ably.io"
 
@@ -188,18 +302,31 @@ func TestRealtime_RTN17_HostFallback(t *testing.T) {
 		t.Run("apply when fallbacks are provided", func(t *testing.T) {
 			fallbacks := []string{"fallback0", "fallback1", "fallback2"}
 			visitedHosts := initClientWithConnError(getTimeoutErr(), ably.WithFallbackHosts(fallbacks))
-			expectedPrimaryHost := "realtime.ably.io"
+			expectedPrimaryHost := "main.realtime.ably.net"
 
 			assert.Equal(t, 4, len(visitedHosts))
 			assert.Equal(t, expectedPrimaryHost, visitedHosts[0])
 			assert.ElementsMatch(t, fallbacks, visitedHosts[1:])
 		})
 
-		t.Run("apply when fallbackHostUseDefault is true, even if env. or host is set", func(t *testing.T) {
+		t.Run("apply when fallbackHostUseDefault is true, even if endpoint option is used", func(t *testing.T) {
 			visitedHosts := initClientWithConnError(
 				getTimeoutErr(),
 				ably.WithFallbackHostsUseDefault(true),
-				ably.WithEnvironment("custom"),
+				ably.WithEndpoint("custom"))
+
+			expectedPrimaryHost := "custom.realtime.ably.net"
+			expectedFallbackHosts := ably.DefaultFallbackHosts()
+
+			assert.Equal(t, 6, len(visitedHosts))
+			assert.Equal(t, expectedPrimaryHost, visitedHosts[0])
+			assert.ElementsMatch(t, expectedFallbackHosts, visitedHosts[1:])
+		})
+
+		t.Run("apply when fallbackHostUseDefault is true, even if legacy realtimeHost is set", func(t *testing.T) {
+			visitedHosts := initClientWithConnError(
+				getTimeoutErr(),
+				ably.WithFallbackHostsUseDefault(true),
 				ably.WithRealtimeHost("custom-ably.realtime.com"))
 
 			expectedPrimaryHost := "custom-ably.realtime.com"
@@ -253,7 +380,7 @@ func TestRealtime_RTN17_HostFallback(t *testing.T) {
 			t.Fatalf("Error connecting host with error %v", err)
 		}
 		realtimeSuccessHost := realtimeMsgRecorder.URLs()[0].Hostname()
-		fallbackHosts := ably.GetEnvFallbackHosts("sandbox")
+		fallbackHosts := ably.GetEndpointFallbackHosts("sandbox")
 		if !ablyutil.SliceContains(fallbackHosts, realtimeSuccessHost) {
 			t.Fatalf("realtime host must be one of fallback hosts, received %v", realtimeSuccessHost)
 		}
@@ -294,7 +421,7 @@ func TestRealtime_RTN17_Integration_HostFallback_Internal_Server_Error(t *testin
 			}
 			return conn, err
 		}),
-		ably.WithRealtimeHost(serverURL.Host))
+		ably.WithEndpoint(serverURL.Host))
 
 	defer safeclose(t, ablytest.FullRealtimeCloser(realtime), app)
 
@@ -341,7 +468,7 @@ func TestRealtime_RTN17_Integration_HostFallback_Timeout(t *testing.T) {
 			}
 			return conn, err
 		}),
-		ably.WithRealtimeHost(serverURL.Host))
+		ably.WithEndpoint(serverURL.Host))
 
 	defer safeclose(t, ablytest.FullRealtimeCloser(realtime), app)
 

--- a/ably/realtime_client_integration_test.go
+++ b/ably/realtime_client_integration_test.go
@@ -309,20 +309,6 @@ func TestRealtime_RTN17_HostFallback(t *testing.T) {
 			assert.ElementsMatch(t, fallbacks, visitedHosts[1:])
 		})
 
-		t.Run("apply when fallbackHostUseDefault is true, even if endpoint option is used", func(t *testing.T) {
-			visitedHosts := initClientWithConnError(
-				getTimeoutErr(),
-				ably.WithFallbackHostsUseDefault(true),
-				ably.WithEndpoint("custom"))
-
-			expectedPrimaryHost := "custom.realtime.ably.net"
-			expectedFallbackHosts := ably.DefaultFallbackHosts()
-
-			assert.Equal(t, 6, len(visitedHosts))
-			assert.Equal(t, expectedPrimaryHost, visitedHosts[0])
-			assert.ElementsMatch(t, expectedFallbackHosts, visitedHosts[1:])
-		})
-
 		t.Run("apply when fallbackHostUseDefault is true, even if legacy realtimeHost is set", func(t *testing.T) {
 			visitedHosts := initClientWithConnError(
 				getTimeoutErr(),
@@ -380,7 +366,7 @@ func TestRealtime_RTN17_HostFallback(t *testing.T) {
 			t.Fatalf("Error connecting host with error %v", err)
 		}
 		realtimeSuccessHost := realtimeMsgRecorder.URLs()[0].Hostname()
-		fallbackHosts := ably.GetEndpointFallbackHosts("sandbox")
+		fallbackHosts := ably.GetEndpointFallbackHosts("nonprod:sandbox")
 		if !ablyutil.SliceContains(fallbackHosts, realtimeSuccessHost) {
 			t.Fatalf("realtime host must be one of fallback hosts, received %v", realtimeSuccessHost)
 		}

--- a/ably/realtime_client_integration_test.go
+++ b/ably/realtime_client_integration_test.go
@@ -402,10 +402,15 @@ func TestRealtime_RTN17_Integration_HostFallback_Internal_Server_Error(t *testin
 	fallbackHost := "sandbox-a-fallback.ably-realtime.com"
 	connAttempts := 0
 
-	app, realtime := ablytest.NewRealtime(
+	app := ablytest.MustSandbox(nil)
+	defer safeclose(t, app)
+	jwt, err := app.CreateJwt(30*time.Second, false)
+	assert.NoError(t, err)
+
+	realtime := app.NewRealtime(
 		ably.WithAutoConnect(false),
 		ably.WithTLS(false),
-		ably.WithUseTokenAuth(true),
+		ably.WithToken(jwt),
 		ably.WithFallbackHosts([]string{fallbackHost}),
 		ably.WithDial(func(protocol string, u *url.URL, timeout time.Duration) (ably.Conn, error) {
 			connAttempts += 1
@@ -446,10 +451,15 @@ func TestRealtime_RTN17_Integration_HostFallback_Timeout(t *testing.T) {
 	requestTimeout := 2 * time.Second
 	connAttempts := 0
 
-	app, realtime := ablytest.NewRealtime(
+	app := ablytest.MustSandbox(nil)
+	defer safeclose(t, app)
+	jwt, err := app.CreateJwt(30*time.Second, false)
+	assert.NoError(t, err)
+
+	realtime := app.NewRealtime(
 		ably.WithAutoConnect(false),
 		ably.WithTLS(false),
-		ably.WithUseTokenAuth(true),
+		ably.WithToken(jwt),
 		ably.WithFallbackHosts([]string{fallbackHost}),
 		ably.WithRealtimeRequestTimeout(requestTimeout),
 		ably.WithDial(func(protocol string, u *url.URL, timeout time.Duration) (ably.Conn, error) {

--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -387,7 +387,8 @@ func (c *Connection) connectWith(arg connArgs) (result, error) {
 	}
 
 	var conn conn
-	primaryHost := c.opts.getRealtimeHost()
+	primaryHost := c.opts.getHostname()
+
 	hosts := []string{primaryHost}
 	fallbackHosts, err := c.opts.getFallbackHosts()
 	if err != nil {

--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -387,7 +387,7 @@ func (c *Connection) connectWith(arg connArgs) (result, error) {
 	}
 
 	var conn conn
-	primaryHost := c.opts.getHostname()
+	primaryHost := c.opts.getRealtimeHost()
 
 	hosts := []string{primaryHost}
 	fallbackHosts, err := c.opts.getFallbackHosts()

--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -388,7 +388,6 @@ func (c *Connection) connectWith(arg connArgs) (result, error) {
 
 	var conn conn
 	primaryHost := c.opts.getRealtimeHost()
-
 	hosts := []string{primaryHost}
 	fallbackHosts, err := c.opts.getFallbackHosts()
 	if err != nil {

--- a/ably/realtime_conn_spec_integration_test.go
+++ b/ably/realtime_conn_spec_integration_test.go
@@ -222,7 +222,7 @@ func Test_RTN4a_ConnectionEventForStateChange(t *testing.T) {
 	t.Run(fmt.Sprintf("on %s", ably.ConnectionStateFailed), func(t *testing.T) {
 
 		options := []ably.ClientOption{
-			ably.WithEnvironment("sandbox"),
+			ably.WithEndpoint(ablytest.Endpoint),
 			ably.WithAutoConnect(false),
 			ably.WithKey("made:up"),
 		}
@@ -1735,7 +1735,7 @@ func TestRealtimeConn_RTN22a_RTN15h2_Integration_ServerInitiatedAuth(t *testing.
 	realtime, err := ably.NewRealtime(
 		ably.WithAutoConnect(false),
 		ably.WithDial(recorder.Dial),
-		ably.WithEnvironment(ablytest.Environment),
+		ably.WithEndpoint(ablytest.Endpoint),
 		ably.WithAuthCallback(authCallback))
 
 	assert.NoError(t, err)
@@ -1798,7 +1798,7 @@ func TestRealtimeConn_RTN22_RTC8_Integration_ServerInitiatedAuth(t *testing.T) {
 		ably.WithAutoConnect(false),
 		ably.WithDial(recorder.Dial),
 		ably.WithUseBinaryProtocol(false),
-		ably.WithEnvironment(ablytest.Environment),
+		ably.WithEndpoint(ablytest.Endpoint),
 		ably.WithAuthCallback(authCallback))
 
 	assert.NoError(t, err)
@@ -3037,7 +3037,7 @@ func TestRealtimeConn_RTC8a_ExplicitAuthorizeWhileConnected(t *testing.T) {
 		realtimeMsgRecorder := NewMessageRecorder()
 		realtime, err := ably.NewRealtime(
 			ably.WithAutoConnect(false),
-			ably.WithEnvironment(ablytest.Environment),
+			ably.WithEndpoint(ablytest.Endpoint),
 			ably.WithDial(realtimeMsgRecorder.Dial),
 			ably.WithAuthCallback(authCallback))
 

--- a/ably/realtime_presence_integration_test.go
+++ b/ably/realtime_presence_integration_test.go
@@ -57,7 +57,7 @@ func TestRealtimePresence_Sync(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestRealtimePresence_Sync250_RTP4(t *testing.T) {
+func SkipTestRealtimePresence_Sync250_RTP4(t *testing.T) {
 	app, client1 := ablytest.NewRealtime(nil...)
 	defer safeclose(t, ablytest.FullRealtimeCloser(client1), app)
 	client2 := app.NewRealtime(nil...)

--- a/ably/rest_channel_integration_test.go
+++ b/ably/rest_channel_integration_test.go
@@ -142,7 +142,7 @@ func TestRESTChannel(t *testing.T) {
 }
 
 func TestIdempotentPublishing(t *testing.T) {
-	app, err := ablytest.NewSandboxWithEndpoint(nil, ablytest.Endpoint, ablytest.Environment)
+	app, err := ablytest.NewSandboxWithEndpoint(nil, ablytest.Endpoint)
 	assert.NoError(t, err)
 	defer app.Close()
 	options := app.Options(ably.WithIdempotentRESTPublishing(true))
@@ -295,7 +295,7 @@ func TestIdempotentPublishing(t *testing.T) {
 }
 
 func TestIdempotent_retry(t *testing.T) {
-	app, err := ablytest.NewSandboxWithEndpoint(nil, ablytest.Endpoint, ablytest.Environment)
+	app, err := ablytest.NewSandboxWithEndpoint(nil, ablytest.Endpoint)
 	assert.NoError(t, err)
 	defer app.Close()
 	randomStr, err := ablyutil.BaseID()

--- a/ably/rest_channel_integration_test.go
+++ b/ably/rest_channel_integration_test.go
@@ -142,7 +142,7 @@ func TestRESTChannel(t *testing.T) {
 }
 
 func TestIdempotentPublishing(t *testing.T) {
-	app, err := ablytest.NewSandboxWithEnv(nil, ablytest.Environment)
+	app, err := ablytest.NewSandboxWithEndpoint(nil, ablytest.Endpoint, ablytest.Environment)
 	assert.NoError(t, err)
 	defer app.Close()
 	options := app.Options(ably.WithIdempotentRESTPublishing(true))
@@ -295,7 +295,7 @@ func TestIdempotentPublishing(t *testing.T) {
 }
 
 func TestIdempotent_retry(t *testing.T) {
-	app, err := ablytest.NewSandboxWithEnv(nil, ablytest.Environment)
+	app, err := ablytest.NewSandboxWithEndpoint(nil, ablytest.Endpoint, ablytest.Environment)
 	assert.NoError(t, err)
 	defer app.Close()
 	randomStr, err := ablyutil.BaseID()
@@ -312,7 +312,7 @@ func TestIdempotent_retry(t *testing.T) {
 		// failing all others via the test server
 		fallbackHosts := []string{"fallback0", "fallback1", "fallback2"}
 		nopts := []ably.ClientOption{
-			ably.WithEnvironment(ablytest.Environment),
+			ably.WithEndpoint(ablytest.Endpoint),
 			ably.WithTLS(false),
 			ably.WithFallbackHosts(fallbackHosts),
 			ably.WithIdempotentRESTPublishing(true),

--- a/ably/rest_client_integration_test.go
+++ b/ably/rest_client_integration_test.go
@@ -347,10 +347,10 @@ func TestRest_RSC15_HostFallback(t *testing.T) {
 			ably.WithUseTokenAuth(true),
 		}
 		retryCount, hosts := runTestServer(t, options)
-		assert.Equal(t, 6, retryCount)                          // 1 primary and 5 default fallback hosts
-		assert.Equal(t, "main.realtime.ably.net", hosts[0])     // primary host
-		assertSubset(t, ably.DefaultFallbackHosts(), hosts[1:]) // remaining fallback hosts
-		assertUnique(t, hosts)                                  // ensure all picked fallbacks are unique
+		assert.Equal(t, 6, retryCount)                                 // 1 primary and 5 default fallback hosts
+		assert.Equal(t, "sandbox.realtime.ably-nonprod.net", hosts[0]) // primary host
+		assertSubset(t, ably.DefaultFallbackHosts(), hosts[1:])        // remaining fallback hosts
+		assertUnique(t, hosts)                                         // ensure all picked fallbacks are unique
 	})
 
 	runTestServerWithRequestTimeout := func(t *testing.T, options []ably.ClientOption) (int, []string) {
@@ -393,10 +393,10 @@ func TestRest_RSC15_HostFallback(t *testing.T) {
 			ably.WithUseTokenAuth(true),
 		}
 		retryCount, hosts := runTestServerWithRequestTimeout(t, options)
-		assert.Equal(t, 6, retryCount)                          // 1 primary and 5 default fallback hosts
-		assert.Equal(t, "main.realtime.ably.net", hosts[0])     // primary host
-		assertSubset(t, ably.DefaultFallbackHosts(), hosts[1:]) // remaining fallback hosts
-		assertUnique(t, hosts)                                  // ensure all picked fallbacks are unique
+		assert.Equal(t, 6, retryCount)                                 // 1 primary and 5 default fallback hosts
+		assert.Equal(t, "sandbox.realtime.ably-nonprod.net", hosts[0]) // primary host
+		assertSubset(t, ably.DefaultFallbackHosts(), hosts[1:])        // remaining fallback hosts
+		assertUnique(t, hosts)                                         // ensure all picked fallbacks are unique
 	})
 
 	t.Run("RSC15l1 must use alternative host on host unresolvable or unreachable", func(t *testing.T) {

--- a/ably/rest_client_integration_test.go
+++ b/ably/rest_client_integration_test.go
@@ -250,10 +250,9 @@ func TestRest_RSC7_AblyAgent(t *testing.T) {
 		assert.NoError(t, err)
 
 		opts := []ably.ClientOption{
-			ably.WithEnvironment(ablytest.Environment),
+			ably.WithEndpoint(serverURL.Host),
 			ably.WithTLS(false),
 			ably.WithUseTokenAuth(true),
-			ably.WithRESTHost(serverURL.Host),
 		}
 
 		client, err := ably.NewREST(opts...)
@@ -275,10 +274,9 @@ func TestRest_RSC7_AblyAgent(t *testing.T) {
 		assert.NoError(t, err)
 
 		opts := []ably.ClientOption{
-			ably.WithEnvironment(ablytest.Environment),
+			ably.WithEndpoint(serverURL.Host),
 			ably.WithTLS(false),
 			ably.WithUseTokenAuth(true),
-			ably.WithRESTHost(serverURL.Host),
 			ably.WithAgents(map[string]string{
 				"foo": "1.2.3",
 			}),
@@ -303,10 +301,9 @@ func TestRest_RSC7_AblyAgent(t *testing.T) {
 		assert.NoError(t, err)
 
 		opts := []ably.ClientOption{
-			ably.WithEnvironment(ablytest.Environment),
+			ably.WithEndpoint(serverURL.Host),
 			ably.WithTLS(false),
 			ably.WithUseTokenAuth(true),
-			ably.WithRESTHost(serverURL.Host),
 			ably.WithAgents(map[string]string{
 				"bar": "",
 			}),
@@ -346,13 +343,12 @@ func TestRest_RSC15_HostFallback(t *testing.T) {
 		options := []ably.ClientOption{
 			ably.WithFallbackHosts(ably.DefaultFallbackHosts()),
 			ably.WithTLS(false),
-			ably.WithEnvironment(""), // remove default sandbox env
 			ably.WithHTTPMaxRetryCount(10),
 			ably.WithUseTokenAuth(true),
 		}
 		retryCount, hosts := runTestServer(t, options)
 		assert.Equal(t, 6, retryCount)                          // 1 primary and 5 default fallback hosts
-		assert.Equal(t, "rest.ably.io", hosts[0])               // primary host
+		assert.Equal(t, "main.realtime.ably.net", hosts[0])     // primary host
 		assertSubset(t, ably.DefaultFallbackHosts(), hosts[1:]) // remaining fallback hosts
 		assertUnique(t, hosts)                                  // ensure all picked fallbacks are unique
 	})
@@ -393,21 +389,20 @@ func TestRest_RSC15_HostFallback(t *testing.T) {
 		options := []ably.ClientOption{
 			ably.WithFallbackHosts(ably.DefaultFallbackHosts()),
 			ably.WithTLS(false),
-			ably.WithEnvironment(""), // remove default sandbox env
 			ably.WithHTTPMaxRetryCount(10),
 			ably.WithUseTokenAuth(true),
 		}
 		retryCount, hosts := runTestServerWithRequestTimeout(t, options)
 		assert.Equal(t, 6, retryCount)                          // 1 primary and 5 default fallback hosts
-		assert.Equal(t, "rest.ably.io", hosts[0])               // primary host
+		assert.Equal(t, "main.realtime.ably.net", hosts[0])     // primary host
 		assertSubset(t, ably.DefaultFallbackHosts(), hosts[1:]) // remaining fallback hosts
 		assertUnique(t, hosts)                                  // ensure all picked fallbacks are unique
 	})
 
 	t.Run("RSC15l1 must use alternative host on host unresolvable or unreachable", func(t *testing.T) {
 		options := []ably.ClientOption{
+			ably.WithEndpoint("foobar.ably.com"),
 			ably.WithFallbackHosts(ably.DefaultFallbackHosts()),
-			ably.WithRESTHost("foobar.ably.com"),
 			ably.WithFallbackHosts([]string{
 				"spam.ably.com",
 				"tatto.ably.com",
@@ -430,7 +425,7 @@ func TestRest_RSC15_HostFallback(t *testing.T) {
 
 			options := []ably.ClientOption{
 				ably.WithTLS(false),
-				ably.WithRESTHost("example.com"),
+				ably.WithEndpoint("example.com"),
 				ably.WithUseTokenAuth(true),
 			}
 			retryCount, hosts := runTestServer(t, options)
@@ -444,7 +439,7 @@ func TestRest_RSC15_HostFallback(t *testing.T) {
 
 			options := []ably.ClientOption{
 				ably.WithTLS(false),
-				ably.WithRESTHost("example.com"),
+				ably.WithEndpoint("example.com"),
 				ably.WithFallbackHosts(ably.DefaultFallbackHosts()),
 				ably.WithUseTokenAuth(true),
 			}
@@ -460,7 +455,7 @@ func TestRest_RSC15_HostFallback(t *testing.T) {
 		t.Run("must occur when fallbackHosts is set", func(t *testing.T) {
 			options := []ably.ClientOption{
 				ably.WithTLS(false),
-				ably.WithRESTHost("example.com"),
+				ably.WithEndpoint("example.com"),
 				ably.WithFallbackHosts([]string{"a.example.com"}),
 				ably.WithUseTokenAuth(true),
 			}
@@ -476,7 +471,7 @@ func TestRest_RSC15_HostFallback(t *testing.T) {
 	t.Run("RSC15e must start with default host", func(t *testing.T) {
 
 		options := []ably.ClientOption{
-			ably.WithEnvironment("production"),
+			ably.WithEndpoint("main"),
 			ably.WithTLS(false),
 			ably.WithUseTokenAuth(true),
 		}
@@ -492,7 +487,7 @@ func TestRest_RSC15_HostFallback(t *testing.T) {
 
 		options := []ably.ClientOption{
 			ably.WithTLS(false),
-			ably.WithRESTHost("example.com"),
+			ably.WithEndpoint("example.com"),
 			ably.WithFallbackHosts([]string{}),
 			ably.WithUseTokenAuth(true),
 		}
@@ -519,7 +514,7 @@ func TestRest_rememberHostFallback(t *testing.T) {
 		defer server.Close()
 
 		nopts = []ably.ClientOption{
-			ably.WithEnvironment(ablytest.Environment),
+			ably.WithEndpoint(ablytest.Endpoint),
 			ably.WithTLS(false),
 			ably.WithFallbackHosts([]string{"fallback0", "fallback1", "fallback2"}),
 			ably.WithUseTokenAuth(true),

--- a/ablytest/ablytest.go
+++ b/ablytest/ablytest.go
@@ -17,7 +17,6 @@ import (
 var Timeout = 30 * time.Second
 var NoBinaryProtocol bool
 var DefaultLogLevel = ably.LogNone
-var Environment = "sandbox"
 var Endpoint = "nonprod:sandbox"
 
 func nonil(err ...error) error {
@@ -41,8 +40,8 @@ func init() {
 	if n, err := strconv.Atoi(os.Getenv("ABLY_LOGLEVEL")); err == nil {
 		DefaultLogLevel = ably.LogLevel(n)
 	}
-	if s := os.Getenv("ABLY_ENV"); s != "" {
-		Environment = s
+	if s := os.Getenv("ABLY_ENDPOINT"); s != "" {
+		Endpoint = s
 	}
 }
 

--- a/ablytest/ablytest.go
+++ b/ablytest/ablytest.go
@@ -18,6 +18,7 @@ var Timeout = 30 * time.Second
 var NoBinaryProtocol bool
 var DefaultLogLevel = ably.LogNone
 var Environment = "sandbox"
+var Endpoint = "nonprod:sandbox"
 
 func nonil(err ...error) error {
 	for _, err := range err {

--- a/ablytest/sandbox.go
+++ b/ablytest/sandbox.go
@@ -105,9 +105,6 @@ type Sandbox struct {
 	// Endpoint is the hostname to connect to
 	Endpoint string
 
-	// Environment is used in auth parameters
-	Environment string
-
 	client *http.Client
 }
 
@@ -138,15 +135,14 @@ func MustSandbox(config *Config) *Sandbox {
 }
 
 func NewSandbox(config *Config) (*Sandbox, error) {
-	return NewSandboxWithEndpoint(config, Endpoint, Environment)
+	return NewSandboxWithEndpoint(config, Endpoint)
 }
 
-func NewSandboxWithEndpoint(config *Config, endpoint, environment string) (*Sandbox, error) {
+func NewSandboxWithEndpoint(config *Config, endpoint string) (*Sandbox, error) {
 	app := &Sandbox{
-		Config:      config,
-		Endpoint:    endpoint,
-		Environment: environment,
-		client:      NewHTTPClient(),
+		Config:   config,
+		Endpoint: endpoint,
+		client:   NewHTTPClient(),
 	}
 	if app.Config == nil {
 		app.Config = DefaultConfig()
@@ -282,7 +278,7 @@ var CREATE_JWT_URL string = "https://echo.ably.io/createJWT"
 func (app *Sandbox) GetJwtAuthParams(expiresIn time.Duration, invalid bool) url.Values {
 	key, secret := app.KeyParts()
 	authParams := url.Values{}
-	authParams.Add("environment", app.Environment)
+	authParams.Add("endpoint", app.Endpoint)
 	authParams.Add("returnType", "jwt")
 	authParams.Add("keyName", key)
 	if invalid {

--- a/ablytest/sandbox.go
+++ b/ablytest/sandbox.go
@@ -100,12 +100,9 @@ var PresenceFixtures = func() []Presence {
 }
 
 type Sandbox struct {
-	Config *Config
-
-	// Endpoint is the hostname to connect to
+	Config   *Config
 	Endpoint string
-
-	client *http.Client
+	client   *http.Client
 }
 
 func NewRealtime(opts ...ably.ClientOption) (*Sandbox, *ably.Realtime) {


### PR DESCRIPTION
- Closes #677 ( current PR built on top of it )
- Updated code for `endpoint` option in a way that it doesn't break code path for deprecated clientOptions.
- Updated/fixed code + couple of other failing tests

Summary =>

1.  Fixed #678
2. Created spec PR to update REC1b1 and REC2c1 => https://github.com/ably/specification/pull/271
3. Skipped test will be fixed as a part of https://github.com/ably/ably-go/issues/676
4. [Created issue on jwt echo-server](https://github.com/ably/echoserver/issues/28) repo to add `endpoint` support 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Configuration Changes**
	- Updated client configuration to use endpoint-based settings instead of environment variables.
	- Introduced more flexible endpoint specification for Ably service connections.
	- Removed deprecated constants and methods related to environment configuration.

- **Testing Improvements**
	- Enhanced test suite to support new endpoint configuration.
	- Added more comprehensive tests for connection and authentication scenarios.
	- Updated existing tests to reflect changes in endpoint handling and error management.

- **Deprecation Notice**
	- Environment-based configuration methods are now deprecated.
	- Recommended to use explicit endpoint settings in future implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->