### PR TITLE
test: gate ablytest sandbox provisioning behind an internal build tag

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -46,7 +46,7 @@ jobs:
           ABLY_PROTOCOL: ${{ matrix.protocol == 'json' && 'application/json' || 'application/x-msgpack' }}
         run: |
           set -o pipefail
-          go test -tags=integration -p 1 -race -v -timeout 120m ./... |& tee >(~/go/bin/go-junit-report > "${PROTOCOL}-integration.junit")
+          go test -tags=integration,ably_internal_sdk_tests_only -p 1 -race -v -timeout 120m ./... |& tee >(~/go/bin/go-junit-report > "${PROTOCOL}-integration.junit")
 
       - name: Upload test results
         if: always()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,8 +64,8 @@ git clone git@github.com:ably/ably-go.git --recurse-submodules
 The tests can be run with the commands: 
  
 ```
-export ABLY_PROTOCOL="application/json" && go test -tags=integration -p 1 -race -v -timeout 120m ./...
-export ABLY_PROTOCOL="application/x-msgpack" && go test -tags=integration -p 1 -race -v -timeout 120m ./...
+export ABLY_PROTOCOL="application/json" && go test -tags=integration,ably_internal_sdk_tests_only -p 1 -race -v -timeout 120m ./...
+export ABLY_PROTOCOL="application/x-msgpack" && go test -tags=integration,ably_internal_sdk_tests_only -p 1 -race -v -timeout 120m ./...
 ``` 
 
 Depending on which protocol they are to be run for. It is also necessary to clean the test cache in between runs of these tests which can be done with the command: 
@@ -74,11 +74,11 @@ Depending on which protocol they are to be run for. It is also necessary to clea
 go clean -testcache
 ``` 
 
-When adding new integration tests, the following build tag must be included at the top of the file to exclude these tests for running in CI as part of the Unit test step.
+When adding new integration tests, the following build tags must be included at the top of the file. The `!unit` tag excludes these tests from the Unit test step in CI. The `ably_internal_sdk_tests_only` tag gates the `ablytest` sandbox-provisioning helpers, to signal that these are intended only for running ably-go's own test suite, not for external users.
 
 ```
-//go:build !unit
-// +build !unit
+//go:build !unit && ably_internal_sdk_tests_only
+// +build !unit,ably_internal_sdk_tests_only
 ```
 
 ### Release process

--- a/ably/auth_integration_test.go
+++ b/ably/auth_integration_test.go
@@ -1,5 +1,5 @@
-//go:build !unit
-// +build !unit
+//go:build !unit && ably_internal_sdk_tests_only
+// +build !unit,ably_internal_sdk_tests_only
 
 package ably_test
 

--- a/ably/event_emitter_integration_test.go
+++ b/ably/event_emitter_integration_test.go
@@ -1,5 +1,5 @@
-//go:build !unit
-// +build !unit
+//go:build !unit && ably_internal_sdk_tests_only
+// +build !unit,ably_internal_sdk_tests_only
 
 package ably_test
 

--- a/ably/event_emitter_spec_integration_test.go
+++ b/ably/event_emitter_spec_integration_test.go
@@ -1,5 +1,5 @@
-//go:build !unit
-// +build !unit
+//go:build !unit && ably_internal_sdk_tests_only
+// +build !unit,ably_internal_sdk_tests_only
 
 package ably_test
 

--- a/ably/http_paginated_response_integration_test.go
+++ b/ably/http_paginated_response_integration_test.go
@@ -1,5 +1,5 @@
-//go:build !unit
-// +build !unit
+//go:build !unit && ably_internal_sdk_tests_only
+// +build !unit,ably_internal_sdk_tests_only
 
 package ably_test
 

--- a/ably/main_integration_test.go
+++ b/ably/main_integration_test.go
@@ -1,5 +1,5 @@
-//go:build !unit
-// +build !unit
+//go:build !unit && ably_internal_sdk_tests_only
+// +build !unit,ably_internal_sdk_tests_only
 
 package ably_test
 

--- a/ably/message_updates_integration_test.go
+++ b/ably/message_updates_integration_test.go
@@ -1,5 +1,5 @@
-//go:build !unit
-// +build !unit
+//go:build !unit && ably_internal_sdk_tests_only
+// +build !unit,ably_internal_sdk_tests_only
 
 package ably_test
 

--- a/ably/proto_message_integration_test.go
+++ b/ably/proto_message_integration_test.go
@@ -1,5 +1,5 @@
-//go:build !unit
-// +build !unit
+//go:build !unit && ably_internal_sdk_tests_only
+// +build !unit,ably_internal_sdk_tests_only
 
 package ably_test
 

--- a/ably/realtime_channel_delta_integration_test.go
+++ b/ably/realtime_channel_delta_integration_test.go
@@ -1,5 +1,5 @@
-//go:build !unit
-// +build !unit
+//go:build !unit && ably_internal_sdk_tests_only
+// +build !unit,ably_internal_sdk_tests_only
 
 package ably_test
 

--- a/ably/realtime_channel_integration_test.go
+++ b/ably/realtime_channel_integration_test.go
@@ -1,5 +1,5 @@
-//go:build !unit
-// +build !unit
+//go:build !unit && ably_internal_sdk_tests_only
+// +build !unit,ably_internal_sdk_tests_only
 
 package ably_test
 

--- a/ably/realtime_channel_spec_integration_test.go
+++ b/ably/realtime_channel_spec_integration_test.go
@@ -1,5 +1,5 @@
-//go:build !unit
-// +build !unit
+//go:build !unit && ably_internal_sdk_tests_only
+// +build !unit,ably_internal_sdk_tests_only
 
 package ably_test
 

--- a/ably/realtime_client_integration_test.go
+++ b/ably/realtime_client_integration_test.go
@@ -1,5 +1,5 @@
-//go:build !unit
-// +build !unit
+//go:build !unit && ably_internal_sdk_tests_only
+// +build !unit,ably_internal_sdk_tests_only
 
 package ably_test
 

--- a/ably/realtime_conn_integration_test.go
+++ b/ably/realtime_conn_integration_test.go
@@ -1,5 +1,5 @@
-//go:build !unit
-// +build !unit
+//go:build !unit && ably_internal_sdk_tests_only
+// +build !unit,ably_internal_sdk_tests_only
 
 package ably_test
 

--- a/ably/realtime_conn_spec_integration_test.go
+++ b/ably/realtime_conn_spec_integration_test.go
@@ -1,5 +1,5 @@
-//go:build !unit
-// +build !unit
+//go:build !unit && ably_internal_sdk_tests_only
+// +build !unit,ably_internal_sdk_tests_only
 
 package ably_test
 

--- a/ably/realtime_presence_integration_test.go
+++ b/ably/realtime_presence_integration_test.go
@@ -1,5 +1,5 @@
-//go:build !unit
-// +build !unit
+//go:build !unit && ably_internal_sdk_tests_only
+// +build !unit,ably_internal_sdk_tests_only
 
 package ably_test
 

--- a/ably/recovery_context_test.go
+++ b/ably/recovery_context_test.go
@@ -1,5 +1,5 @@
-//go:build !unit
-// +build !unit
+//go:build !unit && ably_internal_sdk_tests_only
+// +build !unit,ably_internal_sdk_tests_only
 
 package ably_test
 

--- a/ably/rest_channel_integration_test.go
+++ b/ably/rest_channel_integration_test.go
@@ -1,5 +1,5 @@
-//go:build !unit
-// +build !unit
+//go:build !unit && ably_internal_sdk_tests_only
+// +build !unit,ably_internal_sdk_tests_only
 
 package ably_test
 

--- a/ably/rest_channel_spec_integration_test.go
+++ b/ably/rest_channel_spec_integration_test.go
@@ -1,5 +1,5 @@
-//go:build !unit
-// +build !unit
+//go:build !unit && ably_internal_sdk_tests_only
+// +build !unit,ably_internal_sdk_tests_only
 
 package ably_test
 

--- a/ably/rest_client_integration_test.go
+++ b/ably/rest_client_integration_test.go
@@ -1,5 +1,5 @@
-//go:build !unit
-// +build !unit
+//go:build !unit && ably_internal_sdk_tests_only
+// +build !unit,ably_internal_sdk_tests_only
 
 package ably_test
 

--- a/ably/rest_presence_spec_integration_test.go
+++ b/ably/rest_presence_spec_integration_test.go
@@ -1,5 +1,5 @@
-//go:build !unit
-// +build !unit
+//go:build !unit && ably_internal_sdk_tests_only
+// +build !unit,ably_internal_sdk_tests_only
 
 package ably_test
 

--- a/ably/transitioner_integration_test.go
+++ b/ably/transitioner_integration_test.go
@@ -1,5 +1,5 @@
-//go:build !unit
-// +build !unit
+//go:build !unit && ably_internal_sdk_tests_only
+// +build !unit,ably_internal_sdk_tests_only
 
 package ably_test
 

--- a/ablytest/sandbox.go
+++ b/ablytest/sandbox.go
@@ -1,3 +1,12 @@
+//go:build !unit && ably_internal_sdk_tests_only
+// +build !unit,ably_internal_sdk_tests_only
+
+// This file provisions and tears down sandbox test apps against the Ably
+// backend. It is intended to facilitate anyone being able to develop and
+// contribute to the ably-go SDK. We politely request that users running tests
+// of their own apps not use this, and instead provision a test app in their
+// own account. See https://faqs.ably.com/how-can-i-set-up-different-environments-in-ably
+
 package ablytest
 
 import (


### PR DESCRIPTION
The ablytest package is importable, so anything it exports is callable by downstream consumers. Those helpers are intended only for running ably-go's own integration tests, not as a supported API.

We don't want to actually put any security barries in place, because we want SDK development to be open to all, and there's no way to verify whether a given test app will be used for SDK development or not. But we can at least add a build tag that makes it at obvious that this is not the intended usecase.

This is not a security boundary (the code can be copied, or an external caller can just specify that tag), but rather a polite request, intended to avoid misunderstandings and unintentional reliance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tightened integration test execution to run only with the new internal test tag, helping separate these tests from standard builds.
  * Updated test workflow output to continue generating per-protocol reports.
* **Documentation**
  * Clarified integration test setup steps, including protocol-specific environment settings and the required build tags for new test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->