### PR TITLE
feat: Update the hasMsgSerial flag

### DIFF
--- a/ably/proto_error.go
+++ b/ably/proto_error.go
@@ -1,5 +1,10 @@
 package ably
 
+import (
+	"strconv"
+	"strings"
+)
+
 // errorInfo describes an error object returned via ProtocolMessage.
 type errorInfo struct {
 	StatusCode int    `json:"statusCode,omitempty" codec:"statusCode,omitempty"`
@@ -25,4 +30,54 @@ func (e *errorInfo) FromMap(ctx map[string]interface{}) {
 	if v, ok := ctx["serverId"]; ok {
 		e.Server = v.(string)
 	}
+}
+
+func (e *errorInfo) String() string {
+	if e == nil {
+		return "(nil)"
+	}
+
+	const (
+		labelMsg        = "msg="
+		labelCode       = "Code="
+		labelStatusCode = "StatusCode="
+		labelHref       = "Href="
+		labelServer     = "Server="
+	)
+
+	size := len("(") + len(labelMsg) + len(e.Message) +
+		len(","+labelCode) + len(strconv.Itoa(e.Code)) +
+		len(","+labelStatusCode) + len(strconv.Itoa(e.StatusCode)) + len(")")
+
+	if e.HRef != "" {
+		size += len(","+labelHref) + len(e.HRef)
+	}
+
+	if e.Server != "" {
+		size += len(","+labelServer) + len(e.Server)
+	}
+
+	var b strings.Builder
+	b.Grow(size)
+
+	b.WriteString("(" + labelMsg)
+	b.WriteString(e.Message)
+	b.WriteString("," + labelCode)
+	b.WriteString(strconv.Itoa(e.Code))
+	b.WriteString("," + labelStatusCode)
+	b.WriteString(strconv.Itoa(e.StatusCode))
+
+	if e.HRef != "" {
+		b.WriteString("," + labelHref)
+		b.WriteString(e.HRef)
+	}
+
+	if e.Server != "" {
+		b.WriteString("," + labelServer)
+		b.WriteString(e.Server)
+	}
+
+	b.WriteString(")")
+
+	return b.String()
 }

--- a/ably/proto_error_test.go
+++ b/ably/proto_error_test.go
@@ -1,0 +1,64 @@
+package ably
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_errorInfo_String(t *testing.T) {
+	tests := []struct {
+		name           string
+		err            *errorInfo
+		expectedString string
+		expectedSize   int
+	}{
+		{
+			name: "error with all fields",
+			err: &errorInfo{
+				StatusCode: 400,
+				Code:       40012,
+				HRef:       "ably.com/errors/40012",
+				Message:    "something went wrong",
+				Server:     "s1",
+			},
+			expectedString: "(msg=something went wrong,Code=40012,StatusCode=400,Href=ably.com/errors/40012,Server=s1)",
+			expectedSize:   89,
+		},
+		{
+			name: "error with no href",
+			err: &errorInfo{
+				StatusCode: 400,
+				Code:       40012,
+				Message:    "something went wrong",
+				Server:     "s1",
+			},
+			expectedString: "(msg=something went wrong,Code=40012,StatusCode=400,Server=s1)",
+			expectedSize:   62,
+		},
+		{
+			name: "error with no server",
+			err: &errorInfo{
+				StatusCode: 400,
+				Code:       40012,
+				HRef:       "ably.com/errors/40012",
+				Message:    "something went wrong",
+			},
+			expectedString: "(msg=something went wrong,Code=40012,StatusCode=400,Href=ably.com/errors/40012)",
+			expectedSize:   79,
+		},
+		{
+			name:           "nil error",
+			err:            nil,
+			expectedString: "(nil)",
+			expectedSize:   5,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := tt.err.String()
+
+			assert.Equal(t, tt.expectedString, s)
+			assert.Equal(t, tt.expectedSize, len(s))
+		})
+	}
+}

--- a/ably/proto_protocol_message.go
+++ b/ably/proto_protocol_message.go
@@ -162,26 +162,26 @@ func (msg *protocolMessage) String() string {
 	case actionConnect:
 		return fmt.Sprintf("(action=%q)", msg.Action)
 	case actionConnected:
-		return fmt.Sprintf("(action=%q, id=%q, details=%#v)", msg.Action, msg.ConnectionID, msg.ConnectionDetails)
+		return fmt.Sprintf("(action=%q, id=%q, details=%#v, error=%s)", msg.Action, msg.ConnectionID, msg.ConnectionDetails, msg.Error)
 	case actionDisconnect:
 		return fmt.Sprintf("(action=%q)", msg.Action)
 	case actionDisconnected:
-		return fmt.Sprintf("(action=%q)", msg.Action)
+		return fmt.Sprintf("(action=%q, error=%s)", msg.Action, msg.Error)
 	case actionClose:
 		return fmt.Sprintf("(action=%q)", msg.Action)
 	case actionClosed:
 		return fmt.Sprintf("(action=%q)", msg.Action)
 	case actionError:
-		return fmt.Sprintf("(action=%q, error=%#v)", msg.Action, msg.Error)
+		return fmt.Sprintf("(action=%q, error=%s)", msg.Action, msg.Error)
 	case actionAttach:
 		return fmt.Sprintf("(action=%q, channel=%q)", msg.Action, msg.Channel)
 	case actionAttached:
-		return fmt.Sprintf("(action=%q, channel=%q, channelSerial=%q, flags=%x)",
-			msg.Action, msg.Channel, msg.ChannelSerial, msg.Flags)
+		return fmt.Sprintf("(action=%q, channel=%q, channelSerial=%q, flags=%x, error=%s)",
+			msg.Action, msg.Channel, msg.ChannelSerial, msg.Flags, msg.Error)
 	case actionDetach:
 		return fmt.Sprintf("(action=%q, channel=%q)", msg.Action, msg.Channel)
 	case actionDetached:
-		return fmt.Sprintf("(action=%q, channel=%q)", msg.Action, msg.Channel)
+		return fmt.Sprintf("(action=%q, channel=%q, error=%s)", msg.Action, msg.Channel, msg.Error)
 	case actionPresence, actionSync:
 		return fmt.Sprintf("(action=%q, id=%v, channel=%q, timestamp=%d, connectionId=%v, presenceMessages=%v)",
 			msg.Action, msg.ID, msg.Channel, msg.Timestamp, msg.ConnectionID, msg.Presence)

--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -1057,7 +1057,12 @@ func (vc verboseConn) Receive(deadline time.Time) (*protocolMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	vc.logger.Verbosef("Realtime Connection: received %s", msg)
+
+	if msg.Error != nil {
+		vc.logger.Errorf("Realtime Connection: error received %s", msg)
+	} else {
+		vc.logger.Verbosef("Realtime Connection: received %s", msg)
+	}
 	return msg, nil
 }
 

--- a/ably/realtime_conn.go
+++ b/ably/realtime_conn.go
@@ -617,7 +617,7 @@ func (c *Connection) advanceSerial() {
 }
 
 func (c *Connection) send(msg *protocolMessage, onAck func(err error)) {
-	hasMsgSerial := msg.Action == actionMessage || msg.Action == actionPresence
+	hasMsgSerial := msg.Action == actionMessage || msg.Action == actionPresence || msg.Action == actionObject
 	c.mtx.Lock()
 	// RTP16a - in case of presence msg send, check for connection status and send accordingly
 	switch state := c.state; state {


### PR DESCRIPTION
This PR has two changes:

1. The hasMsgSerial flag now includes `actionObject` protocol message actions. 

This means that LiveObject messages have their message serials advanced when publishing. This was causing the connection to be disconnected and re-established by the server because when publishing multiple separated protocol messages with an `actionObject` Action type the messages where not monotonic and the server would error and disconnect. This had a further side effect that websocket go-routines where being leaked.

2. Improve logging around messages

Messages Received on a connection with `Disconnected` action, amongst others, may contain an error. There is now a check if an error is set if so it is logged as an Error. 

The `ProtocolMessage.String()` method now captures the errors in the Messages that may have an error set. Which messages maybe Errors set is based on a look in the Realtime codebase.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging to clearly differentiate error messages from regular messages.
  * Enhanced internal handling to ensure serial numbers are correctly assigned to additional message types.

* **New Features**
  * Error details are now included in status messages for certain connection and channel actions, providing clearer information when issues occur.
  * Added detailed string representations for error information to improve error visibility and debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->