### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log
 
-## [1.2.22](https://github.com/ably/ably-go/tree/v.1.2.22)
+## [1.3.0](https://github.com/ably/ably-go/tree/v1.3.0)
 
-[Full Changelog](https://github.com/ably/ably-go/compare/v1.2.21...v.1.2.22)
+[Full Changelog](https://github.com/ably/ably-go/compare/v1.2.22...v1.3.0)
+
+**Closed issues:**
+
+- Implement vcdiff delta support [\#689](https://github.com/ably/ably-go/issues/689)
+
+## [1.2.22](https://github.com/ably/ably-go/tree/v1.2.22)
+
+[Full Changelog](https://github.com/ably/ably-go/compare/v1.2.21...v1.2.22)
 
 **Implemented enhancements:**
 

--- a/ably/proto_http.go
+++ b/ably/proto_http.go
@@ -11,7 +11,7 @@ const (
 	ablyProtocolVersionHeader = "X-Ably-Version"
 	ablyErrorCodeHeader       = "X-Ably-Errorcode"
 	ablyErrorMessageHeader    = "X-Ably-Errormessage"
-	clientLibraryVersion      = "1.2.22"
+	clientLibraryVersion      = "1.3.0"
 	clientRuntimeName         = "go"
 	ablyProtocolVersion       = "2" // CSV2
 	ablyClientIDHeader        = "X-Ably-ClientId"


### PR DESCRIPTION
Added support for delta encoding using vcdiff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added a top-level changelog entry for version 1.3.0, updated the Full Changelog range to v1.2.22...v1.3.0, introduced a “Closed issues” note for vcdiff delta support, and retained the existing 1.2.22 section.

- Chores
  - Bumped the client library version to 1.3.0, updating SDK identification metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->