### PR TITLE
Update REC1b2 for updated version of spec point

### DIFF
--- a/ably/export_test.go
+++ b/ably/export_test.go
@@ -200,8 +200,8 @@ func ApplyOptionsWithDefaults(o ...ClientOption) *clientOptions {
 	return applyOptionsWithDefaults(o...)
 }
 
-func IsEndpointFQDN(endpoint string) bool {
-	return isEndpointFQDN(endpoint)
+func IsEndpointHostname(endpoint string) bool {
+	return isEndpointHostname(endpoint)
 }
 
 type ConnStateChanges = connStateChanges

--- a/ably/options.go
+++ b/ably/options.go
@@ -503,9 +503,9 @@ func (opts *clientOptions) getRealtimeHost() string {
 	return defaultOptions.RealtimeHost
 }
 
-// isEndpointFQDN returns true if the given endpoint is a hostname, which may
+// REC1b2: isEndpointHostname returns true if the given endpoint is a hostname, which may
 // be an IPv4 address, IPv6 address or localhost
-func isEndpointFQDN(endpoint string) bool {
+func isEndpointHostname(endpoint string) bool {
 	return strings.Contains(endpoint, ".") || strings.Contains(endpoint, "::") || endpoint == "localhost"
 }
 
@@ -515,7 +515,7 @@ func (opts *clientOptions) getHostnameFromEndpoint() string {
 	if empty(endpoint) {
 		return defaultPrimaryHost
 	}
-	if isEndpointFQDN(endpoint) { // REC1b2
+	if isEndpointHostname(endpoint) { // REC1b2
 		return endpoint
 	}
 	return getPrimaryHost(endpoint) // REC1b4
@@ -554,7 +554,7 @@ func (opts *clientOptions) realtimeURL(realtimeHost string) (realtimeUrl string)
 func (opts *clientOptions) getFallbackHosts() ([]string, error) {
 	if !empty(opts.Endpoint) {
 		if opts.FallbackHosts == nil {
-			if isEndpointFQDN(opts.Endpoint) { // REC2c2
+			if isEndpointHostname(opts.Endpoint) { // REC2c2
 				return opts.FallbackHosts, nil
 			}
 			return getEndpointFallbackHosts(opts.Endpoint), nil

--- a/ably/options_test.go
+++ b/ably/options_test.go
@@ -424,9 +424,10 @@ func TestPaginateParams(t *testing.T) {
 	})
 }
 
-func TestIsEndpointFQDN(t *testing.T) {
-	assert.Equal(t, false, ably.IsEndpointFQDN("sandbox"))
-	assert.Equal(t, true, ably.IsEndpointFQDN("sandbox.example.com"))
-	assert.Equal(t, true, ably.IsEndpointFQDN("127.0.0.1"))
-	assert.Equal(t, true, ably.IsEndpointFQDN("localhost"))
+func TestIsEndpointHostname(t *testing.T) {
+	assert.Equal(t, false, ably.IsEndpointHostname("sandbox"))
+	assert.Equal(t, true, ably.IsEndpointHostname("sandbox.example.com"))
+	assert.Equal(t, true, ably.IsEndpointHostname("127.0.0.1"))
+	assert.Equal(t, true, ably.IsEndpointHostname("::1"))
+	assert.Equal(t, true, ably.IsEndpointHostname("localhost"))
 }


### PR DESCRIPTION
Reflects the changes of spec commit `f28cad3` from https://github.com/ably/specification/pull/302, which were themselves based on the special-case logic implemented in this repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a test case to verify correct handling of IPv6 loopback addresses in endpoint validation.

- **Refactor**
  - Renamed functions to clarify endpoint hostname validation terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->