### PR TITLE
fix: Prevent deadlock when releasing a realtime channel

### DIFF
--- a/ably/realtime_channel.go
+++ b/ably/realtime_channel.go
@@ -207,8 +207,8 @@ func (c *RealtimeChannels) Exists(name string) bool {
 // To release a channel, the [ably.ChannelState] must be INITIALIZED, DETACHED, or FAILED (RSN4, RTS4).
 func (ch *RealtimeChannels) Release(ctx context.Context, name string) error {
 	ch.mtx.Lock()
-	defer ch.mtx.Unlock()
 	c, ok := ch.chans[name]
+	ch.mtx.Unlock()
 	if !ok {
 		return nil
 	}
@@ -216,7 +216,9 @@ func (ch *RealtimeChannels) Release(ctx context.Context, name string) error {
 	if err != nil {
 		return err
 	}
+	ch.mtx.Lock()
 	delete(ch.chans, name)
+	ch.mtx.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
The RealtimeChannels mutex is acquired to retrieve the channel relating to an inbound message, so holding that mutex whilst waiting for Detach to complete causes a deadlock because the inbound DETACHED message the Detach call is waiting for also tries to acquire the mutex.

This commit fixes the deadlock by releasing the mutex before calling Detach, and then acquiring it again once it completes in order to release the channel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when releasing realtime channels: channels now detach cleanly before removal, preventing rare deadlocks and ensuring resources are fully freed.
  * After release, channels are correctly removed and no longer accessible.

* **Tests**
  * Added an integration test validating the full channel release lifecycle, including attach/detach state transitions and post-release cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->