### PR TITLE
fix: stop setting read limit on a connected event

### DIFF
--- a/ably/export_test.go
+++ b/ably/export_test.go
@@ -160,12 +160,6 @@ func (c *Connection) MsgSerial() int64 {
 	return c.msgSerial
 }
 
-func (c *Connection) IsReadLimitSetExternally() bool {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
-	return c.isReadLimitSetExternally
-}
-
 func (c *Connection) ReadLimit() int64 {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()

--- a/ably/options.go
+++ b/ably/options.go
@@ -28,9 +28,9 @@ const (
 	defaultEndpoint    = "main"
 	defaultPrimaryHost = "main.realtime.ably.net" // REC1a
 
-	Port           = 80
-	TLSPort        = 443
-	maxMessageSize = 65536 // 64kb, default value TO3l8
+	Port             = 80
+	TLSPort          = 443
+	defaultReadLimit = 1024 * 1024 * 2 // 2mb
 
 	// RTN17c
 	internetCheckUrl = "https://internet-up.ably-realtime.com/is-the-internet-up.txt"

--- a/ably/realtime_channel_integration_test.go
+++ b/ably/realtime_channel_integration_test.go
@@ -270,18 +270,6 @@ func TestRealtimeChannel_AttachWhileDisconnected(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestRealtimeChannel_ShouldSetAblySandboxDefaultReadLimit(t *testing.T) {
-	app, client := ablytest.NewRealtime(ably.WithEchoMessages(false))
-	defer safeclose(t, ablytest.FullRealtimeCloser(client), app)
-	assert.Equal(t, int64(65536), client.Connection.ReadLimit()) // Default read limit when not connected
-
-	err := ablytest.Wait(ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected), nil)
-	assert.NoError(t, err)
-
-	assert.Equal(t, int64(16384), client.Connection.ReadLimit()) // sandbox read limit
-	assert.False(t, client.Connection.IsReadLimitSetExternally())
-}
-
 func TestRealtimeChannel_ShouldSetProvidedReadLimit(t *testing.T) {
 	app, client := ablytest.NewRealtime(ably.WithEchoMessages(false))
 	defer safeclose(t, ablytest.FullRealtimeCloser(client), app)
@@ -290,7 +278,6 @@ func TestRealtimeChannel_ShouldSetProvidedReadLimit(t *testing.T) {
 	err := ablytest.Wait(ablytest.ConnWaiter(client, client.Connect, ably.ConnectionEventConnected), nil)
 	assert.NoError(t, err)
 
-	assert.True(t, client.Connection.IsReadLimitSetExternally())
 	assert.Equal(t, int64(2048), client.Connection.ReadLimit())
 }
 
@@ -316,7 +303,7 @@ func TestRealtimeChannel_SetDefaultReadLimitIfServerHasNoLimit(t *testing.T) {
 	assert.Nil(t, err)
 
 	// If server set limit is 0, value is set to default readlimit
-	assert.Equal(t, int64(65536), client.Connection.ReadLimit())
+	assert.Equal(t, int64(2097152), client.Connection.ReadLimit())
 }
 
 func TestRealtimeChannel_ShouldReturnErrorIfReadLimitExceeded(t *testing.T) {
@@ -331,7 +318,6 @@ func TestRealtimeChannel_ShouldReturnErrorIfReadLimitExceeded(t *testing.T) {
 	err = ablytest.Wait(ablytest.ConnWaiter(client2, client2.Connect, ably.ConnectionEventConnected), nil)
 	assert.NoError(t, err)
 
-	assert.True(t, client2.Connection.IsReadLimitSetExternally())
 	assert.Equal(t, int64(1024), client2.Connection.ReadLimit())
 
 	channel1 := client1.Channels.Get("test")


### PR DESCRIPTION
This PR removes setting the websocket readlimit based on the `ConnectionDetails.MaxMessageSize` received when a message with a Connected action (4).

The `ConnectionDetails.MaxMessageSize` should be used to restrict publishing messages over this value.

Connections do have a read limit set still but the default limit has been raised to 2mb.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Increased the default read limit for WebSocket connections to 2MB.
  * Removed dynamic adjustment of the read limit based on server-provided values.
  * Simplified connection settings by removing external read limit flag and related checks.

* **Documentation**
  * Updated comments to reflect the new default read limit.

* **Tests**
  * Removed tests and assertions related to the previous read limit behavior and external flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->