### PR TITLE
fix: guard against nil onAck in result-returning *Async methods

### DIFF
--- a/ably/message_updates_integration_test.go
+++ b/ably/message_updates_integration_test.go
@@ -358,5 +358,26 @@ func TestRealtimeChannel_MessageUpdates(t *testing.T) {
 
 			assert.Equal(t, len(tokens), ackCount, "All appends should complete")
 		})
+
+		t.Run("nil onAck is treated as fire-and-forget", func(t *testing.T) {
+			publishResult, err := channel.PublishWithResult(ctx, "ai-response", "seed")
+			require.NoError(t, err)
+			require.NotNil(t, publishResult.Serial)
+
+			err = channel.AppendMessageAsync(&ably.Message{
+				Serial: *publishResult.Serial,
+				Data:   " token",
+			}, nil)
+			require.NoError(t, err)
+
+			// Round-trip a follow-up sync append so we know the ACK for the
+			// nil-callback append has been processed without panicking the
+			// connection's read loop.
+			_, err = channel.AppendMessage(ctx, &ably.Message{
+				Serial: *publishResult.Serial,
+				Data:   " done",
+			})
+			require.NoError(t, err)
+		})
 	})
 }

--- a/ably/realtime_channel.go
+++ b/ably/realtime_channel.go
@@ -749,6 +749,9 @@ func (c *RealtimeChannel) PublishWithResult(ctx context.Context, name string, da
 // PublishWithResultAsync is the same as PublishWithResult except instead of blocking it calls onAck
 // with the result or error. Note onAck must not block as it would block the internal client.
 func (c *RealtimeChannel) PublishWithResultAsync(name string, data interface{}, onAck func(*PublishResult, error)) error {
+	if onAck == nil {
+		onAck = func(*PublishResult, error) {}
+	}
 	return c.PublishMultipleWithResultAsync([]*Message{{Name: name, Data: data}}, func(results []PublishResult, err error) {
 		if err != nil {
 			onAck(nil, err)
@@ -788,6 +791,9 @@ func (c *RealtimeChannel) PublishMultipleWithResult(ctx context.Context, message
 // PublishMultipleWithResultAsync is the same as PublishMultipleWithResult except it calls onAck
 // instead of blocking (RTL6j, RTL6j1 alternative).
 func (c *RealtimeChannel) PublishMultipleWithResultAsync(messages []*Message, onAck func([]PublishResult, error)) error {
+	if onAck == nil {
+		onAck = func([]PublishResult, error) {}
+	}
 	id := c.client.Auth.clientIDForCheck()
 	for _, v := range messages {
 		if v.ClientID != "" && id != wildcardClientID && v.ClientID != id {
@@ -856,6 +862,9 @@ func (c *RealtimeChannel) HistoryUntilAttach(o ...HistoryOption) (*HistoryReques
 // performMessageOperationAsync is a shared helper for UpdateMessageAsync, DeleteMessageAsync, and AppendMessageAsync.
 // Implements RTL32a-e: validates serial, applies options, sets action/version, encodes data, and sends the protocol message.
 func (c *RealtimeChannel) performMessageOperationAsync(msg *Message, action MessageAction, onAck func(*UpdateDeleteResult, error), options ...UpdateOption) error {
+	if onAck == nil {
+		onAck = func(*UpdateDeleteResult, error) {}
+	}
 	if err := validateMessageSerial(msg); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- `AppendMessageAsync(msg, nil)` (and the `UpdateMessageAsync` / `DeleteMessageAsync` siblings) segfaulted when the server ACK arrived, because `performMessageOperationAsync` invoked the callback unconditionally at `realtime_channel.go:908`.
- The same latent bug existed in `PublishWithResultAsync` and `PublishMultipleWithResultAsync`.
- Normalize a nil `onAck` to a no-op at the top of each — mirroring the nil-safety that `msgAckCallback.call` already provides at the lower layer.

Surfaced by [ably/docs#3351](https://github.com/ably/docs/pull/3351), where a fire-and-forget append example using `AppendMessageAsync(msg, nil)` crashed at runtime.

## Test plan

- [x] New integration sub-test `TestRealtimeChannel_MessageUpdates/AppendMessageAsync/nil_onAck_is_treated_as_fire-and-forget` — calls `AppendMessageAsync(msg, nil)`, then round-trips a follow-up sync `AppendMessage` so we know the ACK for the nil-callback append landed without panicking the connection's read loop. Passes against `nonprod:sandbox` in ~0.6s.
- [x] `go vet ./ably/...` clean
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Async message publish operations now handle missing callbacks gracefully, enabling fire-and-forget usage patterns without errors or crashes. Improved stability for asynchronous publishing workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ably/ably-go/pull/702)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->