### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Change Log
 
+## [1.4.0](https://github.com/ably/ably-go/tree/v1.4.0)
+
+[Full Changelog](https://github.com/ably/ably-go/compare/v1.3.0...v1.4.0)
+
+**This release adds support for Message Updates, Deletes, and Appends** — allowing published messages to be updated, deleted, or appended to after the fact using the new `UpdateMessage`, `DeleteMessage`, and `AppendMessage` operations.
+
+**Implemented enhancements:**
+
+- feat: Implement Message Updates, Deletes, and Appends [\#697](https://github.com/ably/ably-go/pull/697)
+- Add V2 operation types for protocol v6+ [\#695](https://github.com/ably/ably-go/pull/695)
+- state: add v2 object create types [\#699](https://github.com/ably/ably-go/pull/699)
+- Switch to github.com/coder/websocket [\#698](https://github.com/ably/ably-go/pull/698)
+
+**Fixed bugs:**
+
+- fix: Prevent deadlock when releasing a realtime channel [\#693](https://github.com/ably/ably-go/pull/693)
+
+**Merged pull requests:**
+
+- Only run tests on the latest two Go versions [\#700](https://github.com/ably/ably-go/pull/700)
+
 ## [1.3.0](https://github.com/ably/ably-go/tree/v1.3.0)
 
 [Full Changelog](https://github.com/ably/ably-go/compare/v1.2.22...v1.3.0)

--- a/ably/proto_http.go
+++ b/ably/proto_http.go
@@ -11,7 +11,7 @@ const (
 	ablyProtocolVersionHeader = "X-Ably-Version"
 	ablyErrorCodeHeader       = "X-Ably-Errorcode"
 	ablyErrorMessageHeader    = "X-Ably-Errormessage"
-	clientLibraryVersion      = "1.3.0"
+	clientLibraryVersion      = "1.4.0"
 	clientRuntimeName         = "go"
 	// ablyProtocolVersion is the default Ably protocol version used for all requests.
 	// Protocol v5 is required for message operations (publish/update/delete/append) to return


### PR DESCRIPTION
## Summary

This PR releases version 1.4.0 of the ably-go SDK.

This is a **minor version bump** (1.3.0 → 1.4.0) because it introduces new functionality — support for Message Updates, Deletes, and Appends — in a backwards-compatible way. Per semantic versioning, new features warrant a minor version increment.

## Changes

- **Message Updates, Deletes, and Appends** (#697) — the headline feature: published messages can now be updated, deleted, or appended to after the fact using the new `UpdateMessage`, `DeleteMessage`, and `AppendMessage` operations
- Add V2 operation types for protocol v6+ (#695)
- state: add v2 object create types (#699)
- Switch to github.com/coder/websocket (#698)
- fix: Prevent deadlock when releasing a realtime channel (#693)
- Only run tests on the latest two Go versions (#700)

## Release checklist

- [x] Version bumped in `ably/proto_http.go`
- [x] `CHANGELOG.md` updated
- [ ] PR approved and merged
- [ ] Tag `v1.4.0` pushed
- [ ] GitHub Release created
- [ ] Ably Changelog entry posted (headwayapp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for message updates, deletions, and appends in real-time channels.

* **Bug Fixes**
  * Fixed deadlock issue when releasing a realtime channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->