### PR TITLE
Only run tests on the latest two Go versions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.19', '1.20', '1.23', '1.24', '1.25']
+        # Test on the two latest Go releases, matching the Go release policy: https://go.dev/doc/devel/release
+        go-version: ['1.25', '1.26']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -14,7 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.19', '1.20', '1.23', '1.24', '1.25']
+        # Test on the two latest Go releases, matching the Go release policy: https://go.dev/doc/devel/release
+        go-version: ['1.25', '1.26']
         protocol: ['json', 'msgpack']
 
     steps:


### PR DESCRIPTION
The integration tests are quite heavyweight, and running them 10 times in parallel (i.e. JSON + msgpack across 5 Go versions) adds unnecessary load to the sandbox cluster.

Go has a backwards compatibility guarantee between versions, and also only officially supports the two latest Go versions, so it's sufficient for us to only test on the latest two Go versions in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration testing configuration to align with current Go version support standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->